### PR TITLE
gather: consider restarting pods as not healthy

### DIFF
--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -361,12 +361,18 @@ func isHealthyPod(pod *corev1.Pod) bool {
 		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
 			return false
 		}
+		if status.RestartCount > 0 {
+			return false
+		}
 	}
 	for _, status := range pod.Status.ContainerStatuses {
 		if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode != 0 {
 			return false
 		}
 		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.RestartCount > 0 {
 			return false
 		}
 	}


### PR DESCRIPTION
In case a container is restarting or has restart count higher than zero, consider it not healthy and copy it to the report in case the related operator is degraded.