### PR TITLE
TestProxyOverride

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test-unit:
 test-e2e:
 	go test ./test/integration -v -run ^\(TestIsIOHealthy\)$$ ^\(TestPullSecretExists\)$$ -timeout 1m
 	test/integration/resource_samples/apply.sh
-	go test ./test/integration -v -timeout 20m $(TEST_OPTIONS)
+	go test ./test/integration -v -timeout 32m $(TEST_OPTIONS)
 .PHONY: test-e2e
 
 vet:

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -86,11 +86,11 @@ func TestOptOutOptIn(t *testing.T) {
 		t.Fatalf("The pull-secret read failed: %s", err)
 	}
 	resetSecrets := func() {
-		err := forceUpdateSecret(OpenShiftConfig, PullSecret, pullSecret)
+		_, err := forceUpdateSecret(OpenShiftConfig, PullSecret, pullSecret)
 		if err != nil {
 			t.Error(err)
 		}
-		err = forceUpdateSecret(OpenShiftConfig, Support, supportSecret)
+		_, err = forceUpdateSecret(OpenShiftConfig, Support, supportSecret)
 		if err != nil {
 			t.Error(err)
 		}
@@ -156,7 +156,7 @@ func TestOptOutOptIn(t *testing.T) {
 		t.Fatalf("The Cluster Operator wasn't disabled after removing pull-secret")
 	}
 	// Return to original pull secret, so that IO would be enabled again
-	err = forceUpdateSecret(OpenShiftConfig, PullSecret, pullSecret)
+	_, err = forceUpdateSecret(OpenShiftConfig, PullSecret, pullSecret)
 	if err != nil {
 		t.Errorf("cannot return original pull-secret: %s", err)
 	}

--- a/test/integration/bugs_test.go
+++ b/test/integration/bugs_test.go
@@ -279,18 +279,17 @@ func TestClusterDefaultNodeSelector(t *testing.T) {
 
 //https://bugzilla.redhat.com/show_bug.cgi?id=1820595
 func TestProxyOverride(t *testing.T) {
-	// 2 proxies
-	// set one as clusterwide
-	// check that upload does not work
-	// override io proxy
-	// check that upload works
 	proxy_io := tinyproxy(t)
-	defer proxy_io.delete()
 	proxy_global := tinyproxy(t)
+	defer proxy_io.delete()
 	defer proxy_global.delete()
-	defer proxy_global.setClusterWideProxy(t)
+
+	defer proxy_global.setAsClusterWideProxy(t)
+	// check that upload does not work now
 	triggerArchiveUpload(t, false)
-	defer proxy_io.setIOProxyOverride(t)
+	defer proxy_io.setAsIOProxyOverride(t)
+	// check that upload works now
 	triggerArchiveUpload(t, true)
+	// check that upload did go trough the proxy
 	proxy_io.LogChecker.Search("cloud.redhat.com")
 }

--- a/test/integration/bugs_test.go
+++ b/test/integration/bugs_test.go
@@ -310,3 +310,57 @@ func TestClusterDefaultNodeSelector(t *testing.T) {
 		t.Log("Pod is scheduled")
 	}
 }
+
+//https://bugzilla.redhat.com/show_bug.cgi?id=1820595
+func TestProxyOverride(t *testing.T) {
+	// 2 proxies
+	// set one as clusterwide
+	// check that upload does not work
+	// override io proxy
+	// check that upload works
+	proxy_io := tinyproxy(t)
+	defer proxy_io.delete()
+	proxy_global := tinyproxy(t)
+	defer proxy_global.delete()
+	proxy_global.setClusterWideProxy(t)
+	triggerArchiveUpload(t, false)
+	proxy_io.setIOProxyOverride(t)
+	triggerArchiveUpload(t, true)
+	proxy_io.LogChecker.Search("cloud.redhat.com")
+	// Check that works
+	//type Patch struct {
+	//      HTTPS string `json:"httpsProxy"`
+	//}
+	//xd := make([]Patch, 1)
+	//xd[0].HTTPS= proxy.adress
+	//patch_bytes, err := json.Marshal(xd)
+	//data := fmt.Sprintf("{ \"op\": \"replace\", \"path\": \"/data/httpsProxy\", \"value\": \"%s\" }", proxy.adress)
+
+	//patch_bytes := []byte(fmt.Sprintf("{data:{httpsProxy:\"%s\"}}", proxy.adress))
+	//e(t, err, "failed marshalling")
+	//    modifiedSecret := corev1.Secret{
+	//        TypeMeta: metav1.TypeMeta{},
+	//        ObjectMeta: metav1.ObjectMeta{
+	//            Name:      Support,
+	//            Namespace: OpenShiftConfig,
+	//        },
+	//        Data: map[string][]byte{
+	//            "interval": []byte("1m"), // for faster testing
+	//            "httpsProxy": []byte(proxy_io.adress),
+	//            "httpProxy": []byte(proxy_io.adress),
+	//        },
+	//        Type: "Opaque",
+	//    }
+	//
+	//    clientset.CoreV1().Secrets(OpenShiftConfig).Delete(context.Background(), Support, metav1.DeleteOptions{})
+	//    _, err := clientset.CoreV1().Secrets(OpenShiftConfig).Create(context.Background(), &modifiedSecret, metav1.CreateOptions{})
+	//    e(t,err, "xd")
+	//    t.Log(proxy_io.adress)
+	//    restartInsightsOperator(t)
+	//    defer degradeOperatorMonitoring(t)()
+	//    checker := LogChecker(t).Timeout(2*time.Minute)
+	//    checker.SinceNow().Search(`Recording events/openshift-monitoring`)
+	//    checker.EnableSinceLastCheck().Search(`Wrote \d+ records to disk in \d+`)
+	//    checker.Search("Uploaded report successfully")
+	//    proxy_io.LogChecker.Search("cloud.redhat.com")
+}

--- a/test/integration/log_checker.go
+++ b/test/integration/log_checker.go
@@ -169,7 +169,7 @@ func (lc *LogCheck) Execute() *LogCheck {
 		}
 	}
 	if lc.failFast && resultError != nil {
-		t.Fatal(resultError)
+		t.Error(resultError)
 	}
 	lc.Err = resultError
 	return lc

