### PR TITLE
[release 4.5] Bug 1888607: Fixes policyClient and the corresponding config.

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -136,6 +136,14 @@ rules:
   - list
   - get
   - watch
+- apiGroups:
+    - machine.openshift.io
+  resources:
+    - machinesets
+  verbs:
+    - get
+    - list
+    - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -62,14 +62,6 @@ rules:
   - namespaces
   verbs:
   - get
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - list
-  - get
-  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -136,6 +128,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - get
+  - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -106,6 +106,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 	if err != nil {
 		return err
 	}
+
 	gatherConfigClient, err := configv1client.NewForConfig(gatherKubeConfig)
 	if err != nil {
 		return err

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -72,12 +72,6 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 	if err != nil {
 		return err
 	}
-
-	policyClient, err := policyclient.NewForConfig(controller.KubeConfig)
-	if err != nil {
-		return err
-	}
-
 	// these are gathering clients
 	gatherProtoKubeConfig := rest.CopyConfig(controller.ProtoKubeConfig)
 	if len(s.Impersonate) > 0 {
@@ -122,6 +116,11 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 		return err
 	}
 
+	gatherPolicyClient, err := policyclient.NewForConfig(gatherKubeConfig)
+	if err != nil {
+		return err
+	}
+
 	registryClient, err := imageregistryv1client.NewForConfig(gatherKubeConfig)
 	if err != nil {
 		return err
@@ -154,7 +153,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 
 	// the gatherers periodically check the state of the cluster and report any
 	// config to the recorder
-	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1(), gatherKubeClient.CertificatesV1beta1(), metricsClient, registryClient.ImageregistryV1(), gatherNetworkClient, dynamicClient, policyClient)
+	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1(), gatherKubeClient.CertificatesV1beta1(), metricsClient, registryClient.ImageregistryV1(), gatherNetworkClient, dynamicClient, gatherPolicyClient)
 	periodic := periodic.New(configObserver, recorder, map[string]gather.Interface{
 		"config": configPeriodic,
 	})


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Backports (4.5) a fix for the permissions that caused some resources to be skipped during gathering.

How to verify:
After this change, when you locally change your config/local.yaml, to some invalid account
impersonate: system:serviceaccount:openshift-insights:some-invalid-account
All the gatherers should return error and no archive should be created in /tmp in the end (withtout this, only pdb was gathered, because it used operator account)

## Categories
<!-- Select the categories that your PR better fits on -->

- [x] Bugfix
- [ ] Enhancement
- [x] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- Not necessary

## Documentation
<!-- Are these changes reflected in documentation? -->

- Not necessary

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- Not necessary

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

No new data is gathered.

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-3270
https://bugzilla.redhat.com/show_bug.cgi?id=1888607