### PR TITLE
Report logs when checkPods is going to fail

### DIFF
--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -56,7 +56,7 @@ func TestOptOutOptIn(t *testing.T) {
 	resourceVersion := latestSecret.GetResourceVersion()
 	pullSecret.SetResourceVersion(resourceVersion) // need to update the version, otherwise operation is not permitted
 
-	errConfig := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+	errConfig := wait.PollImmediate(5*time.Second, 10*time.Minute, func() (bool, error) {
 		objs := map[string]interface{}{}
 		errUnmarshals := json.Unmarshal([]byte(pullSecret.Data[".dockerconfigjson"]), &objs)
 		if errUnmarshals != nil {
@@ -79,7 +79,7 @@ func TestOptOutOptIn(t *testing.T) {
 
 	// Check if reports are uploaded - Logs show that insights-operator is enabled and reports are uploaded
 	restartInsightsOperator(t)
-	errDisabled := wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+	errDisabled := wait.PollImmediate(1*time.Second, 20*time.Minute, func() (bool, error) {
 		insightsDisabled := isOperatorDisabled(t, clusterOperatorInsights())
 		if insightsDisabled {
 			return false, nil

--- a/test/integration/bugs_test.go
+++ b/test/integration/bugs_test.go
@@ -96,7 +96,7 @@ func TestUnreachableHost(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	// Check the operator is not degraded anymore
-	errDegraded := wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+	errDegraded := wait.PollImmediate(1*time.Second, 20*time.Minute, func() (bool, error) {
 		insightsDegraded := isOperatorDegraded(t, clusterOperatorInsights())
 		if insightsDegraded {
 			return false, nil

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -102,7 +102,7 @@ func restartInsightsOperator(t *testing.T) {
 
 	for _, pod := range pods.Items {
 		clientset.CoreV1().Pods("openshift-insights").Delete(pod.Name, &metav1.DeleteOptions{})
-		err := wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(1*time.Second, 20*time.Minute, func() (bool, error) {
 			_, err := clientset.CoreV1().Pods("openshift-insights").Get(pod.Name, metav1.GetOptions{})
 			if err == nil {
 				t.Logf("the pod is not yet deleted: %v\n", err)
@@ -150,7 +150,7 @@ func checkPodsLogs(t *testing.T, kubeClient *kubernetes.Clientset, message strin
 			panic(err.Error())
 		}
 
-		errLog := wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
+		errLog := wait.PollImmediate(5*time.Second, 30*time.Minute, func() (bool, error) {
 			req := kubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
 			podLogs, err := req.Stream()
 			if err != nil {
@@ -194,7 +194,7 @@ func TestMain(m *testing.M) {
 func waitForOperator(kubeClient *kubernetes.Clientset) error {
 	depClient := kubeClient.AppsV1().Deployments("openshift-insights")
 
-	err := wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(1*time.Second, 20*time.Minute, func() (bool, error) {
 		_, err := depClient.Get("insights-operator", metav1.GetOptions{})
 		if err != nil {
 			fmt.Printf("error waiting for operator deployment to exist: %v\n", err)

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -168,6 +168,7 @@ func checkPodsLogs(t *testing.T, kubeClient *kubernetes.Clientset, message strin
 			result := strings.Contains(log, message)
 			if result == false {
 				t.Logf("No %s in logs\n", message)
+				t.Logf("Logs for verification: ****\n%s", log)
 				return false, nil
 			}
 


### PR DESCRIPTION
The test is failing quite often and I suspect the problem is quite hidden in pod logs. I wanted to see what is the exact problem and adding the output of actual logs for it.

This is increasing timeouts of our e2e tests to double. It looks the environment is now very slow and we just need to be patient.