### PR TITLE
TestPodLogsCollected fix

### DIFF
--- a/test/integration/bugs_test.go
+++ b/test/integration/bugs_test.go
@@ -140,7 +140,7 @@ func TestPodLogsCollected(t *testing.T) {
 	defer ChangeReportTimeInterval(t, 1)()
 	pod := findPod(t, clientset, "openshift-monitoring", "cluster-monitoring-operator")
 	defer degradeOperator(t, clientset, pod)()
-	checkPodsLogs(t, clientset, "Writing \\d+ records to", true)
+	checkPodsLogs(t, clientset, `Wrote \d+ records to disk in \d+`, true)
 	if !LatestArchiveContainsPodLogs(t, clientset, pod) {
 		t.Fatal("There are no logs!")
 	}


### PR DESCRIPTION
We should wait a little bit longer for a log that tells logs are already written, not that the logs are currently being written.