### PR TITLE
Bug 1881848: Do not return CRD not found error, just log it

### DIFF
--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -720,6 +720,12 @@ func GatherCRD(i *Gatherer) func() ([]record.Record, []error) {
 		records := []record.Record{}
 		for _, crdName := range toBeCollected {
 			crd, err := i.crdClient.CustomResourceDefinitions().Get(crdName, metav1.GetOptions{})
+			// Log missing CRDs, but do not return the error.
+			if errors.IsNotFound(err) {
+				klog.V(2).Infof("Cannot find CRD: %q", crdName)
+				continue
+			}
+			// Other errors will be returned.
 			if err != nil {
 				return []record.Record{}, []error{err}
 			}


### PR DESCRIPTION
Currently, if a CRD is missing from a cluster and the Insights Operator with unsucessfully attempt to collect it, it will crash. However, some CRDs are supposed to be missing, which would cause I.O. to repeatedly crash. Instead, these errors should only be logged and the error should not be reported.