### PR TITLE
Bug 1862444: Limit collection of ALERTS metric to 1000 lines (~500KiB) to avoid unbearably large archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,24 @@ There's a tool named `gen_cert_key.py` that can be used to automatically generat
 ```
 gen_cert_file.py kubeconfig.yaml
 ```
+
+### Fetching metrics from Prometheus endpoint
+
+```
+sudo kubefwd svc -n openshift-monitoring -d openshift-monitoring.svc -l prometheus=k8s
+curl --cert k8s.crt --key k8s.key  -k 'https://prometheus-k8s.openshift-monitoring.svc:9091/metrics'
+```
+
+### Debugging prometheus metrics without valid CA
+
+Get a bearer token
+```
+oc sa get-token prometheus-k8s -n openshift-monitoring
+```
+Change in pkg/controller/operator.go after creating metricsGatherKubeConfig (about line 86)
+```
+metricsGatherKubeConfig.Insecure = true
+metricsGatherKubeConfig.BearerToken = "paste your token here"
+metricsGatherKubeConfig.CAFile = "" // by default it is "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+metricsGatherKubeConfig.CAData = []byte{}
+```

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -159,36 +159,39 @@ Location in archive: config/configmaps/
 See: docs/insights-archive-sample/config/configmaps
 
 
+## ContainerImages
+
+collects essential information about running containers.
+Specifically, the age of pods, the set of running images and the container names are collected.
+
+Location in archive: config/running_containers.json
+
+
 ## MostRecentMetrics
 
 gathers cluster Federated Monitoring metrics.
 
 The GET REST query to URL /federate
 Gathered metrics:
-  ALERTS
   etcd_object_counts
   cluster_installer
   namespace CPU and memory usage
+  followed by at most 1000 lines of ALERTS metric
 
 Location in archive: config/metrics/
 See: docs/insights-archive-sample/config/metrics
 
 
-Output raw size: 108
+Output raw size: 120
 
 ### Examples
 
 #### MostRecentMetrics
