### PR TITLE
[release 4.4] Bug 1885516: Fixes 'make build'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	go build -ldflags "-X github.com/openshift/insights-operator/vendor/k8s.io/client-go/pkg/version.gitCommit=$$(git rev-parse HEAD) -X github.com/openshift/insights-operator/vendor/k8s.io/client-go/pkg/version.gitVersion=v1.0.0+$$(git rev-parse --short=7 HEAD)" -o bin/insights-operator ./cmd/insights-operator
+	GO111MODULE=on go build -mod=vendor -ldflags "-X k8s.io/client-go/pkg/version.gitCommit=$$(git rev-parse HEAD) -X k8s.io/client-go/pkg/version.gitVersion=v1.0.0+$$(git rev-parse --short=7 HEAD)" -o bin/insights-operator ./cmd/insights-operator
 .PHONY: build
 
 test-unit:


### PR DESCRIPTION
The paths in the `-ldflags` part of build script were incorrect causing the client-go `version.gitCommit` and `version.gitVersion` remained on the default value.