### PR TITLE
Gather ServiceAccounts stats from cluster namespaces

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -2,7 +2,7 @@ kind: GenericOperatorConfig
 apiVersion: operator.openshift.io/v1alpha1
 leaderElection:
   disable: true
-interval: "30s"
+interval: "60s"
 storagePath: /tmp/insights-operator
 endpoint: http://[::1]:8081
 #impersonate: system:serviceaccount:openshift-insights:gather

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -248,3 +248,17 @@ Response see https://docs.okd.io/latest/rest_api/policy_apis/poddisruptionbudget
 
 Location in archive: config/pdbs/
 See: docs/insights-archive-sample/config/pdbs
+
+
+## ServiceAccounts
+
+collects ServiceAccount stats
+from kubernetes default and namespaces starting with openshift.
+
+The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/serviceaccount.go#L83
+Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#serviceaccount-v1-core
+
+Location of serviceaccounts in archive: config/serviceaccounts
+See: docs/insights-archive-sample/config/serviceaccounts
+
+

--- a/docs/insights-archive-sample/config/serviceaccounts.json
+++ b/docs/insights-archive-sample/config/serviceaccounts.json
@@ -1,0 +1,175 @@
+{
+    "serviceAccounts": {
+        "TOTAL_COUNT": 211,
+        "namespaces": {
+            "default": {
+                "name": "local-storage-operator",
+                "secrets": 2
+            },
+            "kube-public": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "kube-system": {
+                "name": "statefulset-controller",
+                "secrets": 2
+            },
+            "openshift": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-apiserver": {
+                "name": "openshift-apiserver-sa",
+                "secrets": 2
+            },
+            "openshift-apiserver-operator": {
+                "name": "openshift-apiserver-operator",
+                "secrets": 2
+            },
+            "openshift-authentication": {
+                "name": "oauth-openshift",
+                "secrets": 2
+            },
+            "openshift-authentication-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-cloud-credential-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-cluster-node-tuning-operator": {
+                "name": "tuned",
+                "secrets": 2
+            },
+            "openshift-cluster-samples-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-cluster-storage-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-config": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-config-managed": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-console": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-console-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-controller-manager": {
+                "name": "openshift-controller-manager-sa",
+                "secrets": 2
+            },
+            "openshift-controller-manager-operator": {
+                "name": "openshift-controller-manager-operator",
+                "secrets": 2
+            },
+            "openshift-dns": {
+                "name": "dns",
+                "secrets": 2
+            },
+            "openshift-dns-operator": {
+                "name": "dns-operator",
+                "secrets": 2
+            },
+            "openshift-image-registry": {
+                "name": "registry",
+                "secrets": 2
+            },
+            "openshift-ingress": {
+                "name": "router",
+                "secrets": 2
+            },
+            "openshift-ingress-operator": {
+                "name": "ingress-operator",
+                "secrets": 2
+            },
+            "openshift-insights": {
+                "name": "operator",
+                "secrets": 2
+            },
+            "openshift-kube-apiserver": {
+                "name": "installer-sa",
+                "secrets": 2
+            },
+            "openshift-kube-apiserver-operator": {
+                "name": "kube-apiserver-operator",
+                "secrets": 2
+            },
+            "openshift-kube-controller-manager": {
+                "name": "kube-controller-manager-sa",
+                "secrets": 2
+            },
+            "openshift-kube-controller-manager-operator": {
+                "name": "kube-controller-manager-operator",
+                "secrets": 2
+            },
+            "openshift-kube-scheduler": {
+                "name": "openshift-kube-scheduler-sa",
+                "secrets": 2
+            },
+            "openshift-kube-scheduler-operator": {
+                "name": "openshift-kube-scheduler-operator",
+                "secrets": 2
+            },
+            "openshift-machine-api": {
+                "name": "machine-api-operator",
+                "secrets": 2
+            },
+            "openshift-machine-config-operator": {
+                "name": "node-bootstrapper",
+                "secrets": 2
+            },
+            "openshift-marketplace": {
+                "name": "marketplace-operator",
+                "secrets": 2
+            },
+            "openshift-monitoring": {
+                "name": "thanos-querier",
+                "secrets": 2
+            },
+            "openshift-multus": {
+                "name": "multus",
+                "secrets": 2
+            },
+            "openshift-network-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-operator-lifecycle-manager": {
+                "name": "olm-operator-serviceaccount",
+                "secrets": 2
+            },
+            "openshift-sdn": {
+                "name": "sdn-controller",
+                "secrets": 2
+            },
+            "openshift-service-ca": {
+                "name": "service-serving-cert-signer-sa",
+                "secrets": 2
+            },
+            "openshift-service-ca-operator": {
+                "name": "service-ca-operator",
+                "secrets": 2
+            },
+            "openshift-service-catalog-apiserver-operator": {
+                "name": "openshift-service-catalog-apiserver-operator",
+                "secrets": 2
+            },
+            "openshift-service-catalog-controller-manager-operator": {
+                "name": "openshift-service-catalog-controller-manager-operator",
+                "secrets": 2
+            }
+        }
+    }
+}

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
-	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	networkv1client "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
@@ -40,6 +40,7 @@ type Support struct {
 	config.Controller
 }
 
