### PR TITLE
Skip TestArchiveUploadedAndResultReceived

### DIFF
--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -48,6 +48,7 @@ func TestIsIOHealthy(t *testing.T) {
 // Check if an archive is uploaded and insights results retrieved in a reasonable amount of time
 // This test can be performed on OCP 4.7 and newer
 func TestArchiveUploadedAndResultReceived(t *testing.T) {
+	t.Skip("Skipping until CCXDEV-3397 gets resolved")
 	start := logLineTime(t, `Reporting status periodically to .* every`)
 	end := logLineTime(t, `Successfully reported id=`)
 	uploadingTime := duration(t, start, end)


### PR DESCRIPTION
Temporarily skipping TestArchiveUploadedAndResultReceived, this test keeps failing, and devs work on fixing the problem ([CCXDEV-3397](https://issues.redhat.com/browse/CCXDEV-3397))