### PR TITLE
Shortening the initial upload delay

### DIFF
--- a/pkg/insights/insightsuploader/insightsuploader.go
+++ b/pkg/insights/insightsuploader/insightsuploader.go
@@ -76,7 +76,7 @@ func (c *Controller) Run(ctx context.Context) {
 	enabled := cfg.Report
 	endpoint := cfg.Endpoint
 	interval := cfg.Interval
-	initialDelay := wait.Jitter(interval/8, 2)
+	initialDelay := wait.Jitter(interval/12, 1)
 	lastReported := c.reporter.LastReportedTime()
 	if !lastReported.IsZero() {
 		next := lastReported.Add(interval)


### PR DESCRIPTION
If you look at the wait.Jitter function https://github.com/kubernetes/apimachinery/blob/master/pkg/util/wait/wait.go#L193 then you can see that the initial delay was (in case of 2h intervals) in [15m, 45m) interval.

This is to shorten the initial delay to [10m, 20m) in case of 2h intervals. 