### PR TITLE
manifests: Remove run-level, insights operator does not need it

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -7,4 +7,3 @@ metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
     name: openshift-insights
-    openshift.io/run-level: "1"


### PR DESCRIPTION
Insights should follow normal admission control rules for a cluster.