### PR TITLE
pkg/controller/status/status: Set reasons for conditions

### DIFF
--- a/docs/insights-archive-sample/config/clusteroperator/insights
+++ b/docs/insights-archive-sample/config/clusteroperator/insights
@@ -15,22 +15,26 @@
       {
         "type": "Degraded",
         "status": "False",
+        "reason": "AsExpected",
         "lastTransitionTime": "2020-03-18T12:14:52Z"
       },
       {
         "type": "Available",
         "status": "True",
+        "reason": "AsExpected",
         "lastTransitionTime": "2020-03-18T12:14:52Z"
       },
       {
         "type": "Progressing",
         "status": "False",
         "lastTransitionTime": "2020-03-18T12:16:52Z",
+        "reason": "AsExpected",
         "message": "Monitoring the cluster"
       },
       {
         "type": "Disabled",
         "status": "False",
+        "reason": "AsExpected",
         "lastTransitionTime": "2020-03-18T12:16:52Z"
       }
     ],

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -208,6 +208,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:   configv1.OperatorDegraded,
 				Status: configv1.ConditionFalse,
+				Reason: "AsExpected",
 			})
 		}
 
@@ -224,6 +225,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:   OperatorDisabled,
 				Status: configv1.ConditionFalse,
+				Reason: "AsExpected",
 			})
 		}
 
@@ -240,6 +242,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:   configv1.OperatorDegraded,
 				Status: configv1.ConditionFalse,
+				Reason: "AsExpected",
 			})
 		}
 
@@ -260,6 +263,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 	setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 		Type:   configv1.OperatorAvailable,
 		Status: configv1.ConditionTrue,
+		Reason: "AsExpected",
 	})
 
 	// update the Progressing condition with a summary of the current state
@@ -272,6 +276,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:    configv1.OperatorProgressing,
 				Status:  configv1.ConditionTrue,
+				Reason:  "Initializing",
 				Message: "Initializing the operator",
 			})
 		}
@@ -281,6 +286,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 		setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 			Type:    configv1.OperatorProgressing,
 			Status:  configv1.ConditionFalse,
+			Reason:  "Degraded",
 			Message: "An error has occurred",
 		})
 
@@ -299,6 +305,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 		setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 			Type:    configv1.OperatorProgressing,
 			Status:  configv1.ConditionFalse,
+			Reason:  "AsExpected",
 			Message: "Monitoring the cluster",
 		})
 	}

--- a/pkg/gather/clusterconfig/testdata/clusteroperators.json
+++ b/pkg/gather/clusterconfig/testdata/clusteroperators.json
@@ -837,22 +837,26 @@
                     {
                         "type": "Degraded",
                         "status": "False",
+                        "reason": "AsExpected",
                         "lastTransitionTime": "2020-04-17T12:12:48Z"
                     },
                     {
                         "type": "Available",
                         "status": "True",
+                        "reason": "AsExpected",
                         "lastTransitionTime": "2020-04-17T12:12:48Z"
                     },
                     {
                         "type": "Progressing",
                         "status": "False",
+                        "reason": "AsExpected",
                         "lastTransitionTime": "2020-04-17T12:14:48Z",
                         "message": "Monitoring the cluster"
                     },
                     {
                         "type": "Disabled",
                         "status": "False",
+                        "reason": "AsExpected",
                         "lastTransitionTime": "2020-04-17T12:14:48Z"
                     }
                 ],


### PR DESCRIPTION
We've been light on reasons for expected conditions like `Progressing=False` since 80ab9237bc.  But if we feel like we have a message we want to set to help humans understand the condition, we should be setting a reason string for machines too.  `AsExpected` follows [the library-go precedent][1].

The `Degraded` reason I'm adding here isn't a great fit for a progressing reason, but does match the current logic used to set `Progressing=True`.  The insights operator doesn't actually supply any in-cluster APIs beyond ClusterOperator as far as I can tell, so it's not clear to me what sort of progressing it would do except its internal intialization (which I give a new `Initializing` reason).  But adding an odd reason seemed easy enough, and we can always circle back later and remove this `Progressing=True` case if we decide we don't need it.

[1]: https://github.com/openshift/library-go/blob/94c59dec54be25c8527e51e8c0a885712aeb01b5/pkg/operator/status/condition.go#L67