### PR TITLE
Bug 1753755 - fix overriding the refresh interval in CI

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+type Configurator interface {
+	Config() *Controller
+	ConfigChanged() (<-chan struct{}, func())
+}
+
 // Controller defines the standard config for this operator.
 type Serialized struct {
 	Report      bool   `json:"report"`

--- a/pkg/config/configobserver/configobserver.go
+++ b/pkg/config/configobserver/configobserver.go
@@ -130,14 +130,15 @@ func (c *Controller) retrieveConfig() error {
 		nextConfig.Report = len(nextConfig.Endpoint) > 0
 
 		if intervalString, ok := secret.Data["interval"]; ok {
-			duration, err := time.ParseDuration(string(intervalString))
-			if err == nil && duration < time.Minute {
-				err = fmt.Errorf("too short")
+			duration, errp := time.ParseDuration(string(intervalString))
+
+			if errp == nil && duration < time.Minute {
+				errp = fmt.Errorf("too short")
 			}
-			if err == nil {
+			if errp == nil {
 				nextConfig.Interval = duration
 			} else {
-				err = fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to one minute: %v", err)
+				err = fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to one minute: %v", errp)
 				nextConfig.Report = false
 			}
 		}

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -109,7 +109,7 @@ func (s *Support) Run(controller *controllercmd.ControllerContext) error {
 	// the gatherers periodically check the state of the cluster and report any
 	// config to the recorder
 	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1())
-	periodic := periodic.New(s.Interval, recorder, map[string]gather.Interface{
+	periodic := periodic.New(configObserver, recorder, map[string]gather.Interface{
 		"config": configPeriodic,
 	})
 	statusReporter.AddSources(periodic.Sources()...)

--- a/pkg/insights/insightsuploader/insightsuploader.go
+++ b/pkg/insights/insightsuploader/insightsuploader.go
@@ -18,11 +18,6 @@ import (
 	"github.com/openshift/insights-operator/pkg/insights/insightsclient"
 )
 
-type Configurator interface {
-	Config() *config.Controller
-	ConfigChanged() (<-chan struct{}, func())
-}
-
 type Authorizer interface {
 	IsAuthorizationError(error) bool
 }
@@ -41,11 +36,11 @@ type Controller struct {
 
 	summarizer   Summarizer
 	client       *insightsclient.Client
-	configurator Configurator
+	configurator config.Configurator
 	reporter     StatusReporter
 }
 
-func New(summarizer Summarizer, client *insightsclient.Client, configurator Configurator, statusReporter StatusReporter) *Controller {
+func New(summarizer Summarizer, client *insightsclient.Client, configurator config.Configurator, statusReporter StatusReporter) *Controller {
 	return &Controller{
 		Simple: controllerstatus.Simple{Name: "insightsuploader"},
 


### PR DESCRIPTION
The interval for uploading was refreshed, but the period module
was not watching the config change, so no new reports were sent
in CI.

Also, this fixes propagating error messages when the interval is set too
low (using `duration, err := ...` was causing the top level `err` value
to be shadowed.)