### PR TITLE
Use github.com/eparis/urlhash to anonymize URLs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2 // indirect
 	github.com/coreos/bbolt v1.3.3 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/eparis/urlhash v0.0.0-20191022152723-5838cc59d83c
 	github.com/getsentry/raven-go v0.2.1-0.20190513200303-c977f96e1095 // indirect
 	github.com/google/btree v1.0.0 // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/eparis/urlhash v0.0.0-20191022152723-5838cc59d83c h1:uxDvRtFHFmVtpzxr/BuQgAG4PLfhkOjkiHv/yFETXy8=
+github.com/eparis/urlhash v0.0.0-20191022152723-5838cc59d83c/go.mod h1:Xl/cZVrYJPwRbTiMZuHOMxC5bJ67oR1mXMW6ScZrPFs=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -188,6 +188,20 @@ rules:
   - pods
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - urlsalt
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/eparis/urlhash"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,10 @@ type Gatherer struct {
 
 	lock        sync.Mutex
 	lastVersion *configv1.ClusterVersion
+}
+
+func init() {
+	urlhash.SetAllowedWords(urlhash.OpenShiftWords)
 }
 
 func New(client configv1client.ConfigV1Interface, coreClient corev1client.CoreV1Interface) *Gatherer {
@@ -327,9 +332,9 @@ func anonymizeURLSlice(in []string) []string {
 	return outSlice
 }
 
-var reURL = regexp.MustCompile(`[^\.\-/\:]`)
-
-func anonymizeURL(s string) string { return reURL.ReplaceAllString(s, "x") }
+func anonymizeURL(s string) string {
+	return urlhash.HashURL(s)
+}
 
 type ClusterOperatorAnonymizer struct{ *configv1.ClusterOperator }
 

--- a/vendor/github.com/eparis/urlhash/LICENSE
+++ b/vendor/github.com/eparis/urlhash/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/eparis/urlhash/url.go
+++ b/vendor/github.com/eparis/urlhash/url.go
@@ -1,0 +1,220 @@
+package urlhash
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math/rand"
+	"net"
+	"net/url"
+	"strings"
+)
+
+var (
+	globalSalt     = ""
+	allowedWords   = map[string]struct{}{}
+	OpenShiftWords = map[string]struct{}{
+		"kubernetes": {},
+		"k8s":        {},
+		"openshift":  {},
+		"console":    {},
+		"api":        {},
+		"com":        {},
+		"net":        {},
+		"org":        {},
+	}
+)
+
+// Returns the sha256 value of salt+value
+func hash(value string, salt string) string {
+	input := salt + value
+	output := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("%x", output)
+}
+
+// Returns the last len(value) sha256 values of salt+value
+func hashTrunc(value string, salt string, size int) string {
+	hashVal := hash(value, salt)
+	hashLen := len(hashVal)
+	if hashLen > size {
+		hashVal = hashVal[hashLen-size:]
+	}
+	return hashVal
+}
+
+// Returns the len(word) hash of a 'word'.
+// returns the word itself if it is 'allowed'
+func hashWord(word, salt string) string {
+	if _, ok := allowedWords[word]; ok {
+		return word
+	}
+	return hashTrunc(word, salt, len(word))
+}
+
+// Walk the text of an address, split by `sep` and return the hash (of len trunc)
+// so 1.2.3.4 may return abc.def.g12.345
+// and 2001:db8::1 may return dead:beef::1234
+func hashIPHelper(ipStr string, salt string, sep string, trunc int) string {
+	out := ""
+	parts := strings.Split(ipStr, sep)
+	for i, part := range parts {
+		if i != 0 {
+			out = out + sep
+		}
+		if part == "" {
+			continue
+		}
+		hashVal := hashTrunc(part, salt, trunc)
+		out = out + hashVal
+	}
+	return out
+}
+
+// Returns the hash of salt+IP.
+// 1.2.3.4 will hash as hash(salt+1).hash(salt+2).hash(salt+3).hash(salt+4)
+// similarly for IPv6
+func hashIP(ip net.IP, salt string) string {
+	ipStr := ip.String()
+	if p4 := ip.To4(); len(p4) == net.IPv4len {
+		return hashIPHelper(ipStr, salt, ".", 3)
+	}
+	if p6 := ip.To16(); len(p6) == net.IPv6len {
+		return "[" + hashIPHelper(ipStr, salt, ":", 4) + "]"
+	}
+	return hashWord(ipStr, salt)
+}
+
+// Break the string on `/`, `.`, and `-`. Individually salt+hash each of those
+// `words`. If all of the 'stuff' before the `/` looks like an IP handle it a little
+// differently.
+func hashString(str, salt string) string {
+	// Before we break it up, if it's an IP, handle it special
+	if ip := net.ParseIP(str); ip != nil {
+		return hashIP(ip, salt)
+	}
+	out := ""
+	slashParts := strings.Split(str, "/")
+	for i, slashPart := range slashParts {
+		if i != 0 {
+			out = out + "/"
+		}
+		dotParts := strings.Split(slashPart, ".")
+		for j, dotPart := range dotParts {
+			if j != 0 {
+				out = out + "."
+			}
+			dashParts := strings.Split(dotPart, "-")
+			for k, word := range dashParts {
+				if k != 0 {
+					out = out + "-"
+				}
+				out = out + hashWord(word, salt)
+			}
+		}
+	}
+	return out
+}
+
+// check if a string can be parsed as a CIDR
+func validCIDR(in string) (net.IP, *net.IPNet, bool) {
+	ip, ipnet, err := net.ParseCIDR(in)
+	if err != nil {
+		return nil, nil, false
+	}
+	return ip, ipnet, true
+}
+
+func cidrHash(ip net.IP, cidr *net.IPNet, salt string) string {
+	// do hash the IP portion
+	out := hashIP(ip, salt)
+	out = out + "/"
+	// do not hash the subnet len
+	ones, _ := cidr.Mask.Size()
+	return fmt.Sprintf("%s%d", out, ones)
+}
+
+// SetAllowedWords allows you to specify words which will not be hashed. These will
+// instead be returned unchanged.
+func SetAllowedWords(allowed map[string]struct{}) {
+	allowedWords = allowed
+}
+
+// SetSalt allows you to set the salt which will be used in calls to
+// HashURL.
+func SetSalt(salt string) {
+	globalSalt = salt
+}
+
+// HashURLSalt is the same as HashURL except you can pass an explict salt to
+// use for this call. Whereas HashURL uses the salt set globally.
+func HashURLSalt(urlString, salt string) string {
+	// If it looks like a cidr (aka 192.168.0.0/24) parse it.
+	if ip, ipnet, ok := validCIDR(urlString); ok {
+		return cidrHash(ip, ipnet, salt)
+	}
+
+	// Make sure that every string parses with a 'Scheme'. Stoopid RFC. Without this we
+	// parse things like `127.0.0.1:8080` very oddly.
+	if !strings.Contains(urlString, "://") {
+		urlString = "placeholder://" + urlString
+	}
+
+	// Parse it
+	u, err := url.Parse(urlString)
+	if err != nil {
+		// If we still don't look like a URL, just hash it and move along
+		return hash(urlString, salt)
+	}
+
+	// Just print the scheme (excludig our magic string)
+	out := ""
+	if u.Scheme != "" && u.Scheme != "placeholder" {
+		out = u.Scheme + "://"
+	}
+
+	if ip := net.ParseIP(u.Host); ip != nil {
+		out = out + hashIP(ip, salt)
+	} else {
+		// has the hostname
+		host := u.Hostname()
+		if host != "" {
+			out = out + hashString(host, salt)
+
+			// hash the port
+			port := u.Port()
+			if port != "" {
+				out = out + ":" + hashString(port, salt)
+			}
+		}
+	}
+
+	// hash the path
+	path := u.Path
+	if path != "" {
+		// If the host was not found, treat the path as the host
+		out = out + hashString(path, salt)
+	}
+	return out
+}
+
+// HashURL takes an url and returns a hash. This hash should be non-trivial to get the
+// original value, but should be stable. So one can compare the output of the hash accross
+// different urls. For example if openshift and com are in the 'AllowedWords' the urls
+// might hash as:
+//    https://this.openshift.com -> https://0a31.openshift.com
+//    https://that.openshift.com -> https://deb4.openshift.com
+//    https://this.that -> https://0a31.deb4
+func HashURL(urlString string) string {
+	return HashURLSalt(urlString, globalSalt)
+}
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// GetNewSalt returns a random string of a given length. Which can be used in SetSalt.
+// please note you may need to seed rand before calling this function.
+func GetNewSalt(length int) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,6 +38,8 @@ github.com/davecgh/go-spew/spew
 # github.com/emicklei/go-restful v2.9.5+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
+# github.com/eparis/urlhash v0.0.0-20191022152723-5838cc59d83c
+github.com/eparis/urlhash
 # github.com/evanphx/json-patch v4.2.0+incompatible
 github.com/evanphx/json-patch
 # github.com/getsentry/raven-go v0.2.1-0.20190513200303-c977f96e1095


### PR DESCRIPTION
It should give us stable values of ip addresses and URLs but not actually leak
customer data. This isn't simple to work backwards to the original IP because
the values are salted with a random string.

Input:  https://my.openshift-console-ingress.api.console.customer.com/path/to/something/openshift
Output: https://05.openshift-console-5bd922e.api.console.ee8ca6dd.com/b5bf/39/ca74813cb/openshift

Input:  https://127.0.0.1
Output: https://04c.7e9.7e9.b4b

Input:  https://127.0.0.2
Output: https://04c.7e9.7e9.b35

This also attempts to keep things like 'http://' or 'https://'.
It also will retain certain words in URLs, like openshift, or console.
It also represent ip addresses a bit wierdly, since you get 3 hex characters, but you can make
useful comparisions between hashed values.