### PR TITLE
Bug 1788116: override node selector (4.2)

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-insights
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     name: openshift-insights
     openshift.io/run-level: "1"


### PR DESCRIPTION
To ensure the deployment works properly in case of default node selector
is set.

(cherry picked from commit 53cfc74e5b5edf7fb3fc192080ee4d7299d5ad96)