### PR TITLE
Bug 1750665 - increase default interval and use configmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN make build
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 COPY --from=builder /go/src/github.com/openshift/insights-operator/bin/insights-operator /usr/bin/
-COPY config/pod.yaml /etc/insights-operator/server.yaml
 COPY manifests /manifests
 LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/usr/bin/insights-operator"]

--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -1,8 +1,0 @@
-kind: GenericOperatorConfig
-apiVersion: operator.openshift.io/v1alpha1
-leaderElection:
-  disable: true
-interval: "10m"
-storagePath: /var/lib/insights-operator
-endpoint: https://cloud.redhat.com/api/ingress/v1/upload
-impersonate: system:serviceaccount:openshift-insights:gather

--- a/manifests/04-proxy-cert-configmap.yaml
+++ b/manifests/04-proxy-cert-configmap.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: openshift-insights
-  name: trusted-ca-bundle
-  annotations:
-    release.openshift.io/create-only: "true"
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/04_configmap.yaml
+++ b/manifests/04_configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-insights
+  name: insights-operator-config
+data:
+  operator-config.yaml: |
+    kind: GenericOperatorConfig
+    apiVersion: operator.openshift.io/v1alpha1
+    leaderElection:
+      disable: true
+    interval: "2h"
+    storagePath: /var/lib/insights-operator
+    endpoint: https://cloud.redhat.com/api/ingress/v1/upload
+    impersonate: system:serviceaccount:openshift-insights:gather
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-insights
+  name: trusted-ca-bundle
+  annotations:
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/05-deployment.yaml
+++ b/manifests/05-deployment.yaml
@@ -37,6 +37,9 @@ spec:
       - name: snapshots
         emptyDir: {}
           #sizeLimit: 1Gi # bug https://bugzilla.redhat.com/show_bug.cgi?id=1713207
+      - name: config
+        configMap:
+          name: insights-operator-config
       - name: trusted-ca-bundle
         configMap:
           name: trusted-ca-bundle
@@ -46,8 +49,10 @@ spec:
         image: quay.io/openshift/origin-insights-operator:latest
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - name: snapshots
-          mountPath: /var/lib/insights-operator
+        - mountPath: /var/lib/insights-operator
+          name: snapshots
+        - mountPath: /var/run/configmaps/config
+          name: config
         - mountPath: /var/run/configmaps/trusted-ca-bundle
           name: trusted-ca-bundle
           readOnly: true
@@ -72,4 +77,4 @@ spec:
         args:
         - start
         - -v=4
-        - --config=/etc/insights-operator/server.yaml
+        - --config=/var/run/configmaps/config/operator-config.yaml


### PR DESCRIPTION
For now, every 2h should be enough. We will look into making the
interval smaller once the infrastructure settles down a bit.

In order to be able to override the operator configuration, the pod
configuration has been converted to a configmap.