+// LoadConfig unmarshalls config from obj and loads it to this Support struct
 func (s *Support) LoadConfig(obj map[string]interface{}) error {
 	var cfg config.Serialized
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, &cfg); err != nil {

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apixv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apixv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -67,11 +67,15 @@ const (
 	// csrGatherLimit is the maximum number of crs that
 	// will be listed in a single request to reduce memory usage.
 	csrGatherLimit = 5000
+
+	// Maximal total number of service accounts
+	maxServiceAccountsLimit          = 1000
+	maxServiceAccountNamespacesLimit = 1000
 )
 
 var (
-	openshiftSerializer = openshiftscheme.Codecs.LegacyCodec(configv1.SchemeGroupVersion)
-	kubeSerializer      = kubescheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion)
+	openshiftSerializer     = openshiftscheme.Codecs.LegacyCodec(configv1.SchemeGroupVersion)
+	kubeSerializer          = kubescheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion)
 	policyV1Beta1Serializer = kubescheme.Codecs.LegacyCodec(policyv1beta1.SchemeGroupVersion)
 	// maxEventTimeInterval represents the "only keep events that are maximum 1h old"
 	// TODO: make this dynamic like the reporting window based on configured interval
@@ -89,6 +93,8 @@ var (
 
 	// lineSep is the line separator used by the alerts metric
 	lineSep = []byte{'\n'}
+
+	defaultNamespaces = []string{"default", "kube-system", "kube-public"}
 )
 
 func init() {
@@ -157,6 +163,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherCRD(i),
 		GatherHostSubnet(i),
 		GatherMachineSet(i),
+		GatherServiceAccounts(i),
 	)
 }
 
