### PR TITLE
Updated base image for insights-operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/insights-operator
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.2:base
+FROM registry.svc.ci.openshift.org/ocp/4.4:base
 COPY --from=builder /go/src/github.com/openshift/insights-operator/bin/insights-operator /usr/bin/
 COPY config/pod.yaml /etc/insights-operator/server.yaml
 COPY manifests /manifests


### PR DESCRIPTION
I believe insights-operator should use a base image which corresponds to OCP version.