### PR TITLE
Shorten e2e tests interval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ test-unit:
 .PHONY: test-unit
 
 test-e2e:
-	go test ./test/integration -run ^\(TestPullSecretExists\)$$ -timeout 2h
-	go test ./test/integration -timeout 2h $(TEST_OPTIONS)
+	go test ./test/integration -run ^\(TestPullSecretExists\)$$ -timeout 1m
+	go test ./test/integration -timeout 10m $(TEST_OPTIONS)
 .PHONY: test-e2e
 
 vet:


### PR DESCRIPTION
The timeout for e2e was too high, now it runs in about 7m, so setting 10m should be enough.