### PR TITLE
[release-4.4] Bug 1894245: Fixes records index on diskrecorder

### DIFF
--- a/pkg/record/diskrecorder/diskrecorder.go
+++ b/pkg/record/diskrecorder/diskrecorder.go
@@ -88,7 +88,7 @@ func (r *Recorder) Record(record record.Record) error {
 		recordName = fmt.Sprintf("%s.%s", record.Name, extension)
 	}
 
-	r.records[record.Name] = &memoryRecord{
+	r.records[recordName] = &memoryRecord{
 		name:        recordName,
 		fingerprint: record.Fingerprint,
 		at:          at,


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR backports a bugfix related to the `diskrecorder` that was storing the records using the wrong index, resulting in the reports not being cleared in memory and causing eventual duplicate items.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [x] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No.

## Documentation
<!-- Are these changes reflected in documentation? -->

No.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

None.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Not applicable. This PR doesn't collect any data.

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-3427
https://bugzilla.redhat.com/show_bug.cgi?id=1894245