### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/manifests/05-service.yaml
+++ b/manifests/05-service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: openshift-insights-serving-cert
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     app: insights-operator
   name: metrics

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-insights
   annotations:
     config.openshift.io/inject-proxy: operator
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   strategy:
     type: Recreate

--- a/manifests/07-cluster-operator.yaml
+++ b/manifests/07-cluster-operator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: insights
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:
   versions:

--- a/manifests/07-servicemonitor.yaml
+++ b/manifests/07-servicemonitor.yaml
@@ -3,6 +3,8 @@ kind: ServiceMonitor
 metadata:
   name: insights-operator
   namespace: openshift-insights
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252