### PR TITLE
Bug 1844419: [release-4.4] GatherClusterOperators: store pod logs

### DIFF
--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -42,6 +42,7 @@ import (
 	networkv1client "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
 
 	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/record/diskrecorder"
 )
 
 const (
@@ -49,18 +50,26 @@ const (
 	// 500 KiB of alerts is limit, one alert line has typically 450 bytes => 1137 lines.
 	// This number has been rounded to 1000 for simplicity.
 	// Formerly, the `500 * 1024 / 450` expression was used instead.
-	metricsAlertsLinesLimit = 1000
+	metricsAlertsLinesLimit        = 1000
 	gatherPodDisruptionBudgetLimit = 5000
+
+	// Log compression ratio is defining a multiplier for uncompressed logs
+	// diskrecorder would refuse to write files larger than MaxLogSize, so GatherClusterOperators
+	// has to limit the expected size of the buffer for logs
+	logCompressionRatio = 2
 )
 
 var (
-	openshiftSerializer = openshiftscheme.Codecs.LegacyCodec(configv1.SchemeGroupVersion)
-	kubeSerializer      = kubescheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion)
+	openshiftSerializer     = openshiftscheme.Codecs.LegacyCodec(configv1.SchemeGroupVersion)
+	kubeSerializer          = kubescheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion)
 	policyV1Beta1Serializer = kubescheme.Codecs.LegacyCodec(policyv1beta1.SchemeGroupVersion)
 
 	// maxEventTimeInterval represents the "only keep events that are maximum 1h old"
 	// TODO: make this dynamic like the reporting window based on configured interval
 	maxEventTimeInterval = 1 * time.Hour
+
+	// logTailLines defines a number lines to keep when fetching pod logs
+	logTailLines = int64(100)
 
 	registrySerializer serializer.CodecFactory
 	networkSerializer  serializer.CodecFactory
@@ -242,6 +251,7 @@ func GatherClusterOperators(i *Gatherer) func() ([]record.Record, []error) {
 		}
 		namespaceEventsCollected := sets.NewString()
 		now := time.Now()
