### PR TITLE
Bug 1841057: Skip the initial upload delay

### DIFF
--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -1,0 +1,89 @@
+package status
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/insights-operator/pkg/config"
+	"github.com/openshift/insights-operator/pkg/config/configobserver"
+	"github.com/openshift/insights-operator/pkg/utils"
+	kubeclientfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestSaveInitialStart(t *testing.T) {
+
+	tests := []struct {
+		name                     string
+		clusterOperator          *configv1.ClusterOperator
+		expErr                   error
+		initialRun               bool
+		expectedSafeInitialStart bool
+	}{
+		{
+			name:                     "Non-initial run is has upload delayed",
+			initialRun:               false,
+			expectedSafeInitialStart: false,
+		},
+		{
+			name:                     "Initial run with not existing Insights operator is not delayed",
+			initialRun:               true,
+			clusterOperator:          nil,
+			expectedSafeInitialStart: true,
+		},
+		{
+			name:       "Initial run with existing Insights operator which is degraded is delayed",
+			initialRun: true,
+			clusterOperator: &configv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "insights",
+				},
+				Status: configv1.ClusterOperatorStatus{Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue},
+				}},
+			},
+			expectedSafeInitialStart: false,
+		},
+		{
+			name:       "Initial run with existing Insights operator which is not degraded not delayed",
+			initialRun: true,
+			clusterOperator: &configv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "insights",
+				},
+				Status: configv1.ClusterOperatorStatus{Conditions: []configv1.ClusterOperatorStatusCondition{
+					{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+				}},
+			},
+			expectedSafeInitialStart: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			klog.SetOutput(utils.NewTestLog(t).Writer())
+			operators := []runtime.Object{}
+			if tt.clusterOperator != nil {
+				operators = append(operators, tt.clusterOperator)
+			}
+			kubeclientsetclient := kubeclientfake.NewSimpleClientset()
+
+			client := configfake.NewSimpleClientset(operators...)
+			ctrl := &Controller{name: "insights", client: client.ConfigV1(), configurator: configobserver.New(config.Controller{Report: true}, kubeclientsetclient)}
+
+			err := ctrl.updateStatus(tt.initialRun)
+			isSafe := ctrl.SafeInitialStart()
+			if err != tt.expErr {
+				t.Fatalf("updateStatus returned unexpected error: %s Expected %s", err, tt.expErr)
+			}
+			if isSafe != tt.expectedSafeInitialStart {
+				t.Fatalf("unexpected SafeInitialStart was: %t Expected %t", isSafe, tt.expectedSafeInitialStart)
+			}
+		})
+	}
+}

--- a/pkg/insights/insightsuploader/insightsuploader.go
+++ b/pkg/insights/insightsuploader/insightsuploader.go
@@ -34,6 +34,7 @@ type Summarizer interface {
 type StatusReporter interface {
 	LastReportedTime() time.Time
 	SetLastReportedTime(time.Time)
+	SafeInitialStart() bool
 }
 
 type Controller struct {
@@ -79,6 +80,9 @@ func (c *Controller) Run(ctx context.Context) {
 		if now := time.Now(); next.After(now) {
 			initialDelay = wait.Jitter(now.Sub(next), 1.2)
 		}
+	}
+	if c.reporter.SafeInitialStart() {
+		initialDelay = 0
 	}
 	klog.V(2).Infof("Reporting status periodically to %s every %s, starting in %s", cfg.Endpoint, interval, initialDelay.Truncate(time.Second))
 


### PR DESCRIPTION
If the operator is started for the first time, or if it is not degraded, it will upload the collected data immediately after they are collected.

This is removing the original initial jitter delay between periods. Consequent runs will still be jittered. The 15 seconds detection of data to send is still there even for initial run, so the data should arrive in 15 seconds after they are collected (few seconds).