### PR TITLE
Fix TestArchiveContains/File: Check if insights operator records an event

### DIFF
--- a/test/integration/bugs_test.go
+++ b/test/integration/bugs_test.go
@@ -181,6 +181,7 @@ func TestArchiveContains(t *testing.T) {
 
 	defer ChangeReportTimeInterval(t, 1)()
 	defer degradeOperatorMonitoring(t)()
+	checkPodsLogs(t, clientset, `Recording events/openshift-monitoring`, true)
 	checkPodsLogs(t, clientset, `Wrote \d+ records to disk in \d+`, true)
 
 	//https://bugzilla.redhat.com/show_bug.cgi?id=1838973


### PR DESCRIPTION
Checking if insights operator records an event file before checking that the records were written to the disk should prevent running tests with an older archive that doesn't have new records yet