### PR TITLE
pkg/gather/clusterconfig/clusterconfig: include node information in every archive

### DIFF
--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -86,7 +86,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 	return record.Collect(ctx, recorder,
 		GatherMostRecentMetrics(i),
 		GatherClusterOperators(i),
-		GatherUnhealthyNodes(i),
+		GatherNodes(i),
 		GatherConfigMaps(i),
 		GatherClusterVersion(i),
 		GatherClusterID(i),
@@ -221,18 +221,13 @@ func GatherClusterOperators(i *Gatherer) func() ([]record.Record, []error) {
 	}
 }
 
-// GatherUnhealthyNodes collects all unhealthy Nodes.
-//
-// The node is unhealthy when:
-// the operator.Status.Conditions.Condition Type
-//   is OperatorDegrated and Status is True or
-//      OperatorAvailable and Status is False
+// GatherNodes collects all Nodes.
 //
 // The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/node.go#L78
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core
 //
 // Location in archive: config/node/
-func GatherUnhealthyNodes(i *Gatherer) func() ([]record.Record, []error) {
+func GatherNodes(i *Gatherer) func() ([]record.Record, []error) {
 	return func() ([]record.Record, []error) {
 		nodes, err := i.coreClient.Nodes().List(metav1.ListOptions{})
 		if err != nil {
@@ -240,9 +235,6 @@ func GatherUnhealthyNodes(i *Gatherer) func() ([]record.Record, []error) {
 		}
 		records := make([]record.Record, 0, len(nodes.Items))
 		for i := range nodes.Items {
-			if isHealthyNode(&nodes.Items[i]) {
-				continue
-			}
 			records = append(records, record.Record{Name: fmt.Sprintf("config/node/%s", nodes.Items[i].Name), Item: NodeAnonymizer{&nodes.Items[i]}})
 		}
 
@@ -849,15 +841,6 @@ func anonymizeString(s string) string {
 
 func isProductNamespacedKey(key string) bool {
 	return strings.Contains(key, "openshift.io/") || strings.Contains(key, "k8s.io/") || strings.Contains(key, "kubernetes.io/")
-}
-
-func isHealthyNode(node *corev1.Node) bool {
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == corev1.NodeReady && condition.Status != corev1.ConditionTrue {
-			return false
-		}
-	}
-	return true
 }
 
 // PodAnonymizer implements serialization with anonymization for a Pod

--- a/pkg/gather/clusterconfig/clusterconfig_examples.go
+++ b/pkg/gather/clusterconfig/clusterconfig_examples.go
@@ -64,7 +64,7 @@ func ExampleClusterOperators() (string, error) {
 	return string(b), err
 }
 
-func ExampleUnhealthyNodes() (string, error) {
+func ExampleNodes() (string, error) {
 	kube := kubeClientResponder{}
 
 	kube.Fake.AddReactor("list", "nodes",
@@ -79,7 +79,7 @@ func ExampleUnhealthyNodes() (string, error) {
 		})
 
 	g := &Gatherer{coreClient: kube.CoreV1()}
-	d, errs := GatherUnhealthyNodes(g)()
+	d, errs := GatherNodes(g)()
 	if len(errs) > 0 {
 		return "", errs[0]
 	}

--- a/pkg/gather/clusterconfig/clusterconfig_test.go
+++ b/pkg/gather/clusterconfig/clusterconfig_test.go
@@ -327,8 +327,8 @@ func ExampleGatherClusterOperators_Test() {
 	// [{"Name":"config/clusteroperator/","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":{"metadata":{"creationTimestamp":null},"spec":{},"status":{"conditions":[{"type":"Degraded","status":"","lastTransitionTime":null}],"extension":null}}}]
 }
 
-func ExampleGatherUnhealthyNodes_Test() {
-	b, err := ExampleUnhealthyNodes()
+func ExampleGatherNodes_Test() {
+	b, err := ExampleNodes()
 	if err != nil {
 		fmt.Print(err)
 	}


### PR DESCRIPTION

A lot of scenarios could use node information even if these are reporting
as healthy - e.g. custom taints may prevent pods from scheduling or
single master installs. This commit ensures anonymized node information
is included in every archive.