### PR TITLE
[release-4.6] Bug 1893727: Gather StatefulSet configs from default & …

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -248,3 +248,15 @@ Response see https://docs.okd.io/latest/rest_api/policy_apis/poddisruptionbudget
 
 Location in archive: config/pdbs/
 See: docs/insights-archive-sample/config/pdbs
+
+
+## StatefulSets
+
+collects StatefulSet configs from default namespaces
+
+The Kubernetes API https://github.com/kubernetes/api/blob/master/apps/v1/types.go
+Response see https://docs.openshift.com/container-platform/4.5/rest_api/workloads_apis/statefulset-apps-v1.html#statefulset-apps-v1
+
+Location in archive: config/statefulsets/
+
+

--- a/docs/insights-archive-sample/config/statefulsets/openshift-monitoring/prometheus-k8s.json
+++ b/docs/insights-archive-sample/config/statefulsets/openshift-monitoring/prometheus-k8s.json
@@ -1,0 +1,1147 @@
+{
+    "kind": "StatefulSet",
+    "apiVersion": "apps/v1",
+    "metadata": {
+        "name": "prometheus-k8s",
+        "namespace": "openshift-monitoring",
+        "selfLink": "/apis/apps/v1/namespaces/openshift-monitoring/statefulsets/prometheus-k8s",
+        "uid": "3ac34af5-bfee-40f7-8163-4fc3ce32af2d",
+        "resourceVersion": "19422",
+        "generation": 1,
+        "creationTimestamp": "2020-10-05T12:42:49Z",
+        "labels": {
+            "prometheus": "k8s"
+        },
+        "annotations": {
+            "prometheus-operator-input-hash": "17455614549035312827"
+        },
+        "ownerReferences": [
+            {
+                "apiVersion": "monitoring.coreos.com/v1",
+                "kind": "Prometheus",
+                "name": "k8s",
+                "uid": "1bcb9c84-1613-4d33-8da5-92fe48f9e367",
+                "controller": true,
+                "blockOwnerDeletion": true
+            }
+        ],
+        "managedFields": [
+            {
+                "manager": "operator",
+                "operation": "Update",
+                "apiVersion": "apps/v1",
+                "time": "2020-10-05T12:42:50Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:prometheus-operator-input-hash": {}
+                        },
+                        "f:labels": {
+                            ".": {},
+                            "f:prometheus": {}
+                        },
+                        "f:ownerReferences": {
+                            ".": {},
+                            "k:{\"uid\":\"1bcb9c84-1613-4d33-8da5-92fe48f9e367\"}": {
+                                ".": {},
+                                "f:apiVersion": {},
+                                "f:blockOwnerDeletion": {},
+                                "f:controller": {},
+                                "f:kind": {},
+                                "f:name": {},
+                                "f:uid": {}
+                            }
+                        }
+                    },
+                    "f:spec": {
+                        "f:podManagementPolicy": {},
+                        "f:replicas": {},
+                        "f:revisionHistoryLimit": {},
+                        "f:selector": {
+                            "f:matchLabels": {
+                                ".": {},
+                                "f:app": {},
+                                "f:prometheus": {}
+                            }
+                        },
+                        "f:serviceName": {},
+                        "f:template": {
+                            "f:metadata": {
+                                "f:labels": {
+                                    ".": {},
+                                    "f:app": {},
+                                    "f:prometheus": {}
+                                }
+                            },
+                            "f:spec": {
+                                "f:affinity": {
+                                    ".": {},
+                                    "f:podAntiAffinity": {
+                                        ".": {},
+                                        "f:preferredDuringSchedulingIgnoredDuringExecution": {}
+                                    }
+                                },
+                                "f:containers": {
+                                    "k:{\"name\":\"kube-rbac-proxy\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":9092,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/etc/kube-rbac-proxy\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/tls/private\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"prom-label-proxy\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {}
+                                    },
+                                    "k:{\"name\":\"prometheus\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:livenessProbe": {
+                                            ".": {},
+                                            "f:exec": {
+                                                ".": {},
+                                                "f:command": {}
+                                            },
+                                            "f:failureThreshold": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:name": {},
+                                        "f:readinessProbe": {
+                                            ".": {},
+                                            "f:exec": {
+                                                ".": {},
+                                                "f:command": {}
+                                            },
+                                            "f:failureThreshold": {},
+                                            "f:periodSeconds": {},
+                                            "f:successThreshold": {},
+                                            "f:timeoutSeconds": {}
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/etc/pki/ca-trust/extracted/pem/\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/certs\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/config_out\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/configmaps/kubelet-serving-ca-bundle\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/configmaps/serving-certs-ca-bundle\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/rules/prometheus-k8s-rulefiles-0\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/secrets/kube-etcd-client-certs\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/secrets/kube-rbac-proxy\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/secrets/prometheus-k8s-htpasswd\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/secrets/prometheus-k8s-proxy\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/secrets/prometheus-k8s-tls\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/prometheus\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"prometheus-config-reloader\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:command": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"POD_NAME\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {
+                                                        ".": {},
+                                                        "f:apiVersion": {},
+                                                        "f:fieldPath": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/etc/prometheus/config\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/prometheus/config_out\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"prometheus-proxy\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"HTTPS_PROXY\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"HTTP_PROXY\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"name\":\"NO_PROXY\"}": {
+                                                ".": {},
+                                                "f:name": {}
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":9091,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/etc/pki/ca-trust/extracted/pem/\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {},
+                                                "f:readOnly": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/proxy/htpasswd\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/proxy/secrets\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/etc/tls/private\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"rules-configmap-reloader\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/etc/prometheus/rules/prometheus-k8s-rulefiles-0\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    },
+                                    "k:{\"name\":\"thanos-sidecar\"}": {
+                                        ".": {},
+                                        "f:args": {},
+                                        "f:env": {
+                                            ".": {},
+                                            "k:{\"name\":\"POD_IP\"}": {
+                                                ".": {},
+                                                "f:name": {},
+                                                "f:valueFrom": {
+                                                    ".": {},
+                                                    "f:fieldRef": {
+                                                        ".": {},
+                                                        "f:apiVersion": {},
+                                                        "f:fieldPath": {}
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "f:image": {},
+                                        "f:imagePullPolicy": {},
+                                        "f:name": {},
+                                        "f:ports": {
+                                            ".": {},
+                                            "k:{\"containerPort\":10901,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            },
+                                            "k:{\"containerPort\":10902,\"protocol\":\"TCP\"}": {
+                                                ".": {},
+                                                "f:containerPort": {},
+                                                "f:name": {},
+                                                "f:protocol": {}
+                                            }
+                                        },
+                                        "f:resources": {
+                                            ".": {},
+                                            "f:requests": {
+                                                ".": {},
+                                                "f:cpu": {},
+                                                "f:memory": {}
+                                            }
+                                        },
+                                        "f:terminationMessagePath": {},
+                                        "f:terminationMessagePolicy": {},
+                                        "f:volumeMounts": {
+                                            ".": {},
+                                            "k:{\"mountPath\":\"/etc/tls/grpc\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            },
+                                            "k:{\"mountPath\":\"/prometheus\"}": {
+                                                ".": {},
+                                                "f:mountPath": {},
+                                                "f:name": {}
+                                            }
+                                        }
+                                    }
+                                },
+                                "f:dnsPolicy": {},
+                                "f:nodeSelector": {
+                                    ".": {},
+                                    "f:kubernetes.io/os": {}
+                                },
+                                "f:priorityClassName": {},
+                                "f:restartPolicy": {},
+                                "f:schedulerName": {},
+                                "f:securityContext": {},
+                                "f:serviceAccount": {},
+                                "f:serviceAccountName": {},
+                                "f:terminationGracePeriodSeconds": {},
+                                "f:volumes": {
+                                    ".": {},
+                                    "k:{\"name\":\"config\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"config-out\"}": {
+                                        ".": {},
+                                        "f:emptyDir": {},
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"configmap-kubelet-serving-ca-bundle\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"configmap-serving-certs-ca-bundle\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"prometheus-k8s-db\"}": {
+                                        ".": {},
+                                        "f:emptyDir": {},
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"prometheus-k8s-rulefiles-0\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:name": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"prometheus-trusted-ca-bundle\"}": {
+                                        ".": {},
+                                        "f:configMap": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:items": {},
+                                            "f:name": {},
+                                            "f:optional": {}
+                                        },
+                                        "f:name": {}
+                                    },
+                                    "k:{\"name\":\"secret-grpc-tls\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"secret-kube-etcd-client-certs\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"secret-kube-rbac-proxy\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"secret-prometheus-k8s-htpasswd\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"secret-prometheus-k8s-proxy\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"secret-prometheus-k8s-tls\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    },
+                                    "k:{\"name\":\"tls-assets\"}": {
+                                        ".": {},
+                                        "f:name": {},
+                                        "f:secret": {
+                                            ".": {},
+                                            "f:defaultMode": {},
+                                            "f:secretName": {}
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "f:updateStrategy": {
+                            "f:type": {}
+                        }
+                    }
+                }
+            },
+            {
+                "manager": "kube-controller-manager",
+                "operation": "Update",
+                "apiVersion": "apps/v1",
+                "time": "2020-10-05T12:43:35Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:status": {
+                        "f:collisionCount": {},
+                        "f:currentReplicas": {},
+                        "f:currentRevision": {},
+                        "f:observedGeneration": {},
+                        "f:readyReplicas": {},
+                        "f:replicas": {},
+                        "f:updateRevision": {},
+                        "f:updatedReplicas": {}
+                    }
+                }
+            }
+        ]
+    },
+    "spec": {
+        "replicas": 2,
+        "selector": {
+            "matchLabels": {
+                "app": "prometheus",
+                "prometheus": "k8s"
+            }
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "prometheus",
+                    "prometheus": "k8s"
+                }
+            },
+            "spec": {
+                "volumes": [
+                    {
+                        "name": "config",
+                        "secret": {
+                            "secretName": "prometheus-k8s",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "tls-assets",
+                        "secret": {
+                            "secretName": "prometheus-k8s-tls-assets",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "config-out",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "prometheus-k8s-rulefiles-0",
+                        "configMap": {
+                            "name": "prometheus-k8s-rulefiles-0",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "secret-kube-etcd-client-certs",
+                        "secret": {
+                            "secretName": "kube-etcd-client-certs",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "secret-prometheus-k8s-tls",
+                        "secret": {
+                            "secretName": "prometheus-k8s-tls",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "secret-prometheus-k8s-proxy",
+                        "secret": {
+                            "secretName": "prometheus-k8s-proxy",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "secret-prometheus-k8s-htpasswd",
+                        "secret": {
+                            "secretName": "prometheus-k8s-htpasswd",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "secret-kube-rbac-proxy",
+                        "secret": {
+                            "secretName": "kube-rbac-proxy",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "configmap-serving-certs-ca-bundle",
+                        "configMap": {
+                            "name": "serving-certs-ca-bundle",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "configmap-kubelet-serving-ca-bundle",
+                        "configMap": {
+                            "name": "kubelet-serving-ca-bundle",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "prometheus-k8s-db",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "secret-grpc-tls",
+                        "secret": {
+                            "secretName": "prometheus-k8s-grpc-tls-6atp7crqav4v2",
+                            "defaultMode": 420
+                        }
+                    },
+                    {
+                        "name": "prometheus-trusted-ca-bundle",
+                        "configMap": {
+                            "name": "prometheus-trusted-ca-bundle-d34s91lhv300e",
+                            "items": [
+                                {
+                                    "key": "ca-bundle.crt",
+                                    "path": "tls-ca-bundle.pem"
+                                }
+                            ],
+                            "defaultMode": 420,
+                            "optional": true
+                        }
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "prometheus",
+                        "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:611a9e34a148ab5aea26cb23b6a502c1b55c00881e94d081abf017837feaedc7",
+                        "args": [
+                            "--web.console.templates=/etc/prometheus/consoles",
+                            "--web.console.libraries=/etc/prometheus/console_libraries",
+                            "--config.file=/etc/prometheus/config_out/prometheus.env.yaml",
+                            "--storage.tsdb.path=/prometheus",
+                            "--storage.tsdb.retention.time=15d",
+                            "--web.enable-lifecycle",
+                            "--storage.tsdb.no-lockfile",
+                            "--web.external-url=https://prometheus-k8s-openshift-monitoring.apps.tremes.lab.upshift.rdu2.redhat.com/",
+                            "--web.route-prefix=/",
+                            "--web.listen-address=127.0.0.1:9090"
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "70m",
+                                "memory": "1Gi"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "prometheus-trusted-ca-bundle",
+                                "readOnly": true,
+                                "mountPath": "/etc/pki/ca-trust/extracted/pem/"
+                            },
+                            {
+                                "name": "config-out",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/config_out"
+                            },
+                            {
+                                "name": "tls-assets",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/certs"
+                            },
+                            {
+                                "name": "prometheus-k8s-db",
+                                "mountPath": "/prometheus"
+                            },
+                            {
+                                "name": "prometheus-k8s-rulefiles-0",
+                                "mountPath": "/etc/prometheus/rules/prometheus-k8s-rulefiles-0"
+                            },
+                            {
+                                "name": "secret-kube-etcd-client-certs",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/secrets/kube-etcd-client-certs"
+                            },
+                            {
+                                "name": "secret-prometheus-k8s-tls",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/secrets/prometheus-k8s-tls"
+                            },
+                            {
+                                "name": "secret-prometheus-k8s-proxy",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/secrets/prometheus-k8s-proxy"
+                            },
+                            {
+                                "name": "secret-prometheus-k8s-htpasswd",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/secrets/prometheus-k8s-htpasswd"
+                            },
+                            {
+                                "name": "secret-kube-rbac-proxy",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/secrets/kube-rbac-proxy"
+                            },
+                            {
+                                "name": "configmap-serving-certs-ca-bundle",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/configmaps/serving-certs-ca-bundle"
+                            },
+                            {
+                                "name": "configmap-kubelet-serving-ca-bundle",
+                                "readOnly": true,
+                                "mountPath": "/etc/prometheus/configmaps/kubelet-serving-ca-bundle"
+                            }
+                        ],
+                        "livenessProbe": {
+                            "exec": {
+                                "command": [
+                                    "sh",
+                                    "-c",
+                                    "if [ -x \"$(command -v curl)\" ]; then curl http://localhost:9090/-/healthy; elif [ -x \"$(command -v wget)\" ]; then wget -q -O /dev/null http://localhost:9090/-/healthy; else exit 1; fi"
+                                ]
+                            },
+                            "timeoutSeconds": 3,
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "failureThreshold": 6
+                        },
+                        "readinessProbe": {
+                            "exec": {
+                                "command": [
+                                    "sh",
+                                    "-c",
+                                    "if [ -x \"$(command -v curl)\" ]; then curl http://localhost:9090/-/ready; elif [ -x \"$(command -v wget)\" ]; then wget -q -O /dev/null http://localhost:9090/-/ready; else exit 1; fi"
+                                ]
+                            },
+                            "timeoutSeconds": 3,
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "failureThreshold": 120
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "imagePullPolicy": "IfNotPresent"
+                    },
+                    {
+                        "name": "prometheus-config-reloader",
+                        "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f304a0de3e411a4eb162fae783c5e4c5b683aeb5684ef770f22279c8594ef00e",
+                        "command": [
+                            "/bin/prometheus-config-reloader"
+                        ],
+                        "args": [
+                            "--log-format=logfmt",
+                            "--reload-url=http://localhost:9090/-/reload",
+                            "--config-file=/etc/prometheus/config/prometheus.yaml.gz",
+                            "--config-envsubst-file=/etc/prometheus/config_out/prometheus.env.yaml"
+                        ],
+                        "env": [
+                            {
+                                "name": "POD_NAME",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "metadata.name"
+                                    }
+                                }
+                            }
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "1m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "config",
+                                "mountPath": "/etc/prometheus/config"
+                            },
+                            {
+                                "name": "config-out",
+                                "mountPath": "/etc/prometheus/config_out"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "imagePullPolicy": "IfNotPresent"
+                    },
+                    {
+                        "name": "rules-configmap-reloader",
+                        "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:47e68d4ff0222a3c9ed93c184d2c20781ded48bab860573f2be2eaf7b17ee64a",
+                        "args": [
+                            "--webhook-url=http://localhost:9090/-/reload",
+                            "--volume-dir=/etc/prometheus/rules/prometheus-k8s-rulefiles-0"
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "1m"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "prometheus-k8s-rulefiles-0",
+                                "mountPath": "/etc/prometheus/rules/prometheus-k8s-rulefiles-0"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "imagePullPolicy": "IfNotPresent"
+                    },
+                    {
+                        "name": "thanos-sidecar",
+                        "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9629013c018f3b1e48d2458780cc37d723dd6af1864a99e4415f6ddc33836445",
+                        "args": [
+                            "sidecar",
+                            "--prometheus.url=http://localhost:9090/",
+                            "--tsdb.path=/prometheus",
+                            "--grpc-address=[$(POD_IP)]:10901",
+                            "--http-address=127.0.0.1:10902",
+                            "--grpc-server-tls-cert=/etc/tls/grpc/server.crt",
+                            "--grpc-server-tls-key=/etc/tls/grpc/server.key",
+                            "--grpc-server-tls-client-ca=/etc/tls/grpc/ca.crt"
+                        ],
+                        "ports": [
+                            {
+                                "name": "http",
+                                "containerPort": 10902,
+                                "protocol": "TCP"
+                            },
+                            {
+                                "name": "grpc",
+                                "containerPort": 10901,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "POD_IP",
+                                "valueFrom": {
+                                    "fieldRef": {
+                                        "apiVersion": "v1",
+                                        "fieldPath": "status.podIP"
+                                    }
+                                }
+                            }
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "1m",
+                                "memory": "100Mi"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secret-grpc-tls",
+                                "mountPath": "/etc/tls/grpc"
+                            },
+                            {
+                                "name": "prometheus-k8s-db",
+                                "mountPath": "/prometheus"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "imagePullPolicy": "IfNotPresent"
+                    },
+                    {
+                        "name": "prometheus-proxy",
+                        "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:97627f773f6af5ef82b1cd2d746060ca5dfaa336ea6894eaa8e9f25610fe0153",
+                        "args": [
+                            "-provider=openshift",
+                            "-https-address=:9091",
+                            "-http-address=",
+                            "-email-domain=*",
+                            "-upstream=http://localhost:9090",
+                            "-htpasswd-file=/etc/proxy/htpasswd/auth",
+                            "-openshift-service-account=prometheus-k8s",
+                            "-openshift-sar={\"resource\": \"namespaces\", \"verb\": \"get\"}",
+                            "-openshift-delegate-urls={\"/\": {\"resource\": \"namespaces\", \"verb\": \"get\"}}",
+                            "-tls-cert=/etc/tls/private/tls.crt",
+                            "-tls-key=/etc/tls/private/tls.key",
+                            "-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token",
+                            "-cookie-secret-file=/etc/proxy/secrets/session_secret",
+                            "-openshift-ca=/etc/pki/tls/cert.pem",
+                            "-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                            "-skip-auth-regex=^/metrics"
+                        ],
+                        "ports": [
+                            {
+                                "name": "web",
+                                "containerPort": 9091,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "env": [
+                            {
+                                "name": "HTTP_PROXY"
+                            },
+                            {
+                                "name": "HTTPS_PROXY"
+                            },
+                            {
+                                "name": "NO_PROXY"
+                            }
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "1m",
+                                "memory": "20Mi"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secret-prometheus-k8s-tls",
+                                "mountPath": "/etc/tls/private"
+                            },
+                            {
+                                "name": "secret-prometheus-k8s-proxy",
+                                "mountPath": "/etc/proxy/secrets"
+                            },
+                            {
+                                "name": "secret-prometheus-k8s-htpasswd",
+                                "mountPath": "/etc/proxy/htpasswd"
+                            },
+                            {
+                                "name": "prometheus-trusted-ca-bundle",
+                                "readOnly": true,
+                                "mountPath": "/etc/pki/ca-trust/extracted/pem/"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "imagePullPolicy": "IfNotPresent"
+                    },
+                    {
+                        "name": "kube-rbac-proxy",
+                        "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ec9fd32fa9a1d67790fc4c579c7714edb7fb643474708b52783ede7a61afed6c",
+                        "args": [
+                            "--secure-listen-address=0.0.0.0:9092",
+                            "--upstream=http://127.0.0.1:9095",
+                            "--config-file=/etc/kube-rbac-proxy/config.yaml",
+                            "--tls-cert-file=/etc/tls/private/tls.crt",
+                            "--tls-private-key-file=/etc/tls/private/tls.key",
+                            "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+                            "--logtostderr=true",
+                            "--v=10"
+                        ],
+                        "ports": [
+                            {
+                                "name": "tenancy",
+                                "containerPort": 9092,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "1m",
+                                "memory": "20Mi"
+                            }
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "secret-prometheus-k8s-tls",
+                                "mountPath": "/etc/tls/private"
+                            },
+                            {
+                                "name": "secret-kube-rbac-proxy",
+                                "mountPath": "/etc/kube-rbac-proxy"
+                            }
+                        ],
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "imagePullPolicy": "IfNotPresent"
+                    },
+                    {
+                        "name": "prom-label-proxy",
+                        "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:187ebe4901dccd3c730ac1d56acadbb58365c4410db1aeac7b3936cdae3ff536",
+                        "args": [
+                            "--insecure-listen-address=127.0.0.1:9095",
+                            "--upstream=http://127.0.0.1:9090",
+                            "--label=namespace"
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "1m",
+                                "memory": "20Mi"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "FallbackToLogsOnError",
+                        "imagePullPolicy": "IfNotPresent"
+                    }
+                ],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 600,
+                "dnsPolicy": "ClusterFirst",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "serviceAccountName": "prometheus-k8s",
+                "serviceAccount": "prometheus-k8s",
+                "securityContext": {},
+                "affinity": {
+                    "podAntiAffinity": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "weight": 100,
+                                "podAffinityTerm": {
+                                    "labelSelector": {
+                                        "matchExpressions": [
+                                            {
+                                                "key": "prometheus",
+                                                "operator": "In",
+                                                "values": [
+                                                    "k8s"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "namespaces": [
+                                        "openshift-monitoring"
+                                    ],
+                                    "topologyKey": "kubernetes.io/hostname"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "schedulerName": "default-scheduler",
+                "priorityClassName": "system-cluster-critical"
+            }
+        },
+        "serviceName": "prometheus-operated",
+        "podManagementPolicy": "Parallel",
+        "updateStrategy": {
+            "type": "RollingUpdate"
+        },
+        "revisionHistoryLimit": 10
+    },
+    "status": {
+        "observedGeneration": 1,
+        "replicas": 2,
+        "readyReplicas": 2,
+        "currentReplicas": 2,
+        "updatedReplicas": 2,
+        "currentRevision": "prometheus-k8s-d67c8fcfb",
+        "updateRevision": "prometheus-k8s-d67c8fcfb",
+        "collisionCount": 0
+    }
+}

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	appsclient "k8s.io/client-go/kubernetes/typed/apps/v1"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
@@ -137,6 +138,10 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 		return err
 	}
 
+	appsClient, err := appsclient.NewForConfig(gatherKubeConfig)
+	if err != nil {
+		return err
+	}
 	// ensure the insight snapshot directory exists
 	if _, err := os.Stat(s.StoragePath); err != nil && os.IsNotExist(err) {
 		if err := os.MkdirAll(s.StoragePath, 0777); err != nil {
@@ -159,7 +164,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 
 	// the gatherers periodically check the state of the cluster and report any
 	// config to the recorder
-	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1(), gatherKubeClient.CertificatesV1beta1(), metricsClient, registryClient.ImageregistryV1(), crdClient, gatherNetworkClient, dynamicClient, gatherPolicyClient)
+	configPeriodic := clusterconfig.New(gatherConfigClient, gatherKubeClient.CoreV1(), gatherKubeClient.CertificatesV1beta1(), metricsClient, registryClient.ImageregistryV1(), crdClient, gatherNetworkClient, dynamicClient, gatherPolicyClient, appsClient)
 	periodic := periodic.New(configObserver, recorder, map[string]gather.Interface{
 		"config": configPeriodic,
 	})

--- a/pkg/gather/clusterconfig/clusterconfig_test.go
+++ b/pkg/gather/clusterconfig/clusterconfig_test.go
@@ -11,6 +11,7 @@ import (
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	networkv1 "github.com/openshift/api/network/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apixv1beta1clientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
@@ -627,6 +628,43 @@ metadata:
 	if records[0].Name != "machinesets/test-worker" {
 		t.Fatalf("unexpected machineset name %s", records[0].Name)
 	}
+}
+
+func TestGatherStatefulSet(t *testing.T) {
+	testSet := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "openshift-test",
+		},
+	}
+	client := kubefake.NewSimpleClientset()
+	_, err := client.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-test"}}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("unable to create fake namespace", err)
+	}
+	_, err = client.AppsV1().StatefulSets("openshift-test").Create(context.Background(), &testSet, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("unable to create fake statefulset", err)
+	}
+
+	gatherer := &Gatherer{ctx: context.Background(), coreClient: client.CoreV1(), appsClient: client.AppsV1()}
+
+	records, errs := GatherStatefulSets(gatherer)()
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %#v", errs)
+		return
+	}
+
+	item, err := records[0].Item.Marshal(context.TODO())
+	var gatheredStatefulSet appsv1.StatefulSet
+	_, _, err = appsV1Serializer.Decode(item, nil, &gatheredStatefulSet)
+	if err != nil {
+		t.Fatalf("failed to decode object: %v", err)
+	}
+	if gatheredStatefulSet.Name != "test-statefulset" {
+		t.Fatalf("unexpected statefulset name %s", gatheredStatefulSet.Name)
+	}
+
 }
 
 func ExampleGatherMostRecentMetrics_Test() {


### PR DESCRIPTION
…openshift namespaces
<!-- Short description of the PR. What does it do? -->
This PR backports IO enhancement to gather statefulset configs from `openshift-*` namespaces.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/statefulsets/openshift-monitoring/prometheus-k8s.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md` - updated

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gather/clusterconfig/clusterconfig_test.go` - basic test `TestGatherStatefulSet` added

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->
No sensitive data

## References
<!-- What are related references for this PR? -->
https://issues.redhat.com/browse/INSIGHTOCP-51

