### PR TITLE
Fix test: Increase allowed delay in TestUploadNotDelayedAfterStart

### DIFF
--- a/test/integration/bugs_test.go
+++ b/test/integration/bugs_test.go
@@ -26,7 +26,7 @@ func TestUploadNotDelayedAfterStart(t *testing.T) {
 	time1:=logLineTime(t, `Reporting status periodically to .* every`)
 	time2:=logLineTime(t, `Successfully reported id=`)
 	delay := time2.Sub(time1)
-	allowedDelay := time.Minute
+	allowedDelay := 3*time.Minute
 	t.Logf("Archive upload delay was %d seconds", delay/time.Second)
 	if delay > allowedDelay && delay < time.Hour*24-allowedDelay {
 		t.Fatal("Upload after start took too much time")


### PR DESCRIPTION
The allowed delay was too strict, it sometimes fails with older version if the delay happens to be ~1min 30 secs, which shouldn't cause test failure.