### PR TITLE
Bug 1738495: Invalid token is reported as error in cluster status

### DIFF
--- a/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
+++ b/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
@@ -3,6 +3,7 @@ package clusterauthorizer
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/openshift/insights-operator/pkg/config"
 )
@@ -31,7 +32,14 @@ func (a *Authorizer) Authorize(req *http.Request) error {
 		if req.Header == nil {
 			req.Header = make(http.Header)
 		}
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cfg.Token))
+		token := strings.TrimSpace(cfg.Token)
+		if strings.Contains(token, "\n") || strings.Contains(token, "\r") {
+			return fmt.Errorf("cluster authorization token is not valid: contains newlines")
+		}
+		if len(token) == 0 {
+			return fmt.Errorf("cluster authorization token is empty")
+		}
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 		return nil
 	}
 	return nil

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -111,7 +111,8 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 	klog.V(4).Infof("Uploading %s to %s", source.Type, req.URL.String())
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return err
+		klog.V(4).Infof("Unable to build a request, possible invalid token: %v", err)
+		return fmt.Errorf("unable to build request to connect to Insights server")
 	}
 
 	requestID := resp.Header.Get("x-rh-insights-request-id")


### PR DESCRIPTION
If the token for the cluster contains a newline, the error is
reported in a generic fashion to the cluster operator status which
contains the auth token value. This is an information leak and
should not happen.

Prevent future disclosure bugs by not printing the exact error when
we build an invalid request. Check the token value in both the client
(before setting the header) and when we read from config (before
loading the token) so that we report this error in an earlier place
with a specific error.

To reproduce, put a newline inside the cloud.openshift.com token in
the cluster pull-secret (in openshift-config namespace).

/assign @mfojtik