### PR TITLE
add exclusion annotations to all resources

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-insights
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
     name: openshift-insights

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: insights-operator-auth
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: system:auth-delegator
@@ -15,6 +17,8 @@ kind: RoleBinding
 metadata:
   name: insights-operator-auth
   namespace: kube-system
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
@@ -28,6 +32,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: insights-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 # allow the operator to update cluster operator status
 - apiGroups:
@@ -67,6 +73,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: insights-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: insights-operator
@@ -80,6 +88,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: insights-operator-gather
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""
@@ -123,6 +133,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: insights-operator-gather
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: insights-operator-gather
@@ -136,6 +148,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: insights-operator-gather-reader
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-reader
@@ -150,6 +164,8 @@ kind: Role
 metadata:
   name: insights-operator
   namespace: openshift-config
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""
@@ -166,6 +182,8 @@ kind: RoleBinding
 metadata:
   name: insights-operator
   namespace: openshift-config
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: Role
   name: insights-operator
@@ -180,6 +198,8 @@ kind: Role
 metadata:
   name: insights-operator
   namespace: openshift-insights
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""
@@ -201,6 +221,8 @@ kind: RoleBinding
 metadata:
   name: insights-operator
   namespace: openshift-insights
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: Role
   name: insights-operator

--- a/manifests/03-prometheus_role.yaml
+++ b/manifests/03-prometheus_role.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-insights
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/03-prometheus_rolebinding.yaml
+++ b/manifests/03-prometheus_rolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-insights
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/04-proxy-cert-configmap.yaml
+++ b/manifests/04-proxy-cert-configmap.yaml
@@ -5,5 +5,6 @@ metadata:
   name: trusted-ca-bundle
   annotations:
     release.openshift.io/create-only: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/04-serviceaccount.yaml
+++ b/manifests/04-serviceaccount.yaml
@@ -3,9 +3,13 @@ kind: ServiceAccount
 metadata:
   namespace: openshift-insights
   name: operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: openshift-insights
   name: gather
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added exclusion annotation so the 4.3 CVO will ignore these operators to stay consistent with 4.2 CVO. As seen here, the 4.3 CVO looks at the value when looking at exclusions https://github.com/openshift/hypershift-toolkit/blob/release-4.3/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L76-L77

The 4.2 CVO excluded the following operators and resources with those operators https://github.com/openshift/hypershift-toolkit/blob/release-4.2/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L60-L72
 
**- How to verify it**
Deploy the hypershift toolkit https://github.com/openshift/hypershift-toolkit/tree/release-4.2 and verify that all the resources with this exclusion (exclude.release.openshift.io/internal-openshift-hosted: "true") are not overwriting the ones being deployed into the cluster. 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added exclusion to the rest of the resources that the operator manages.