### PR TITLE
[release 4.4] Bug 1889318: Add the namespace to the gatherers reports to avoid conflicts

### DIFF
--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -157,8 +157,12 @@ func GatherPodDisruptionBudgets(i *Gatherer) func() ([]record.Record, []error) {
 		}
 		records := []record.Record{}
 		for _, pdb := range pdbs.Items {
+			recordName := fmt.Sprintf("config/pdbs/%s", pdb.GetName())
+			if pdb.GetNamespace() != "" {
+				recordName = fmt.Sprintf("config/pdbs/%s/%s", pdb.GetNamespace(), pdb.GetName())
+			}
 			records = append(records, record.Record{
-				Name: fmt.Sprintf("config/pdbs/%s", pdb.GetName()),
+				Name: recordName,
 				Item: PodDisruptionBudgetsAnonymizer{&pdb},
 			})
 		}
@@ -660,8 +664,12 @@ func GatherMachineSet(i *Gatherer) func() ([]record.Record, []error) {
 		}
 		records := []record.Record{}
 		for _, i := range machineSets.Items {
+			recordName := fmt.Sprintf("machinesets/%s", i.GetName())
+			if i.GetNamespace() != "" {
+				recordName = fmt.Sprintf("machinesets/%s/%s", i.GetNamespace(), i.GetName())
+			}
 			records = append(records, record.Record{
-				Name: fmt.Sprintf("machinesets/%s", i.GetName()),
+				Name: recordName,
 				Item: record.JSONMarshaller{Object: i.Object},
 			})
 		}


### PR DESCRIPTION
A backport (4.4) of a bug fix that has to do with problems with gathering data due to if we have more resources with the same name, but the resources are in different namespaces, IO collects only one of them.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- Not necessary

## Documentation
<!-- Are these changes reflected in documentation? -->

- Not necessary

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- Not necessary

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

No new data is collected

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-3303
https://bugzilla.redhat.com/show_bug.cgi?id=1889318