### PR TITLE
Decrease insights secret interval minimal duration

### DIFF
--- a/pkg/config/configobserver/configobserver.go
+++ b/pkg/config/configobserver/configobserver.go
@@ -144,13 +144,13 @@ func (c *Controller) retrieveConfig() error {
 		if intervalString, ok := secret.Data["interval"]; ok {
 			var duration time.Duration
 			duration, err = time.ParseDuration(string(intervalString))
-			if err == nil && duration < time.Minute {
+			if err == nil && duration < 10*time.Second {
 				err = fmt.Errorf("too short")
 			}
 			if err == nil {
 				nextConfig.Interval = duration
 			} else {
-				err = fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to one minute: %v", err)
+				err = fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to ten seconds: %v", err)
 				nextConfig.Report = false
 			}
 		}

--- a/pkg/config/configobserver/configobserver_test.go
+++ b/pkg/config/configobserver/configobserver_test.go
@@ -40,7 +40,7 @@ func TestChangeSupportConfig(t *testing.T) {
 					"interval": []byte("1s"),
 				}},
 			},
-			expErr: fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to one minute: too short"),
+			expErr: fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to ten seconds: too short"),
 		},
 		{name: "correct interval",
 			config: map[string]*corev1.Secret{


### PR DESCRIPTION
Decreasing the minimal duration of insights secret interval can significantly speed-up e2e tests