-[{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAo="}]
+[{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAojIEFsZXJ0cyAK"}]
 
 ## Nodes
 
 collects all Nodes.
-
-The node is unhealthy when:
-the operator.Status.Conditions.Condition Type
-  is OperatorDegrated and Status is True or
-     OperatorAvailable and Status is False
 
 The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/node.go#L78
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/url"
 	"regexp"
 	"sort"
@@ -47,6 +48,12 @@ const (
 	// imageGatherPodLimit is the maximum number of pods that
 	// will be listed in a single request to reduce memory usage.
 	imageGatherPodLimit = 200
+
+	// metricsAlertsLinesLimit is the maximal number of lines read from monitoring Prometheus
+	// 500 KiB of alerts is limit, one alert line has typically 450 bytes => 1137 lines.
+	// This number has been rounded to 1000 for simplicity.
+	// Formerly, the `500 * 1024 / 450` expression was used instead.
+	metricsAlertsLinesLimit = 1000
 )
 
 var (
@@ -64,6 +71,9 @@ var (
 	logTailLines = int64(100)
 
 	imageHostRegex = regexp.MustCompile(`(^|\.)(openshift\.org|registry\.redhat\.io|registry\.access\.redhat\.com)$`)
+
+	// lineSep is the line separator used by the alerts metric
+	lineSep = []byte{'\n'}
 )
 
 func init() {
@@ -123,10 +133,10 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 //
 // The GET REST query to URL /federate
 // Gathered metrics:
-//   ALERTS
 //   etcd_object_counts
 //   cluster_installer
 //   namespace CPU and memory usage
+//   followed by at most 1000 lines of ALERTS metric
 //
 // Location in archive: config/metrics/
 // See: docs/insights-archive-sample/config/metrics
@@ -136,7 +146,6 @@ func GatherMostRecentMetrics(i *Gatherer) func() ([]record.Record, []error) {
 			return nil, nil
 		}
 		data, err := i.metricsClient.Get().AbsPath("federate").
-			Param("match[]", "ALERTS").
 			Param("match[]", "etcd_object_counts").
 			Param("match[]", "cluster_installer").
 			Param("match[]", "namespace:container_cpu_usage_seconds_total:sum_rate").
@@ -147,6 +156,34 @@ func GatherMostRecentMetrics(i *Gatherer) func() ([]record.Record, []error) {
 			klog.Errorf("Unable to retrieve most recent metrics: %v", err)
 			return []record.Record{{Name: "config/metrics", Item: RawByte(fmt.Sprintf("# error: %v\n", err))}}, nil
 		}
+
+		rsp, err := i.metricsClient.Get().AbsPath("federate").
+			Param("match[]", "ALERTS").
+			Stream()
+		if err != nil {
+			// write metrics errors to the file format as a comment
+			klog.Errorf("Unable to retrieve most recent alerts from metrics: %v", err)
+			return []record.Record{{Name: "config/metrics", Item: RawByte(fmt.Sprintf("# error: %v\n", err))}}, nil
+		}
+		r := NewLineLimitReader(rsp, metricsAlertsLinesLimit)
+		alerts, err := ioutil.ReadAll(r)
+		if err != nil && err != io.EOF {
+			klog.Errorf("Unable to read most recent alerts from metrics: %v", err)
+			return nil, []error{err}
+		}
+
+		remainingAlertLines, err := countLines(rsp)
+		if err != nil && err != io.EOF {
+			klog.Errorf("Unable to count truncated lines of alerts metric: %v", err)
+			return nil, []error{err}
+		}
+		totalAlertCount := r.GetTotalLinesRead() + remainingAlertLines
+
+		// # ALERTS <Total Alerts Lines>/<Alerts Line Limit>
+		// The total number of alerts will typically be greater than the true number of alerts by 2
+		// because the `# TYPE ALERTS untyped` header and the final empty line are counter in.
+		data = append(data, []byte(fmt.Sprintf("# ALERTS %d/%d\n", totalAlertCount, metricsAlertsLinesLimit))...)
+		data = append(data, alerts...)
 		records := []record.Record{
 			{Name: "config/metrics", Item: RawByte(data)},
 		}
@@ -1150,4 +1187,61 @@ func hasContainerInCrashloop(pod *corev1.Pod) bool {
 		}
 	}
 	return false
+}
+
+// NewLineLimitReader returns a Reader that reads from `r` but stops with EOF after `n` lines.
+func NewLineLimitReader(r io.Reader, n int) *LineLimitedReader { return &LineLimitedReader{r, n, 0} }
+
+// A LineLimitedReader reads from R but limits the amount of
+// data returned to just N lines. Each call to Read
+// updates N to reflect the new amount remaining.
+// Read returns EOF when N <= 0 or when the underlying R returns EOF.
+type LineLimitedReader struct {
+	reader        io.Reader // underlying reader
+	maxLinesLimit int       // max lines remaining
+	// totalLinesRead is the total number of line separators already read by the underlying reader.
+	totalLinesRead int
+}
+
+func (l *LineLimitedReader) Read(p []byte) (int, error) {
+	if l.maxLinesLimit <= 0 {
+		return 0, io.EOF
+	}
+
+	rc, err := l.reader.Read(p)
+	l.totalLinesRead += bytes.Count(p[:rc], lineSep)
+
+	lc := 0
+	for {
+		lineSepIdx := bytes.Index(p[lc:rc], lineSep)
+		if lineSepIdx == -1 {
+			return rc, err
+		}
+		if l.maxLinesLimit <= 0 {
+			return lc, io.EOF
+		}
+		l.maxLinesLimit--
+		lc += lineSepIdx + 1 // skip past the EOF
+	}
+}
+
+// GetTotalLinesRead return the total number of line separators already read by the underlying reader.
+// This includes lines that have been truncated by the `Read` calls after exceeding the line limit.
+func (l *LineLimitedReader) GetTotalLinesRead() int { return l.totalLinesRead }
+
+// countLines reads the remainder of the reader and counts the number of lines.
+//
+// Inspired by: https://stackoverflow.com/a/24563853/
+func countLines(r io.Reader) (int, error) {
+	buf := make([]byte, 0x8000)
+	// Original implementation started from 0, but a file with no line separator
+	// still contains a single line, so I would say that was an off-by-1 error.
+	lineCount := 1
+	for {
+		c, err := r.Read(buf)
+		lineCount += bytes.Count(buf[:c], lineSep)
+		if err != nil {
+			return lineCount, err
+		}
+	}
 }

--- a/pkg/gather/clusterconfig/clusterconfig_test.go
+++ b/pkg/gather/clusterconfig/clusterconfig_test.go
@@ -442,7 +442,7 @@ func ExampleGatherMostRecentMetrics_Test() {
 	}
 	fmt.Print(string(b))
 	// Output:
-	// [{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAo="}]
+	// [{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAojIEFMRVJUUyAyLzEwMDAKSGVsbG8sIGNsaWVudAo="}]
 }
 
 func ExampleGatherClusterOperators_Test() {


### PR DESCRIPTION
Copy of #147 with a couple of additional fixes and tweaks.

The docs update also includes a forgotten update from #133.

## Description from BugZilla

> When an operator starts generating big amount of Alerts into the prometheus, Insights operator is downloading all the alerts and the resulting file might be big.
>
> The consequence is that internal data pipeline in CCX is failing, because we cannot store archive to Kafka, where maximal limit is 1MB a if the file is larger then 300 KB, services were failing during the Insights rule processing when it was extracting it all to memory.