### PR TITLE
api to metrics service changed from prometheus to legacyregistry

### DIFF
--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -19,10 +19,10 @@ import (
 	knet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/transport"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 
 	"k8s.io/klog"
-
-	"github.com/prometheus/client_golang/prometheus"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -212,14 +212,18 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 }
 
 var (
-	counterRequestSend = prometheus.NewCounterVec(prometheus.CounterOpts{
+	counterRequestSend = metrics.NewCounterVec(&metrics.CounterOpts{
 		Name: "insightsclient_request_send_total",
 		Help: "Tracks the number of metrics sends",
 	}, []string{"client", "status_code"})
 )
 
 func init() {
-	prometheus.MustRegister(
+	err := legacyregistry.Register(
 		counterRequestSend,
 	)
+	if err != nil {
+		fmt.Println(err)
+	}
+
 }


### PR DESCRIPTION
Api to metrics service has been changed suddenly without our knowledge, causing metrics to not be registered anymore, therefore this change is needed to resolve the issue.