### PR TITLE
When config is set to invalid interval, it wasn't being reported correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/insights-operator
 go 1.12
 
 require (
+	code.soquee.net/testlog v0.0.1
 	github.com/coreos/bbolt v1.3.3 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/getsentry/raven-go v0.2.1-0.20190513200303-c977f96e1095 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c/go.mod h1:1vhO7Mn/
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
+code.soquee.net/testlog v0.0.1 h1:oWNjgsx51u6aqAszu3U2wLQykZFJ9vkYI1/Vwu1x8bc=
+code.soquee.net/testlog v0.0.1/go.mod h1:yfJIdROWb6p+nkczs313619wx6f0JsNsdh/tgy2kWZQ=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=

--- a/pkg/config/configobserver/configobserver.go
+++ b/pkg/config/configobserver/configobserver.go
@@ -130,7 +130,8 @@ func (c *Controller) retrieveConfig() error {
 		nextConfig.Report = len(nextConfig.Endpoint) > 0
 
 		if intervalString, ok := secret.Data["interval"]; ok {
-			duration, err := time.ParseDuration(string(intervalString))
+			var duration time.Duration
+			duration, err = time.ParseDuration(string(intervalString))
 			if err == nil && duration < time.Minute {
 				err = fmt.Errorf("too short")
 			}

--- a/pkg/config/configobserver/configobserver_test.go
+++ b/pkg/config/configobserver/configobserver_test.go
@@ -1,0 +1,146 @@
+package configobserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"code.soquee.net/testlog"
+	"github.com/openshift/insights-operator/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	clsetfake "k8s.io/client-go/kubernetes/fake"
+	corefake "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	"k8s.io/klog"
+
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestChangeSupportConfig(t *testing.T) {
+	var cases = []struct {
+		name      string
+		config    map[string]*corev1.Secret
+		expConfig *config.Controller
+		expErr    error
+	}{
+		{name: "interval too short",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: &corev1.Secret{Data: map[string][]byte{
+					".dockerconfigjson": nil,
+				}},
+				supportKey: &corev1.Secret{Data: map[string][]byte{
+					"username": []byte("someone"),
+					"password": []byte("secret"),
+					"endpoint": []byte("http://po.rt"),
+					"interval": []byte("1s"),
+				}},
+			},
+			expErr: fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to one minute: too short"),
+		},
+		{name: "interval too short",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: &corev1.Secret{Data: map[string][]byte{
+					".dockerconfigjson": nil,
+				}},
+				supportKey: &corev1.Secret{Data: map[string][]byte{
+					"interval": []byte("1m"),
+				}},
+			},
+			expConfig: &config.Controller{
+				Interval: 1 * time.Minute,
+			},
+			expErr: nil,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			// log klog to test
+			klog.SetOutput(testlog.New(t).Writer())
+
+			ctrl := config.Controller{}
+			kube := kubeClientResponder{}
+			secs := tt.config
+			// setup mock responses for secretes by secret name
+			kube.CoreV1().(*corefake.FakeCoreV1).Fake.AddReactor("get", "secrets",
+				func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					actionName := ""
+					if getAction, ok := action.(clienttesting.GetAction); ok {
+						actionName = getAction.GetName()
+					}
+
+					//log.Printf("namespace %s resource: %s verb %s Name %s", action.GetNamespace(), action.GetResource(), action.GetVerb(), actionName)
+					key := fmt.Sprintf("(%s) %s.%s", action.GetResource(), action.GetNamespace(), actionName)
+					sv, ok := secs[key]
+					if !ok {
+						return false, nil, nil
+					}
+					return true, sv, nil
+				})
+			// imitates New function
+			c := &Controller{
+				kubeClient:    &kube,
+				defaultConfig: ctrl,
+			}
+			c.mergeConfigLocked()
+			err := c.retrieveToken()
+			if err == nil {
+				err = c.retrieveConfig()
+			}
+			expErrS := ""
+			if tt.expErr != nil {
+				expErrS = tt.expErr.Error()
+			}
+			errS := ""
+			if err != nil {
+				errS = err.Error()
+			}
+			if expErrS != errS {
+				t.Fatalf("The test expected error doesn't fit actual error.\nExpected: %s Actual: %s", tt.expErr, err)
+			}
+			if tt.expConfig != nil && !reflect.DeepEqual(tt.expConfig, c.config) {
+				t.Fatalf("The test expected config doesn't fit actual config.\nExpected: %v Actual: %v", tt.expConfig, c.config)
+			}
+		})
+	}
+
+}
+
+var (
+	pullSecretKey = "(/v1, Resource=secrets) openshift-config.pull-secret"
+	supportKey    = "(/v1, Resource=secrets) openshift-config.support"
+	intervalKey   = "interval"
+)
+
+func mustMarshal(v interface{}) []byte {
+	bt, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return bt
+}
+
+func mustLoad(filename string) []byte {
+	f, err := os.Open(filename)
+	if err != nil {
+		panic(fmt.Errorf("test failed to load data: %v", err))
+	}
+	defer f.Close()
+	bts, err := ioutil.ReadAll(f)
+	if err != nil {
+		panic(fmt.Errorf("test failed to read data: %v", err))
+	}
+	return bts
+}
+
+type kubeClientResponder struct {
+	clsetfake.Clientset
+}
+
+var _ kubernetes.Interface = (*kubeClientResponder)(nil)


### PR DESCRIPTION
The retrieve config was doing checks for interval, but the actual error, but it declared new `err` variable, which was shadowing the original err.
That means any set inside of the block, when the block is left was discarded and err returned to original value from outer scope.
In case of too short interval (under 1 m) the outer 'err' was nil, even thought inner scope set it to "too short" it was discarded and function returned err = nil.