### PR TITLE
Bug 1767719: gather: include network events for namespace that has degraded operator

### DIFF
--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog"
@@ -63,17 +64,28 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 				if isHealthyOperator(&item) {
 					continue
 				}
+				failingPods := []corev1.Pod{}
 				for _, namespace := range namespacesForOperator(&item) {
 					pods, err := i.coreClient.Pods(namespace).List(metav1.ListOptions{})
 					if err != nil {
 						klog.V(2).Infof("Unable to find pods in namespace %s for failing operator %s", namespace, item.Name)
+						continue
 					}
 					for i := range pods.Items {
 						if isHealthyPod(&pods.Items[i]) {
 							continue
 						}
+						failingPods = append(failingPods, pods.Items[i])
 						records = append(records, record.Record{Name: fmt.Sprintf("config/pod/%s/%s", pods.Items[i].Namespace, pods.Items[i].Name), Item: PodAnonymizer{&pods.Items[i]}})
 					}
+				}
+				networkEvents, err := handlePendingPodsNetworkEvents(failingPods, i.coreClient)
+				if err != nil {
+					klog.V(2).Infof("Unable to gather network events: %v", err)
+					continue
+				}
+				for i := range networkEvents {
+					records = append(records, record.Record{Name: fmt.Sprintf("config/events/%s/network", networkEvents[i].Namespace), Item: EventAnonymizer{&networkEvents[i]}})
 				}
 			}
 
@@ -175,6 +187,36 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 	)
 }
 
+func handlePendingPodsNetworkEvents(pods []corev1.Pod, eventsGetter corev1client.EventsGetter) ([]corev1.Event, error) {
+	filteredEvents := []corev1.Event{}
+	if len(pods) == 0 {
+		return filteredEvents, nil
+	}
+	podNamespaces := sets.NewString()
+	for _, pod := range pods {
+		if podNamespaces.Has(pod.Namespace) {
+			continue
+		}
+		podNamespaces.Insert(pod.Namespace)
+	}
+	for _, namespace := range podNamespaces.List() {
+		namespaceEvents, err := eventsGetter.Events(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return filteredEvents, nil
+		}
+		for _, event := range namespaceEvents.Items {
+			if event.InvolvedObject.Kind != "Pod" {
+				continue
+			}
+			if !strings.Contains(event.Message, "failed to create pod network") {
+				continue
+			}
+			filteredEvents = append(filteredEvents, event)
+		}
+	}
+	return filteredEvents, nil
+}
+
 type Raw struct{ string }
 
 func (r Raw) Marshal(_ context.Context) ([]byte, error) {
@@ -219,6 +261,39 @@ type IngressAnonymizer struct{ *configv1.Ingress }
 func (a IngressAnonymizer) Marshal(_ context.Context) ([]byte, error) {
 	a.Ingress.Spec.Domain = anonymizeURL(a.Ingress.Spec.Domain)
 	return runtime.Encode(serializer, a.Ingress)
+}
+
+type ProxyAnonymizer struct{ *configv1.Proxy }
+
+func (a ProxyAnonymizer) Marshal(_ context.Context) ([]byte, error) {
+	a.Proxy.Spec.HTTPProxy = anonymizeURLCSV(a.Proxy.Spec.HTTPProxy)
+	a.Proxy.Spec.HTTPSProxy = anonymizeURLCSV(a.Proxy.Spec.HTTPSProxy)
+	a.Proxy.Spec.NoProxy = anonymizeURLCSV(a.Proxy.Spec.NoProxy)
+	a.Proxy.Spec.ReadinessEndpoints = anonymizeURLSlice(a.Proxy.Spec.ReadinessEndpoints)
+	a.Proxy.Status.HTTPProxy = anonymizeURLCSV(a.Proxy.Status.HTTPProxy)
+	a.Proxy.Status.HTTPSProxy = anonymizeURLCSV(a.Proxy.Status.HTTPSProxy)
+	a.Proxy.Status.NoProxy = anonymizeURLCSV(a.Proxy.Status.NoProxy)
+	return runtime.Encode(serializer, a.Proxy)
+}
+
+func anonymizeURLCSV(s string) string {
+	strs := strings.Split(s, ",")
+	outSlice := anonymizeURLSlice(strs)
+	return strings.Join(outSlice, ",")
+}
+
+func anonymizeURLSlice(in []string) []string {
+	outSlice := []string{}
+	for _, str := range in {
+		outSlice = append(outSlice, anonymizeURL(str))
+	}
+	return outSlice
+}
+
+type EventAnonymizer struct{ *corev1.Event }
+
+func (a EventAnonymizer) Marshal(_ context.Context) ([]byte, error) {
+	return runtime.Encode(serializer, a.Event)
 }
 
 var reURL = regexp.MustCompile(`[^\.\-/\:]`)


### PR DESCRIPTION
Backport of https://github.com/openshift/insights-operator/pull/36

This allows insights operator to collect 1h of events for namespaces defined as relatedObjects when operators is observed as degraded=true.