### PR TITLE
gather: include events in report

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -83,6 +83,12 @@ rules:
   - list
   - watch
 - apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - list
+- apiGroups:
   - ""
   resources:
   - nodes


### PR DESCRIPTION
Collect all events for `openshift-` namespaces that are not older than 1 hour (for starter). The events are compacted to minimize the size in payload. If we still see big file, we can tweak the 1h interval to 30 min.