### PR TITLE
Test if files in insights archive have extension set

### DIFF
--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -354,6 +354,14 @@ func ChangeReportTimeInterval(t *testing.T, minutes time.Duration) func(){
 	return func(){ changeReportTimeInterval(t, previousInterval) }
 }
 
+func latestArchiveFiles(t *testing.T) []string {
+	insightsPod := findPod(t, clientset, "openshift-insights", "insights-operator")
+	archiveLogFiles := `tar tf $(ls -dtr /var/lib/insights-operator/* | tail -1)`
+	stdout, _, _ := ExecCmd(t, clientset, insightsPod.Name, "openshift-insights", archiveLogFiles, nil)
+	stdout = strings.TrimSpace(stdout)
+	return strings.Split(stdout, "\n")
+}
+
 func latestArchiveContainsFiles(t *testing.T, pattern string) (int, error) {
 	insightsPod := findPod(t, clientset, "openshift-insights", "insights-operator")
 	hasLatestArchiveLogs := fmt.Sprintf(`tar tf $(ls -dtr /var/lib/insights-operator/* | tail -1)|grep -c "%s"`, pattern)


### PR DESCRIPTION
Tests if files in insights archive have an extension. There are some exceptions. The test will be needed to be updated if new extensions or exceptions appear.

This test was added to tests after degrading the operator, as these add more files to the insights archive. So there is more to check without making tests run longer.

https://bugzilla.redhat.com/show_bug.cgi?id=1840012

Q: are really these "patterns" supposed to be exceptions?
                `/config$`,
		`/id$`,
		`/invoker$`,
		`/metrics$`,
		`/version$`,