### PR TITLE
[WIP] E2e tests small cleanup/refactor

### DIFF
--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -44,7 +44,7 @@ func TestPullSecretExists(t *testing.T) {
 func TestOptOutOptIn(t *testing.T) {
 	// initially IO should be running
 	errDisabled := wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
-		insightsNotDisabled := !operatorStatus(t, clusterOperatorInsights(), status.OperatorDisabled, configv1.ConditionTrue)
+		insightsNotDisabled := !operatorStatus(t, clusterOperator(t, "insights"), status.OperatorDisabled, configv1.ConditionTrue)
 		if insightsNotDisabled {
 			return true, nil
 		}
@@ -127,7 +127,7 @@ func TestOptOutOptIn(t *testing.T) {
 
 	// Wait for operator to become disabled because of removed pull-secret
 	errDisabled = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
-		insightsDisabled := isOperatorDisabled(t, clusterOperatorInsights())
+		insightsDisabled := isOperatorDisabled(t, clusterOperator(t, "insights"))
 		if insightsDisabled {
 			return true, nil
 		}
@@ -145,7 +145,7 @@ func TestOptOutOptIn(t *testing.T) {
 	// Check if reports are uploaded - Logs show that insights-operator is enabled and reports are uploaded
 	restartInsightsOperator(t)
 	errDisabled = wait.PollImmediate(1*time.Second, 3*time.Minute, func() (bool, error) {
-		insightsNotDisabled := !operatorStatus(t, clusterOperatorInsights(), status.OperatorDisabled, configv1.ConditionTrue)
+		insightsNotDisabled := !operatorStatus(t, clusterOperator(t, "insights"), status.OperatorDisabled, configv1.ConditionTrue)
 		if insightsNotDisabled {
 			return true, nil
 		}


### PR DESCRIPTION
1. removing clusterOperatorInsights() as this function was generalised in previous PR, but did not want to touch other tests in the PR
2. simplifying error check pattern.
```
	if err != nil {
		t.Fatal(err.Error(), "error message")
	}
```
this pattern was appearing very often, so I have simplified it to
```
	e(t, err, "error message")
```
Now there is possible to add any number of error messages to e function, so
```
	e(t, err, "error", "message")
```
or
```
	e(t, err)
```
works too


The e function also prints stack trace inside integration tests
example:
```=== RUN   TestPodLogsCollected
    main_test.go:292: [error message] mesage_inside_err
        github.com/openshift/insights-operator/test/integration.checkPodsLogs(0xc000582f00, 0xc00029b760, 0x13f0de6, 0x20, 0xc000615f6f, 0x1, 0x1)
        	/home/psimovec/w/insights-operator/test/integration/main_test.go:175 +0x214
        github.com/openshift/insights-operator/test/integration.TestPodLogsCollected(0xc000582f00)
        	/home/psimovec/w/insights-operator/test/integration/bugs_test.go:139 +0x72
--- FAIL: TestPodLogsCollected (0.16s)
```


We discussed with Martin, that in future we could use some assert library instead