### PR TITLE
Bug 1744297: Revert "pkg/controller/status/status: Never go degraded (hack)"

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -208,7 +208,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 		if len(errorMessage) > 0 {
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:               configv1.OperatorDegraded,
-				Status:             configv1.ConditionFalse,
+				Status:             configv1.ConditionTrue,
 				LastTransitionTime: metav1.Time{Time: last},
 				Reason:             reason,
 				Message:            errorMessage,


### PR DESCRIPTION
This reverts commit ce4045034751888efeda4f094daed7fa0d6b17a1, #7.

The issue had been Akamai truncating request bodies for chunked uploads smaller than 8 KiB.  The Akamai config has been fixed, and by 2019-08-27T15:04Z the UploadFailed degradations had all gone away.

CC @mfojtik.