### PR TITLE
Limit the metric alerts to at max 1137 lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,24 @@ There's a tool named `gen_cert_key.py` that can be used to automatically generat
 ```
 gen_cert_file.py kubeconfig.yaml
 ```
+
+### Fetching metrics from Prometheus endpoint
+
+```
+sudo kubefwd svc -n openshift-monitoring -d openshift-monitoring.svc -l prometheus=k8s
+curl --cert k8s.crt --key k8s.key  -k 'https://prometheus-k8s.openshift-monitoring.svc:9091/metrics'
+```
+
+### Debugging prometheus metrics without valid CA
+
+Get a bearer token
+```
+oc sa get-token prometheus-k8s -n openshift-monitoring
+```
+Change in pkg/controller/operator.go after creating metricsGatherKubeConfig (about line 86)
+```
+metricsGatherKubeConfig.Insecure = true
+metricsGatherKubeConfig.BearerToken = "paste your token here"
+metricsGatherKubeConfig.CAFile = "" // by default it is "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+metricsGatherKubeConfig.CAData = []byte{}
+```

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -159,36 +159,38 @@ Location in archive: config/configmaps/
 See: docs/insights-archive-sample/config/configmaps
 
 
+## ContainerImages
+
+collects essential information about running containers.
+Specifically, the age of pods, the set of running images and the container names are collected.
+
+Location in archive: config/running_containers.json
+
+
 ## MostRecentMetrics
 
 gathers cluster Federated Monitoring metrics.
 
 The GET REST query to URL /federate
 Gathered metrics:
-  ALERTS
   etcd_object_counts
   cluster_installer
   namespace CPU and memory usage
-
+then followed by at max 1137 lines from ALERTS metric
 Location in archive: config/metrics/
 See: docs/insights-archive-sample/config/metrics
 
 
-Output raw size: 108
+Output raw size: 120
 
 ### Examples
 
 #### MostRecentMetrics
-[{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAo="}]
+[{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAojIEFsZXJ0cyAK"}]
 
 ## Nodes
 
 collects all Nodes.
-
-The node is unhealthy when:
-the operator.Status.Conditions.Condition Type
-  is OperatorDegrated and Status is True or
-     OperatorAvailable and Status is False
 
 The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/node.go#L78
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core

--- a/pkg/gather/clusterconfig/clusterconfig_test.go
+++ b/pkg/gather/clusterconfig/clusterconfig_test.go
@@ -442,7 +442,7 @@ func ExampleGatherMostRecentMetrics_Test() {
 	}
 	fmt.Print(string(b))
 	// Output:
-	// [{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAo="}]
+	// [{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAojIEFsZXJ0cyAK"}]
 }
 
 func ExampleGatherClusterOperators_Test() {


### PR DESCRIPTION
This downloads original metrics, but limits potentially huge alerts to 1137 lines. This is to handle situation when crashlooping service was generating thousands of new alert instances and the resulting metrics were huge.