### PR TITLE
Bug 1881364: Add new team members to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,12 @@ approvers:
 - tisnik
 - alexandrevicenzi
 - martinkunc
-- natiiix 
+- natiiix
+- 0sewa0
+- tremes
+- rluders
+- psimovec
+- Sergey1011010
 reviewers:
 - smarterclayton
 - derekwaynecarr
@@ -16,5 +21,10 @@ reviewers:
 - alexandrevicenzi
 - martinkunc
 - natiiix
+- 0sewa0
+- tremes
+- rluders
+- psimovec
+- Sergey1011010
 
 component: "Insights operator"


### PR DESCRIPTION
Several members of the Insights Operator team are missing from the `OWNERS` file in the Insights Operator repository. This PR adds the missing members to the `OWNERS` file. Hopefully no one has been forgotten.