### PR TITLE
gather: Collect namespace level cpu and memory metrics

### DIFF
--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -110,6 +110,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 //   ALERTS
 //   etcd_object_counts
 //   cluster_installer
+//   namespace CPU and memory usage
 //
 // Location in archive: config/metrics/
 // See: docs/insights-archive-sample/config/metrics
@@ -122,6 +123,8 @@ func GatherMostRecentMetrics(i *Gatherer) func() ([]record.Record, []error) {
 			Param("match[]", "ALERTS").
 			Param("match[]", "etcd_object_counts").
 			Param("match[]", "cluster_installer").
+			Param("match[]", "namespace:container_cpu_usage_seconds_total:sum_rate").
+			Param("match[]", "namespace:container_memory_usage_bytes:sum").
 			DoRaw()
 		if err != nil {
 			// write metrics errors to the file format as a comment


### PR DESCRIPTION
These metrics help identify distribution of CPU and memory use
within a cluster at infrequent intervals. All labels on the new
metrics are present in ALERTS and are also returned in telemetry,
so do not represent a larger source of gathered data.

The data will be used to identify regressions in core and extension
operator usage across the fleet, as well as to ensure that over time
OpenShift operators continue to reduce resource consumption.