### PR TITLE
Bug 1887778: Adds ContainerRuntimeConfig gatherer

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -272,3 +272,13 @@ Location of serviceaccounts in archive: config/serviceaccounts
 See: docs/insights-archive-sample/config/serviceaccounts
 
 
+## ContainerRuntimeConfig
+
+collects ContainerRuntimeConfig information
+
+The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L402
+Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
+
+Location in archive: config/containerruntimeconfigs/
+See: docs/insights-archive-sample/config/containerruntimeconfigs
+

--- a/docs/insights-archive-sample/config/containerruntimeconfigs/set-log-and-pid.json
+++ b/docs/insights-archive-sample/config/containerruntimeconfigs/set-log-and-pid.json
@@ -1,0 +1,80 @@
+{
+    "apiVersion": "machineconfiguration.openshift.io/v1",
+    "kind": "ContainerRuntimeConfig",
+    "metadata": {
+        "creationTimestamp": "2020-10-13T10:24:51Z",
+        "generation": 1,
+        "managedFields": [
+            {
+                "apiVersion": "machineconfiguration.openshift.io/v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:spec": {
+                        ".": {},
+                        "f:containerRuntimeConfig": {
+                            ".": {},
+                            "f:logLevel": {},
+                            "f:pidsLimit": {}
+                        },
+                        "f:machineConfigPoolSelector": {
+                            ".": {},
+                            "f:matchLabels": {
+                                ".": {},
+                                "f:debug-crio": {}
+                            }
+                        }
+                    }
+                },
+                "manager": "kubectl-create",
+                "operation": "Update",
+                "time": "2020-10-13T10:24:51Z"
+            },
+            {
+                "apiVersion": "machineconfiguration.openshift.io/v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:spec": {
+                        "f:containerRuntimeConfig": {
+                            "f:logSizeMax": {},
+                            "f:overlaySize": {}
+                        }
+                    },
+                    "f:status": {
+                        ".": {},
+                        "f:conditions": {},
+                        "f:observedGeneration": {}
+                    }
+                },
+                "manager": "machine-config-controller",
+                "operation": "Update",
+                "time": "2020-10-13T10:25:12Z"
+            }
+        ],
+        "name": "set-log-and-pid",
+        "resourceVersion": "45056",
+        "selfLink": "/apis/machineconfiguration.openshift.io/v1/containerruntimeconfigs/set-log-and-pid",
+        "uid": "949e59e4-8b90-42e1-8467-6369aa1ea932"
+    },
+    "spec": {
+        "containerRuntimeConfig": {
+            "logLevel": "debug",
+            "pidsLimit": 2048
+        },
+        "machineConfigPoolSelector": {
+            "matchLabels": {
+                "debug-crio": "config-log-and-pid"
+            }
+        }
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastTransitionTime": "2020-10-13T10:25:11Z",
+                "message": "Error: could not find any MachineConfigPool set for ContainerRuntimeConfig set-log-and-pid",
+                "status": "False",
+                "type": "Failure"
+            }
+        ],
+        "observedGeneration": 1
+    }
+}

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -165,6 +165,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherMachineSet(i),
 		GatherServiceAccounts(i),
 		GatherMachineConfigPool(i),
+		GatherContainerRuntimeConfig(i),
 	)
 }
 
@@ -867,6 +868,34 @@ func GatherMachineConfigPool(i *Gatherer) func() ([]record.Record, []error) {
 		return records, nil
 	}
 }
+
+// GatherContainerRuntimeConfig collects ContainerRuntimeConfig  information
+//
+// The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L402
+// Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
+//
+// Location in archive: config/containerruntimeconfigs/
+func GatherContainerRuntimeConfig(i *Gatherer) func() ([]record.Record, []error) {
+	return func() ([]record.Record, []error) {
+		crc := schema.GroupVersionResource{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "containerruntimeconfigs"}
+		containerRCs, err := i.dynamicClient.Resource(crc).List(i.ctx, metav1.ListOptions{})
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, []error{err}
+		}
+		records := []record.Record{}
+		for _, i := range containerRCs.Items {
+			records = append(records, record.Record{
+				Name: fmt.Sprintf("config/containerruntimeconfigs/%s", i.GetName()),
+				Item: record.JSONMarshaller{Object: i.Object},
+			})
+		}
+		return records, nil
+	}
+}
+
 
 func (i *Gatherer) gatherNamespaceEvents(namespace string) ([]record.Record, []error) {
 	// do not accidentally collect events for non-openshift namespace

--- a/pkg/gather/clusterconfig/clusterconfig_test.go
+++ b/pkg/gather/clusterconfig/clusterconfig_test.go
@@ -665,6 +665,42 @@ metadata:
 	}
 }
 
+func TestContainerRuntimeConfig(t *testing.T) {
+	var machineconfigpoolYAML = `
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+    name: test-ContainerRC
+`
+	gvr := schema.GroupVersionResource{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "containerruntimeconfigs"}
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+
+	testContainerRuntimeConfigs := &unstructured.Unstructured{}
+
+	_, _, err := decUnstructured.Decode([]byte(machineconfigpoolYAML), nil, testContainerRuntimeConfigs)
+	if err != nil {
+		t.Fatal("unable to decode machineconfigpool ", err)
+	}
+	_, err = client.Resource(gvr).Create(context.Background(), testContainerRuntimeConfigs, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("unable to create fake machineconfigpool ", err)
+	}
+
+	gatherer := &Gatherer{dynamicClient: client}
+	records, errs := GatherContainerRuntimeConfig(gatherer)()
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %#v", errs)
+		return
+	}
+	if len(records) != 1 {
+		t.Fatalf("unexpected number or records %d", len(records))
+	}
+	if records[0].Name != "config/containerruntimeconfigs/test-ContainerRC" {
+		t.Fatalf("unexpected containerruntimeconfig name %s", records[0].Name)
+	}
+}
+
 
 func TestGatherServiceAccounts(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
My cluster didn't have one by default so here is an example you can use to verify:
```yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: ContainerRuntimeConfig
metadata:
 name: set-log-and-pid
spec:
 machineConfigPoolSelector:
   matchLabels:
     debug-crio: config-log-and-pid
 containerRuntimeConfig:
   pidsLimit: 2048
   logLevel: debug
```