### PR TITLE
Check also Pod status before enabling Fast upload

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -127,7 +127,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 
 	// the status controller initializes the cluster operator object and retrieves
 	// the last sync time, if any was set
-	statusReporter := status.NewController(configClient, configObserver, os.Getenv("POD_NAMESPACE"))
+	statusReporter := status.NewController(configClient, gatherKubeClient.CoreV1(), configObserver, os.Getenv("POD_NAMESPACE"))
 
 	// the recorder periodically flushes any recorded data to disk as tar.gz files
 	// in s.StoragePath, and also prunes files above a certain age


### PR DESCRIPTION
There are three main changes here:
- Besides checking reported operator status, before enabling Fast upload path (without initial delay) it is also checking insights Operator Pod status. This is to address https://github.com/openshift/insights-operator/pull/117#issuecomment-645646045.
- Originally, the fast upload mode was enabled and disabled by UpdateStatus, which is happening on startup and then periodically every 30s. On larger clusters when data Gathering took more then 30 seconds, this consequent call to updateStatus was not considered initial and disabled - even if operator was helthy. To fix this, fast mode is now disabled from after insights upload happens (successfully or not)..
- Additional fast upload mode improvement - originally when Cluster Version wasnt available (which is collected during Gather) upload sets waiting time to random interval 0 - 15m, which could slow down initial fast upload. To fix this, when we are in fast upload mode, it is now waiting only 15 sec (to wait for Gather to finish).