@@ -169,7 +176,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 // See: docs/insights-archive-sample/config/pdbs
 func GatherPodDisruptionBudgets(i *Gatherer) func() ([]record.Record, []error) {
 	return func() ([]record.Record, []error) {
-		pdbs, err := i.policyClient.PodDisruptionBudgets("").List(i.ctx, metav1.ListOptions{Limit: gatherPodDisruptionBudgetLimit,})
+		pdbs, err := i.policyClient.PodDisruptionBudgets("").List(i.ctx, metav1.ListOptions{Limit: gatherPodDisruptionBudgetLimit})
 		if err != nil {
 			return nil, []error{err}
 		}
@@ -843,6 +850,60 @@ func (i *Gatherer) gatherNamespaceEvents(namespace string) ([]record.Record, []e
 	return []record.Record{{Name: fmt.Sprintf("events/%s", namespace), Item: EventAnonymizer{&compactedEvents}}}, nil
 }
 
+// GatherServiceAccounts collects ServiceAccount stats
+// from kubernetes default and namespaces starting with openshift.
+//
+// The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/serviceaccount.go#L83
+// Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#serviceaccount-v1-core
+//
+// Location of serviceaccounts in archive: config/serviceaccounts
+// See: docs/insights-archive-sample/config/serviceaccounts
+func GatherServiceAccounts(i *Gatherer) func() ([]record.Record, []error) {
+	return func() ([]record.Record, []error) {
+		config, err := i.coreClient.Namespaces().List(i.ctx, metav1.ListOptions{Limit: maxServiceAccountNamespacesLimit})
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, []error{err}
+		}
+		totalServiceAccounts := 0
+		serviceAccounts := []corev1.ServiceAccount{}
+		records := []record.Record{}
+		namespaces := defaultNamespaces
+		namespaceCollected := sets.NewString()
+		// collect from all openshift* namespaces + kubernetes defaults
+		for _, item := range config.Items {
+			if strings.HasPrefix(item.Name, "openshift") {
+				namespaces = append(namespaces, item.Name)
+			}
+		}
+		for _, namespace := range namespaces {
+			// fetching service accounts from namespace
+			if namespaceCollected.Has(namespace) {
+				continue
+			}
+			svca, err := i.coreClient.ServiceAccounts(namespace).List(i.ctx, metav1.ListOptions{Limit: maxServiceAccountsLimit})
+			if err != nil {
+				klog.V(2).Infof("Unable to read ServiceAccounts in namespace %s error %s", namespace, err)
+				continue
+			}
+
+			totalServiceAccounts += len(svca.Items)
+			for _, j := range svca.Items {
+				if len(serviceAccounts) > maxServiceAccountsLimit {
+					break
+				}
+				serviceAccounts = append(serviceAccounts, j)
+			}
+			namespaceCollected.Insert(namespace)
+		}
+
+		records = append(records, record.Record{Name: fmt.Sprintf("config/serviceaccounts"), Item: ServiceAccountsMarshaller{serviceAccounts, totalServiceAccounts}})
+		return records, nil
+	}
+}
+
 // RawByte is skipping Marshalling from byte slice
 type RawByte []byte
 
@@ -1432,4 +1493,39 @@ func countLines(r io.Reader) (int, error) {
 			return lineCount, err
 		}
 	}
+}
+
+// ServiceAccountsMarshaller implements serialization of Service Accounts
+type ServiceAccountsMarshaller struct {
+	sa                   []corev1.ServiceAccount
+	totalServiceAccounts int
+}
+
+// Marshal implements serialization of ServiceAccount
+func (a ServiceAccountsMarshaller) Marshal(_ context.Context) ([]byte, error) {
+	// Creates map for marshal
+	sr := map[string]interface{}{}
+	st := map[string]interface{}{}
+	st["TOTAL_COUNT"] = a.totalServiceAccounts
+	sr["serviceAccounts"] = st
+	nss := map[string]interface{}{}
+	st["namespaces"] = nss
+	for _, sa := range a.sa {
+		var ns map[string]interface{}
+		var ok bool
+		if _, ok = nss[sa.Namespace]; !ok {
+			ns = map[string]interface{}{}
+			nss[sa.Namespace] = ns
+		} else {
+			ns = nss[sa.Namespace].(map[string]interface{})
+		}
+		ns["name"] = sa.Name
+		ns["secrets"] = len(sa.Secrets)
+	}
+	return json.Marshal(sr)
+}
+
+// GetExtension returns extension for anonymized openshift objects
+func (a ServiceAccountsMarshaller) GetExtension() string {
+	return "json"
 }

--- a/pkg/gather/clusterconfig/clusterconfig_test.go
+++ b/pkg/gather/clusterconfig/clusterconfig_test.go
@@ -12,16 +12,16 @@ import (
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	networkv1 "github.com/openshift/api/network/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apixv1beta1clientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog"
 
@@ -177,18 +177,18 @@ func TestGatherClusterPruner(t *testing.T) {
 	}
 }
 
