### PR TITLE
Bug 1888601: Fixes policyClient and the corresponding config.

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -62,14 +62,6 @@ rules:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - list
-  - get
-  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -136,6 +128,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - get
+  - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -136,7 +136,14 @@ rules:
   - list
   - get
   - watch
-
+- apiGroups:
+    - machine.openshift.io
+  resources:
+    - machinesets
+  verbs:
+    - get
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -75,11 +75,6 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 	if err != nil {
 		return err
 	}
-	policyClient, err := policyclient.NewForConfig(controller.KubeConfig)
-	if err != nil {
-		return err
-	}
-
 	// these are gathering clients
 	gatherProtoKubeConfig := rest.CopyConfig(controller.ProtoKubeConfig)
 	if len(s.Impersonate) > 0 {
@@ -124,6 +119,11 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 		return err
 	}
 
+	gatherPolicyClient, err := policyclient.NewForConfig(gatherKubeConfig)
+	if err != nil {
+		return err
+	}
+
 	registryClient, err := imageregistryv1client.NewForConfig(gatherKubeConfig)
 	if err != nil {
 		return err
@@ -161,7 +161,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 
 	// the gatherers periodically check the state of the cluster and report any
 	// config to the recorder
-	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1(), gatherKubeClient.CertificatesV1beta1(), metricsClient, registryClient.ImageregistryV1(), crdClient, gatherNetworkClient, dynamicClient, policyClient)
+	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1(), gatherKubeClient.CertificatesV1beta1(), metricsClient, registryClient.ImageregistryV1(), crdClient, gatherNetworkClient, dynamicClient, gatherPolicyClient)
 	periodic := periodic.New(configObserver, recorder, map[string]gather.Interface{
 		"config": configPeriodic,
 	})


### PR DESCRIPTION
After this change, when you locally change your config/local.yaml, to some invalid account
impersonate: system:serviceaccount:openshift-insights:some-invalid-account
All the gatherers should return error and no archive should be created in /tmp in the end (withtout this, only pdb was gathered, because it used operator account)