--- a/test/integration/log_checker.go
+++ b/test/integration/log_checker.go
@@ -42,6 +42,14 @@ func (lc *LogCheck) Interval(interval time.Duration) *LogCheck {
 	return lc
 }
 
+func (lc *LogCheck) FailFast(failFast ...bool) *LogCheck {
+	if len(failFast) == 0 {
+		lc.failFast = true
+	}
+	lc.failFast = failFast[0]
+	return lc
+}
+
 func (lc *LogCheck) Timeout(timeout time.Duration) *LogCheck {
 	lc.timeout = timeout
 	return lc
@@ -159,6 +167,9 @@ func (lc *LogCheck) Execute() *LogCheck {
 		if err == nil {
 			resultError = nil
 		}
+	}
+	if lc.failFast && resultError != nil {
+		t.Fatal(resultError)
 	}
 	lc.Err = resultError
 	return lc

--- a/test/integration/log_checker.go
+++ b/test/integration/log_checker.go
@@ -163,3 +163,15 @@ func (lc *LogCheck) Execute() *LogCheck {
 	lc.Err = resultError
 	return lc
 }
+
+func logChecker(t *testing.T, clientset *kubernetes.Clientset) *LogCheck {
+	defaults := &LogCheck{
+		interval:   time.Second,
+		logOptions: corev1.PodLogOptions{},
+		timeout:    5 * time.Minute,
+		failFast:   true,
+		test:       t,
+		clientset:  clientset,
+	}
+	return defaults
+}

--- a/test/integration/proxy.go
+++ b/test/integration/proxy.go
@@ -1,0 +1,89 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"testing"
+	"time"
+)
+
+type TinyProxy struct {
+	pod        *v1.Pod
+	name       string
+	client     v12.PodInterface
+	IP         string
+	PORT       string
+	adress     string
+	status     string
+	ready      bool
+	LogChecker *LogCheck
+	t          *testing.T
+}
+
+func (proxy *TinyProxy) create(t *testing.T, clientset *kubernetes.Clientset) error {
+	proxy.t = t
+	content, err := ioutil.ReadFile("resources_situational/tiny.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to load local pod file: %e", err)
+	}
+	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDecoder()
+	pod := &corev1.Pod{}
+	err = runtime.DecodeInto(decoder, content, pod)
+	if err != nil {
+		return fmt.Errorf("failed to decode local pod file: %e", err)
+	}
+	namespace := corev1.NamespaceDefault
+	proxy.client = clientset.CoreV1().Pods(namespace)
+	result, err := proxy.client.Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create pod: %e", err)
+	}
+	proxy.name = result.Name
+	proxy.LogChecker = logChecker(t, clientset).Namespace(namespace).PodName(proxy.name)
+	t.Logf("created pod %q.\n", proxy.name)
+	return proxy.pullInfo()
+}
+
+func (proxy *TinyProxy) pullInfo() error {
+	pod, err := proxy.client.Get(context.Background(), proxy.name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("pod %s does not exist: %e", proxy.name, err)
+	}
+	proxy.pod = pod
+	proxy.status = string(pod.Status.Phase)
+	proxy.ready = proxy.status == "Running"
+	if !proxy.ready {
+		return nil
+	}
+	IP := pod.Status.PodIPs[0].IP
+	PORT := pod.Spec.Containers[0].Ports[0].ContainerPort
+	proxy.adress = fmt.Sprintf("%s:%d", IP, PORT)
+	return nil
+}
+
+func (proxy *TinyProxy) waitUntilReady() {
+	wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
+		proxy.pullInfo()
+		proxy.t.Logf("%s status is %s", proxy.name, proxy.status)
+		return proxy.ready, nil
+	})
+}
+
+func (proxy *TinyProxy) delete() {
+	err := proxy.client.Delete(context.Background(), proxy.name, metav1.DeleteOptions{})
+	t := proxy.t
+	t.Logf("deleting pod %s...", proxy.name)
+	if err != nil {
+		t.Logf("failed to delete pod " + proxy.name)
+	}
+}

