### PR TITLE
Add more verbosity to the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ test-unit:
 .PHONY: test-unit
 
 test-e2e:
-	go test ./test/integration -run ^\(TestIsIOHealthy\)$$ ^\(TestPullSecretExists\)$$ -timeout 1m
-	go test ./test/integration -timeout 13m $(TEST_OPTIONS)
+	go test ./test/integration -v -run ^\(TestIsIOHealthy\)$$ ^\(TestPullSecretExists\)$$ -timeout 1m
+	go test ./test/integration -v -timeout 13m $(TEST_OPTIONS)
 .PHONY: test-e2e
 
 vet:


### PR DESCRIPTION
At the moment test logs are not so informative:

```
secret/support created
go test ./test/integration -run ^\(TestIsIOHealthy\)$ ^\(TestPullSecretExists\)$ -timeout 1m
ok  	github.com/openshift/insights-operator/test/integration	0.754s
go test ./test/integration -timeout 13m 
ok  	github.com/openshift/insights-operator/test/integration	676.211s
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-insights-operator-master-insights-operator-e2e-tests-periodic/1320515607073918976/artifacts/insights-operator-e2e-tests-periodic/container-logs/test.log

It would be nice to have more details.