### PR TITLE
Synchronize gathering and flushing

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -96,7 +96,6 @@ func (s *Support) Run(controller *controllercmd.ControllerContext) error {
 	// the recorder periodically flushes any recorded data to disk as tar.gz files
 	// in s.StoragePath, and also prunes files above a certain age
 	recorder := diskrecorder.New(s.StoragePath, s.Interval)
-	go recorder.PeriodicallyFlush(ctx)
 	go recorder.PeriodicallyPrune(ctx, statusReporter)
 
 	// the gatherers periodically check the state of the cluster and report any

--- a/pkg/record/interface.go
+++ b/pkg/record/interface.go
@@ -8,6 +8,7 @@ import (
 
 type Interface interface {
 	Record(Record) error
+	Flush(context.Context) error
 }
 
 type Record struct {


### PR DESCRIPTION
While testing the insights-operator, I've noticed a lot of messages like
this:

```
E0828 14:22:05.301631   28307 diskrecorder.go:186] Tried to copy to insights-2019-08-28-122158.tar.gz which already exists
E0828 14:22:35.301368   28307 diskrecorder.go:186] Tried to copy to insights-2019-08-28-122228.tar.gz which already exists
```

There seemed to be two problems:

1. the fingerprints not being set while the clearRecords method was
not clearing the data when fingerprint was empty
2. the race condition of gathering and flushing the data

The main source of the messages seemed to be the 2nd case. What seemed
to happen was the flushing happening in the middle of the gathering
phase, leading to couple of records from the same time being left for
the next flushing. During the next flush, the old records were still
left, but the tar with the timestamp has already been created, so it
failed with 'Tried to copy' error.

I suggest simplifying the whole process and flush just after gathering
phase, to avoid this situation completely.