### PR TITLE
pkg/controller/status: Set reason and message for Disabled=False

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -222,8 +222,10 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			})
 		} else {
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
-				Type:   OperatorDisabled,
-				Status: configv1.ConditionFalse,
+				Type:    OperatorDisabled,
+				Status:  configv1.ConditionFalse,
+				Reason:  "Enabled".
+				Message: "Health reporting is enabled",
 			})
 		}
 


### PR DESCRIPTION
Because, on install failures, having the installer log:

    Cluster operator insights Disabled is False with Enabled: Health reporting is enabled

will be more obvious and less distracting than its [current][1]:

    Cluster operator insights Disabled is False with :

It would be nice if the installer could ignore this unsurprising state
entirely, but since the insights operator defines `Disabled` locally
instead of having it be part of the official OpenShift API
(github.com/openshift/api/config), I don't want the installer to
assume that all operators are sharing the same `Disabled` semantics.

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.3/544