--- a/test/integration/proxy.go
+++ b/test/integration/proxy.go
@@ -23,7 +23,7 @@ type TinyProxy struct {
 	client     v12.PodInterface
 	IP         string
 	PORT       string
-	adress     string
+	address    string
 	status     string
 	ready      bool
 	LogChecker *LogCheck
@@ -67,7 +67,7 @@ func (proxy *TinyProxy) pullInfo() error {
 	}
 	IP := pod.Status.PodIPs[0].IP
 	PORT := pod.Spec.Containers[0].Ports[0].ContainerPort
-	proxy.adress = fmt.Sprintf("%s:%d", IP, PORT)
+	proxy.address = fmt.Sprintf("%s:%d", IP, PORT)
 	return nil
 }
 

--- a/test/integration/proxy.go
+++ b/test/integration/proxy.go
@@ -51,7 +51,12 @@ func (proxy *TinyProxy) create(t *testing.T, clientset *kubernetes.Clientset) er
 	proxy.name = result.Name
 	proxy.LogChecker = logChecker(t, clientset).Namespace(namespace).PodName(proxy.name)
 	t.Logf("created pod %q.\n", proxy.name)
-	return proxy.pullInfo()
+	err = proxy.pullInfo()
+	if err != nil {
+		return err
+	}
+	proxy.waitUntilReady()
+	return nil
 }
 
 func (proxy *TinyProxy) pullInfo() error {

--- a/test/integration/resource_samples/csr.yaml
+++ b/test/integration/resource_samples/csr.yaml
@@ -2,6 +2,7 @@ apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: service.default
+  namespace: openshift-config
 spec:
   signerName: www.example.com/example
   groups:

--- a/test/integration/resources_situational/tiny.yaml
+++ b/test/integration/resources_situational/tiny.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: tinyproxy-
+  labels:
+    name: tiny
+spec:
+  containers:
+    - name: tinyproxy
+      image: docker.io/vimagick/tinyproxy
+      ports:
+        - containerPort: 8888
+          name: https
+          protocol: TCP


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1820595
added TestProxyOverride - it runs for kinda long time ~10 mins
:beetle: [WIP, reset function doesn't always work properly] updated forceUpdateSecret to return "reset" function, added deleteSecret.. refactored some tests accordingly 
fixes bug with logChecker - logChecker did not fail when "failFast" was set, it just set .Err to the error


needs https://github.com/openshift/insights-operator/pull/165 merged first (OK)

forking the used tinyproxy container might be better option? 