### PR TITLE
[release-4.6] temporarily remove e2e-tests (delayed upload)

### DIFF
--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -45,15 +45,6 @@ func TestIsIOHealthy(t *testing.T) {
 	checkPodsLogs(t, `The operator is healthy`)
 }
 
-// Check if an archive is uploaded and insights results retrieved in a reasonable amount of time
-// This test can be performed on OCP 4.7 and newer
-func TestArchiveUploadedAndResultReceived(t *testing.T) {
-	start := logLineTime(t, `Reporting status periodically to .* every`)
-	end := logLineTime(t, `Successfully reported id=`)
-	uploadingTime := duration(t, start, end)
-	t.Logf("Archive upload time is %v seconds", uploadingTime)
-}
-
 // Check if opt-in/opt-out works
 func TestOptOutOptIn(t *testing.T) {
 	// initially IO should be running

--- a/test/integration/bugs_test.go
+++ b/test/integration/bugs_test.go
@@ -21,19 +21,6 @@ const knownFileSuffixesInsideArchiveRegex string = `(` +
 	`(\/|^)(config|id|invoker|metrics|version)` +
 	`)$`
 
-//https://bugzilla.redhat.com/show_bug.cgi?id=1841057
-func TestUploadNotDelayedAfterStart(t *testing.T) {
-	LogChecker(t).Timeout(30 * time.Second).Search(`It is safe to use fast upload`)
-	time1 := logLineTime(t, `Reporting status periodically to .* every`)
-	time2 := logLineTime(t, `Successfully reported id=`)
-	delay := time2.Sub(time1)
-	allowedDelay := 3 * time.Minute
-	t.Logf("Archive upload delay was %d seconds", delay/time.Second)
-	if delay > allowedDelay && delay < time.Hour*24-allowedDelay {
-		t.Fatal("Upload after start took too much time")
-	}
-}
-
 // https://bugzilla.redhat.com/show_bug.cgi?id=1750665
 // https://bugzilla.redhat.com/show_bug.cgi?id=1753755
 func TestDefaultUploadFrequency(t *testing.T) {


### PR DESCRIPTION
Upload delay hasn't been changed in this version yet -  these tests cause failures of unrelated backporting PRs