### PR TITLE
Bug 1745973: Don't reported Degraded on upload error, report UploadDegraded

### DIFF
--- a/pkg/insights/insightsuploader/insightsuploader.go
+++ b/pkg/insights/insightsuploader/insightsuploader.go
@@ -135,13 +135,15 @@ func (c *Controller) Run(ctx context.Context) {
 					return
 				}
 				if authorizer.IsAuthorizationError(err) {
-					c.Simple.UpdateStatus(controllerstatus.Summary{Reason: "NotAuthorized", Message: fmt.Sprintf("Reporting was not allowed: %v", err)})
+					c.Simple.UpdateStatus(controllerstatus.Summary{Operation: controllerstatus.Uploading,
+						Reason: "NotAuthorized", Message: fmt.Sprintf("Reporting was not allowed: %v", err)})
 					initialDelay = wait.Jitter(interval, 3)
 					return
 				}
 
 				initialDelay = wait.Jitter(interval/8, 1.2)
-				c.Simple.UpdateStatus(controllerstatus.Summary{Reason: "UploadFailed", Message: fmt.Sprintf("Unable to report: %v", err)})
+				c.Simple.UpdateStatus(controllerstatus.Summary{Operation: controllerstatus.Uploading,
+					Reason: "UploadFailed", Message: fmt.Sprintf("Unable to report: %v", err)})
 				return
 			}
 


### PR DESCRIPTION
Given the upload failures are outside of control of the OCP administrator
and they are not fatal for the the functionality of the cluster,
don't set the cluster as degraded for the upload failures.

Separate stats "Uploading" is introduce to indicate the health of the
upload process.