### PR TITLE
[release 4.6] Bug 1891544: Adds ContainerRuntimeConfig gatherer

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -270,3 +270,13 @@ Response see https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-
 
 Location in archive: config/machineconfigpools/
 See: docs/insights-archive-sample/config/machineconfigpools/
+## ContainerRuntimeConfig
+
+collects ContainerRuntimeConfig information
+
+The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L402
+Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
+
+Location in archive: config/containerruntimeconfigs/
+See: docs/insights-archive-sample/config/containerruntimeconfigs
+

--- a/docs/insights-archive-sample/config/containerruntimeconfigs/set-log-and-pid.json
+++ b/docs/insights-archive-sample/config/containerruntimeconfigs/set-log-and-pid.json
@@ -1,0 +1,80 @@
+{
+    "apiVersion": "machineconfiguration.openshift.io/v1",
+    "kind": "ContainerRuntimeConfig",
+    "metadata": {
+        "creationTimestamp": "2020-10-13T10:24:51Z",
+        "generation": 1,
+        "managedFields": [
+            {
+                "apiVersion": "machineconfiguration.openshift.io/v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:spec": {
+                        ".": {},
+                        "f:containerRuntimeConfig": {
+                            ".": {},
+                            "f:logLevel": {},
+                            "f:pidsLimit": {}
+                        },
+                        "f:machineConfigPoolSelector": {
+                            ".": {},
+                            "f:matchLabels": {
+                                ".": {},
+                                "f:debug-crio": {}
+                            }
+                        }
+                    }
+                },
+                "manager": "kubectl-create",
+                "operation": "Update",
+                "time": "2020-10-13T10:24:51Z"
+            },
+            {
+                "apiVersion": "machineconfiguration.openshift.io/v1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:spec": {
+                        "f:containerRuntimeConfig": {
+                            "f:logSizeMax": {},
+                            "f:overlaySize": {}
+                        }
+                    },
+                    "f:status": {
+                        ".": {},
+                        "f:conditions": {},
+                        "f:observedGeneration": {}
+                    }
+                },
+                "manager": "machine-config-controller",
+                "operation": "Update",
+                "time": "2020-10-13T10:25:12Z"
+            }
+        ],
+        "name": "set-log-and-pid",
+        "resourceVersion": "45056",
+        "selfLink": "/apis/machineconfiguration.openshift.io/v1/containerruntimeconfigs/set-log-and-pid",
+        "uid": "949e59e4-8b90-42e1-8467-6369aa1ea932"
+    },
+    "spec": {
+        "containerRuntimeConfig": {
+            "logLevel": "debug",
+            "pidsLimit": 2048
+        },
+        "machineConfigPoolSelector": {
+            "matchLabels": {
+                "debug-crio": "config-log-and-pid"
+            }
+        }
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastTransitionTime": "2020-10-13T10:25:11Z",
+                "message": "Error: could not find any MachineConfigPool set for ContainerRuntimeConfig set-log-and-pid",
+                "status": "False",
+                "type": "Failure"
+            }
+        ],
+        "observedGeneration": 1
+    }
+}

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -177,6 +177,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherMachineSet(i),
 		GatherMachineConfigPool(i),
 		GatherInstallPlans(i),
+		GatherContainerRuntimeConfig(i),
 	)
 }
 
@@ -969,6 +970,32 @@ func GatherMachineConfigPool(i *Gatherer) func() ([]record.Record, []error) {
 		for _, i := range machineCPs.Items {
 			records = append(records, record.Record{
 				Name: fmt.Sprintf("config/machineconfigpools/%s", i.GetName()),
+				Item: record.JSONMarshaller{Object: i.Object},
+			})
+		}
+		return records, nil
+	}
+}
+// GatherContainerRuntimeConfig collects ContainerRuntimeConfig  information
+//
+// The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L402
+// Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
+//
+// Location in archive: config/containerruntimeconfigs/
+func GatherContainerRuntimeConfig(i *Gatherer) func() ([]record.Record, []error) {
+	return func() ([]record.Record, []error) {
+		crc := schema.GroupVersionResource{Group: "machineconfiguration.openshift.io", Version: "v1", Resource: "containerruntimeconfigs"}
+		containerRCs, err := i.dynamicClient.Resource(crc).List(i.ctx, metav1.ListOptions{})
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, []error{err}
+		}
+		records := []record.Record{}
+		for _, i := range containerRCs.Items {
+			records = append(records, record.Record{
+				Name: fmt.Sprintf("config/containerruntimeconfigs/%s", i.GetName()),
 				Item: record.JSONMarshaller{Object: i.Object},
 			})
 		}


### PR DESCRIPTION
A backport (4.6) of a new data enhancement for gathering of ContainerRuntimeConfigs.
My cluster didn't have one by default so here is an example you can use to verify:
```yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: ContainerRuntimeConfig
metadata:
 name: set-log-and-pid
spec:
 machineConfigPoolSelector:
   matchLabels:
     debug-crio: config-log-and-pid
 containerRuntimeConfig:
   pidsLimit: 2048
   logLevel: debug
```

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/containerruntimeconfigs/set-log-and-pid.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gather/clusterconfig/clusterconfig_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-3318
https://issues.redhat.com/browse/INSIGHTOCP-84
https://bugzilla.redhat.com/show_bug.cgi?id=1891544