### PR TITLE
Bug 1893766: IO archive contains more records of than is the limit

### DIFF
--- a/pkg/record/diskrecorder/diskrecorder.go
+++ b/pkg/record/diskrecorder/diskrecorder.go
@@ -88,7 +88,7 @@ func (r *Recorder) Record(record record.Record) error {
 		recordName = fmt.Sprintf("%s.%s", record.Name, extension)
 	}
 
-	r.records[record.Name] = &memoryRecord{
+	r.records[recordName] = &memoryRecord{
 		name:        recordName,
 		fingerprint: record.Fingerprint,
 		at:          at,


### PR DESCRIPTION
It fixes a small problem related to the `diskrecorder` that was storing the records using the wrong index, resulting in the reports not being cleared in memory and causing eventual duplicate items.