### PR TITLE
Provide initial proxy support for insights operator

### DIFF
--- a/manifests/04-proxy-cert-configmap.yaml
+++ b/manifests/04-proxy-cert-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-insights
+  name: trusted-ca-bundle
+  annotations:
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/05-deployment.yaml
+++ b/manifests/05-deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: insights-operator
   namespace: openshift-insights
+  annotations:
+    config.openshift.io/inject-proxy: operator
 spec:
   strategy:
     type: Recreate
@@ -35,6 +37,10 @@ spec:
       - name: snapshots
         emptyDir: {}
           #sizeLimit: 1Gi # bug https://bugzilla.redhat.com/show_bug.cgi?id=1713207
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
+          optional: true
       containers:
       - name: operator
         image: quay.io/openshift/origin-insights-operator:latest
@@ -42,6 +48,9 @@ spec:
         volumeMounts:
         - name: snapshots
           mountPath: /var/lib/insights-operator
+        - mountPath: /var/run/configmaps/trusted-ca-bundle
+          name: trusted-ca-bundle
+          readOnly: true
         ports:
         - containerPort: 8443
           name: https

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"os"
 
-	"k8s.io/client-go/rest"
-
 	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/version"
+	"k8s.io/client-go/rest"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -2,6 +2,9 @@ package insightsclient
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -10,15 +13,16 @@ import (
 	"net"
 	"net/http"
 	"net/textproto"
+	"os"
 	"strconv"
 	"time"
 
+	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/transport"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog"
 
-	"k8s.io/client-go/pkg/version"
+	"github.com/prometheus/client_golang/prometheus"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -52,7 +56,7 @@ var ErrWaitingForVersion = fmt.Errorf("waiting for the cluster version to be loa
 
 func New(client *http.Client, maxBytes int64, metricsName string, authorizer Authorizer, clusterInfo ClusterVersionInfo) *Client {
 	if client == nil {
-		client = &http.Client{Transport: DefaultTransport()}
+		client = &http.Client{}
 	}
 	if maxBytes == 0 {
 		maxBytes = 10 * 1024 * 1024
@@ -64,6 +68,49 @@ func New(client *http.Client, maxBytes int64, metricsName string, authorizer Aut
 		authorizer:  authorizer,
 		clusterInfo: clusterInfo,
 	}
+}
+
+func getTrustedCABundle() (*x509.CertPool, error) {
+	caBytes, err := ioutil.ReadFile("/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(caBytes) == 0 {
+		return nil, nil
+	}
+	certs := x509.NewCertPool()
+	if ok := certs.AppendCertsFromPEM(caBytes); !ok {
+		return nil, errors.New("error loading cert pool from ca data")
+	}
+	return certs, nil
+}
+
+func clientTransport() http.RoundTripper {
+	// default transport, proxy from env
+	clientTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		DisableKeepAlives:   true,
+	}
+
+	// get the cluster proxy trusted CA bundle in case the proxy need it
+	rootCAs, err := getTrustedCABundle()
+	if err != nil {
+		klog.Errorf("Failed to get proxy trusted CA: %v", err)
+	}
+	if rootCAs != nil {
+		clientTransport.TLSClientConfig = &tls.Config{}
+		clientTransport.TLSClientConfig.RootCAs = rootCAs
+	}
+
+	return transport.DebugWrappers(clientTransport)
 }
 
 func (c *Client) Send(ctx context.Context, endpoint string, source Source) error {
@@ -107,6 +154,9 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 
 	req = req.WithContext(ctx)
 	req.Body = pr
+
+	// dynamically set the proxy environment
+	c.client.Transport = clientTransport()
 
 	klog.V(4).Infof("Uploading %s to %s", source.Type, req.URL.String())
 	resp, err := c.client.Do(req)
@@ -158,18 +208,6 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 	}
 
 	return nil
-}
-
-func DefaultTransport() http.RoundTripper {
-	return transport.DebugWrappers(&http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
-		TLSHandshakeTimeout: 10 * time.Second,
-		DisableKeepAlives:   true,
-	})
 }
 
 var (


### PR DESCRIPTION
This wire the proxy certs into operator and enable proxy vars injections. The insights client then use transport that has the correct trust set.

@danehans i think we missed this one.

/cc @smarterclayton @iNecas 