+		unhealthyPods := []*corev1.Pod{}
 		for _, item := range config.Items {
 			if isHealthyOperator(&item) {
 				continue
@@ -252,11 +262,13 @@ func GatherClusterOperators(i *Gatherer) func() ([]record.Record, []error) {
 					klog.V(2).Infof("Unable to find pods in namespace %s for failing operator %s", namespace, item.Name)
 					continue
 				}
-				for i := range pods.Items {
-					if isHealthyPod(&pods.Items[i], now) {
+				for j := range pods.Items {
+					pod := &pods.Items[j]
+					if isHealthyPod(pod, now) {
 						continue
 					}
-					records = append(records, record.Record{Name: fmt.Sprintf("config/pod/%s/%s", pods.Items[i].Namespace, pods.Items[i].Name), Item: PodAnonymizer{&pods.Items[i]}})
+					records = append(records, record.Record{Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name), Item: PodAnonymizer{pod}})
+					unhealthyPods = append(unhealthyPods, pod)
 				}
 				if namespaceEventsCollected.Has(namespace) {
 					continue
@@ -270,8 +282,67 @@ func GatherClusterOperators(i *Gatherer) func() ([]record.Record, []error) {
 				namespaceEventsCollected.Insert(namespace)
 			}
 		}
+
+		// Exit early if no unhealthy pods found
+		if len(unhealthyPods) == 0 {
+			return records, nil
+		}
+
+		// Fetch a list of containers in unhealthy pods and calculate a log size quota
+		// Total log size must not exceed maxLogsSize multiplied by logCompressionRatio
+		klog.V(2).Infof("Found %d unhealthy pods", len(unhealthyPods))
+		totalUnhealthyContainers := 0
+		for _, pod := range unhealthyPods {
+			totalUnhealthyContainers += len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
+		}
+		bufferSize := int64(diskrecorder.MaxLogSize * logCompressionRatio / totalUnhealthyContainers / 2)
+		klog.V(2).Infof("Maximum buffer size: %v bytes", bufferSize)
+		buf := bytes.NewBuffer(make([]byte, 0, bufferSize))
+
+		// Fetch previous and current container logs
+		for _, isPrevious := range []bool{true, false} {
+			for _, pod := range unhealthyPods {
+				allContainers := pod.Spec.InitContainers
+				allContainers = append(allContainers, pod.Spec.Containers...)
+				for _, c := range allContainers {
+					logName := fmt.Sprintf("%s_current.log", c.Name)
+					if isPrevious {
+						logName = fmt.Sprintf("%s_previous.log", c.Name)
+					}
+					buf.Reset()
+					klog.V(2).Infof("Fetching logs for %s container %s pod in namespace %s (previous: %v): %q", c.Name, pod.Name, pod.Namespace, isPrevious, err)
+					// Collect container logs and continue on error
+					err = collectContainerLogs(i, pod, buf, c.Name, isPrevious, &bufferSize)
+					if err != nil {
+						klog.V(2).Infof("Error: %q", err)
+						continue
+					}
+					records = append(records, record.Record{Name: fmt.Sprintf("config/pod/%s/logs/%s/%s", pod.Namespace, pod.Name, logName), Item: Raw{buf.String()}})
+				}
+			}
+		}
+
 		return records, nil
 	}
+}
+
+// collectContainerLogs fetches log lines from the pod
+func collectContainerLogs(i *Gatherer, pod *corev1.Pod, buf *bytes.Buffer, containerName string, isPrevious bool, maxBytes *int64) error {
+	req := i.coreClient.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Previous: isPrevious, Container: containerName, LimitBytes: maxBytes, TailLines: &logTailLines})
+	readCloser, err := req.Stream()
+	if err != nil {
+		klog.V(2).Infof("Failed to fetch log for %s pod in namespace %s for failing operator %s (previous: %v): %q", pod.Name, pod.Namespace, containerName, isPrevious, err)
+		return err
+	}
+
+	defer readCloser.Close()
+
+	_, err = io.Copy(buf, readCloser)
+	if err != nil && err != io.ErrShortBuffer {
+		klog.V(2).Infof("Failed to write log for %s pod in namespace %s for failing operator %s (previous: %v): %q", pod.Name, pod.Namespace, containerName, isPrevious, err)
+		return err
+	}
+	return nil
 }
 
 // GatherNodes collects all Nodes.
@@ -955,7 +1026,6 @@ func (a PodDisruptionBudgetsAnonymizer) Marshal(_ context.Context) ([]byte, erro
 func (a PodDisruptionBudgetsAnonymizer) GetExtension() string {
 	return "json"
 }
-
 
 func isHealthyPod(pod *corev1.Pod, now time.Time) bool {
 	// pending pods may be unable to schedule or start due to failures, and the info they provide in status is important

--- a/pkg/record/diskrecorder/diskrecorder.go
+++ b/pkg/record/diskrecorder/diskrecorder.go
@@ -34,6 +34,9 @@ func (r memoryRecords) Less(i, j int) bool { return r[i].name < r[j].name }
 func (r memoryRecords) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 func (r memoryRecords) Len() int           { return len(r) }
 
+// MaxLogSize defines maximum allowed tarball size
+const MaxLogSize = 8 * 1024 * 1024
+
 type Recorder struct {
 	basePath  string
 	flushCh   chan struct{}
@@ -53,7 +56,7 @@ func New(basePath string, interval time.Duration) *Recorder {
 		maxAge:    interval * 6 * 24,
 		records:   make(map[string]*memoryRecord),
 		flushCh:   make(chan struct{}, 1),
-		flushSize: 8 * 1024 * 1024,
+		flushSize: MaxLogSize,
 	}
 }
 


### PR DESCRIPTION
If the pod is not healthy Insights operator should collect
previous/current logs for the pod containers. Only last 100 lines
is being kept to prevent the archive from growing large.

This also backports #128 so that resulting tarball doesn't exceed 8Mb