-func TestGatherPodDisruptionBudgets(t *testing.T){
+func TestGatherPodDisruptionBudgets(t *testing.T) {
 	coreClient := kubefake.NewSimpleClientset()
 
 	fakeNamespace := "fake-namespace"
 
 	// name -> MinAvailabel
-	fakePDBs := map[string]string {
-		"pdb-four": "4",
+	fakePDBs := map[string]string{
+		"pdb-four":  "4",
 		"pdb-eight": "8",
-		"pdb-ten": "10",
+		"pdb-ten":   "10",
 	}
-	for name, minAvailable := range fakePDBs{
+	for name, minAvailable := range fakePDBs {
 		_, err := coreClient.PolicyV1beta1().
 			PodDisruptionBudgets(fakeNamespace).
 			Create(context.Background(), &policyv1beta1.PodDisruptionBudget{
@@ -222,7 +222,7 @@ func TestGatherPodDisruptionBudgets(t *testing.T){
 		}
 		name := pdba.PodDisruptionBudget.ObjectMeta.Name
 		minAvailable := pdba.PodDisruptionBudget.Spec.MinAvailable.StrVal
-		if pdba.PodDisruptionBudget.Spec.MinAvailable.StrVal !=  fakePDBs[name] {
+		if pdba.PodDisruptionBudget.Spec.MinAvailable.StrVal != fakePDBs[name] {
 			t.Fatalf("pdb item has mismatched MinAvailable value, %q != %q", fakePDBs[name], minAvailable)
 		}
 	}
@@ -626,6 +626,75 @@ metadata:
 	}
 	if records[0].Name != "machinesets/test-worker" {
 		t.Fatalf("unexpected machineset name %s", records[0].Name)
+	}
+}
+
+func TestGatherServiceAccounts(t *testing.T) {
+	tests := []struct {
+		name string
+		data []*corev1.ServiceAccount
+		exp  string
+	}{
+		{
+			name: "one account",
+			data: []*corev1.ServiceAccount{&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "local-storage-operator",
+					Namespace: "default",
+				},
+				Secrets: []corev1.ObjectReference{corev1.ObjectReference{}},
+			}},
+			exp: `{"serviceAccounts":{"TOTAL_COUNT":1,"namespaces":{"default":{"name":"local-storage-operator","secrets":1}}}}`,
+		},
+		{
+			name: "multiple accounts",
+			data: []*corev1.ServiceAccount{&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployer",
+					Namespace: "openshift",
+				},
+				Secrets: []corev1.ObjectReference{corev1.ObjectReference{}},
+			},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-apiserver-sa",
+						Namespace: "openshift-apiserver",
+					},
+					Secrets: []corev1.ObjectReference{corev1.ObjectReference{}},
+				}},
+			exp: `{"serviceAccounts":{"TOTAL_COUNT":2,"namespaces":{"openshift":{"name":"deployer","secrets":1},"openshift-apiserver":{"name":"openshift-apiserver-sa","secrets":1}}}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			coreClient := kubefake.NewSimpleClientset()
+			for _, d := range test.data {
+				_, err := coreClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: d.Namespace}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("unable to create fake ns %s", err)
+				}
+				_, err = coreClient.CoreV1().ServiceAccounts(d.Namespace).
+					Create(context.Background(), d, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("unable to create fake service account %s", err)
+				}
+			}
+			gatherer := &Gatherer{coreClient: coreClient.CoreV1()}
+			sa, errs := GatherServiceAccounts(gatherer)()
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %#v", errs)
+				return
+			}
+			bts, err := sa[0].Item.Marshal(context.Background())
+			if err != nil {
+				t.Fatalf("error marshalling %s", err)
+			}
+			s := string(bts)
+			if test.exp != s {
+				t.Fatalf("serviceaccount test failed. expected: %s got: %s", test.exp, s)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The change is collecting numbers of service accounts from kubernetes default namespaces and openshift built-in namespaces (openshift*).
It would be used to detect that a particular SA exists in ns, specifically to target https://access.redhat.com/solutions/5221881 and find lib-bucket-provisioner from NS openshift-storage