### PR TITLE
Bug 1884221: IO becomes unhealthy due to a file change

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
-	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	networkv1client "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
@@ -191,5 +191,5 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 	go uploader.Run(ctx)
 
 	<-ctx.Done()
-	return fmt.Errorf("stopped")
+	return nil
 }

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -190,6 +190,8 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 	// know any previous last reported time
 	go uploader.Run(ctx)
 
+	klog.Warning("stopped")
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apixv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apixv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,8 +70,8 @@ const (
 )
 
 var (
-	openshiftSerializer = openshiftscheme.Codecs.LegacyCodec(configv1.SchemeGroupVersion)
-	kubeSerializer      = kubescheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion)
+	openshiftSerializer     = openshiftscheme.Codecs.LegacyCodec(configv1.SchemeGroupVersion)
+	kubeSerializer          = kubescheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion)
 	policyV1Beta1Serializer = kubescheme.Codecs.LegacyCodec(policyv1beta1.SchemeGroupVersion)
 	// maxEventTimeInterval represents the "only keep events that are maximum 1h old"
 	// TODO: make this dynamic like the reporting window based on configured interval
@@ -169,7 +169,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 // See: docs/insights-archive-sample/config/pdbs
 func GatherPodDisruptionBudgets(i *Gatherer) func() ([]record.Record, []error) {
 	return func() ([]record.Record, []error) {
-		pdbs, err := i.policyClient.PodDisruptionBudgets("").List(i.ctx, metav1.ListOptions{Limit: gatherPodDisruptionBudgetLimit,})
+		pdbs, err := i.policyClient.PodDisruptionBudgets("").List(i.ctx, metav1.ListOptions{Limit: gatherPodDisruptionBudgetLimit})
 		if err != nil {
 			return nil, []error{err}
 		}


### PR DESCRIPTION
This patch should avoid that the operator ends up with an unhealthy status due to a possible file change.