### PR TITLE
insightsclient: include error message when we are unable to build request

### DIFF
--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -164,7 +164,7 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 	resp, err := c.client.Do(req)
 	if err != nil {
 		klog.V(4).Infof("Unable to build a request, possible invalid token: %v", err)
-		return fmt.Errorf("unable to build request to connect to Insights server")
+		return fmt.Errorf("unable to build request to connect to Insights server: %v", err)
 	}
 
 	requestID := resp.Header.Get("x-rh-insights-request-id")


### PR DESCRIPTION
We see 'Unable to report: unable to build request to connect to Insights server' message reported as reason for degraded insights operator, but we don't know why (probably bad token?).

@iNecas @smarterclayton is there a reason we muted the error we use for degraded message?