### PR TITLE
Gather clusteroperator resources

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -144,6 +144,15 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+    - operator.openshift.io
+  resources:
+    - "*"
+  verbs:
+    - get
+    - list
+    - watch 
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -11,6 +11,7 @@ import (
 	apixv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -144,6 +145,11 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 	if err != nil {
 		return err
 	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(gatherKubeConfig)
+	if err != nil {
+		return err
+	}
 	// ensure the insight snapshot directory exists
 	if _, err := os.Stat(s.StoragePath); err != nil && os.IsNotExist(err) {
 		if err := os.MkdirAll(s.StoragePath, 0777); err != nil {
@@ -166,7 +172,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 
 	// the gatherers periodically check the state of the cluster and report any
 	// config to the recorder
-	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1(), gatherKubeClient.CertificatesV1beta1(), metricsClient, registryClient.ImageregistryV1(), crdClient, gatherNetworkClient, dynamicClient, gatherPolicyClient, appsClient)
+	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1(), gatherKubeClient.CertificatesV1beta1(), metricsClient, registryClient.ImageregistryV1(), crdClient, gatherNetworkClient, dynamicClient, gatherPolicyClient, appsClient, discoveryClient)
 	periodic := periodic.New(configObserver, recorder, map[string]gather.Interface{
 		"config": configPeriodic,
 	})

--- a/pkg/gather/clusterconfig/clusterconfig_examples.go
+++ b/pkg/gather/clusterconfig/clusterconfig_examples.go
@@ -55,8 +55,7 @@ func ExampleClusterOperators() (string, error) {
 				}}}
 			return true, sv, nil
 		})
-
-	g := &Gatherer{client: kube.ConfigV1()}
+	g := &Gatherer{client: kube.ConfigV1(), discoveryClient: kube.Discovery()}
 	d, errs := GatherClusterOperators(g)()
 	if len(errs) > 0 {
 		return "", errs[0]
@@ -78,7 +77,6 @@ func ExampleNodes() (string, error) {
 				}}}
 			return true, sv, nil
 		})
-
 	g := &Gatherer{coreClient: kube.CoreV1()}
 	d, errs := GatherNodes(g)()
 	if len(errs) > 0 {

--- a/pkg/gather/clusterconfig/clusterconfig_test.go
+++ b/pkg/gather/clusterconfig/clusterconfig_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	networkv1 "github.com/openshift/api/network/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,6 +28,7 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog"
 
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	imageregistryfake "github.com/openshift/client-go/imageregistry/clientset/versioned/fake"
 	networkfake "github.com/openshift/client-go/network/clientset/versioned/fake"
 	"github.com/openshift/insights-operator/pkg/record"
@@ -907,6 +909,36 @@ func TestGatherStatefulSet(t *testing.T) {
 	}
 	if gatheredStatefulSet.Name != "test-statefulset" {
 		t.Fatalf("unexpected statefulset name %s", gatheredStatefulSet.Name)
+	}
+
+}
+
+func TestGatherClusterOperator(t *testing.T) {
+	testOperator := &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-clusteroperator",
+		},
+	}
+	configCS := configfake.NewSimpleClientset()
+	_, err := configCS.ConfigV1().ClusterOperators().Create(context.Background(), testOperator, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("unable to create fake clusteroperator", err)
+	}
+	gatherer := &Gatherer{ctx: context.Background(), client: configCS.ConfigV1(), discoveryClient: configCS.Discovery()}
+	records, errs := GatherClusterOperators(gatherer)()
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %#v", errs)
+		return
+	}
+
+	item, err := records[0].Item.Marshal(context.TODO())
+	var gatheredCO configv1.ClusterOperator
+	_, _, err = openshiftSerializer.Decode(item, nil, &gatheredCO)
+	if err != nil {
+		t.Fatalf("failed to decode object: %v", err)
+	}
+	if gatheredCO.Name != "test-clusteroperator" {
+		t.Fatalf("unexpected clusteroperator name %s", gatheredCO.Name)
 	}
 
 }


### PR DESCRIPTION
Gather info about clusteroperator resources. I added only basic test for `CluterOperator` (no related resource there) because it doesn't seem to be easy to use `discoveryClient.ServerPreferredResources()`. This cal requires to have some `APIGroups` available (see https://github.com/kubernetes/client-go/blob/master/discovery/discovery_client.go#L287)), which is not our case.

I would suggest to test this properly in integration tests.