### PR TITLE
First check IO container status and optionally delay first gathering

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -141,7 +141,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 
 	// upload results to the provided client - if no client is configured reporting
 	// is permanently disabled, but if a client does exist the server may still disable reporting
-	uploader := insightsuploader.New(recorder, insightsClient, configObserver, statusReporter)
+	uploader := insightsuploader.New(recorder, insightsClient, configObserver, statusReporter, initialDelay)
 	statusReporter.AddSources(uploader)
 
 	// TODO: future ideas

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"k8s.io/klog"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/pkg/version"
@@ -17,7 +20,8 @@ import (
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/openshift/insights-operator/pkg/authorizer/clusterauthorizer"
 	"github.com/openshift/insights-operator/pkg/config"
@@ -56,7 +60,7 @@ func (s *Support) LoadConfig(obj map[string]interface{}) error {
 
 func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerContext) error {
 	klog.Infof("Starting insights-operator %s", version.Get().String())
-
+	initialDelay := 0 * time.Second
 	if err := s.LoadConfig(controller.ComponentConfig.Object); err != nil {
 		return err
 	}
@@ -123,7 +127,14 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 		"clusterconfig": clusterConfigGatherer,
 	})
 	statusReporter.AddSources(periodic.Sources()...)
-	go periodic.Run(4, ctx.Done())
+
+	// check we can read IO container status and we are not in crash loop
+	err = wait.PollImmediate(20*time.Second, wait.Jitter(s.Controller.Interval/12, 0.1), isRunning(ctx, gatherKubeConfig))
+	if err != nil {
+		initialDelay = wait.Jitter(s.Controller.Interval/12, 1)
+		klog.Infof("Unable to check insights-operator pod status. Setting initial delay to %s", initialDelay)
+	}
+	go periodic.Run(4, ctx.Done(), initialDelay)
 
 	authorizer := clusterauthorizer.New(configObserver)
 	insightsClient := insightsclient.New(nil, 0, "default", authorizer, clusterConfigGatherer)
@@ -156,4 +167,28 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 
 	<-ctx.Done()
 	return nil
+}
+
+func isRunning(ctx context.Context, config *rest.Config) wait.ConditionFunc {
+	return func() (bool, error) {
+		c, err := corev1client.NewForConfig(config)
+		if err != nil {
+			return false, err
+		}
+		pod, err := c.Pods(os.Getenv("POD_NAMESPACE")).Get(ctx, os.Getenv("POD_NAME"), metav1.GetOptions{})
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				klog.Errorf("Couldn't get Insights Operator Pod to detect its status. Error: %v", err)
+			}
+			return false, nil
+		}
+		for _, c := range pod.Status.ContainerStatuses {
+			// all containers has to be in running state to consider them healthy
+			if c.LastTerminationState.Terminated != nil || c.LastTerminationState.Waiting != nil {
+				klog.Info("The last pod state is unhealthy")
+				return false, nil
+			}
+		}
+		return true, nil
+	}
 }

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -17,7 +17,6 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/controllerstatus"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -45,11 +44,10 @@ type Controller struct {
 	statusCh     chan struct{}
 	configurator Configurator
 
-	lock             sync.Mutex
-	sources          []controllerstatus.Interface
-	reported         Reported
-	start            time.Time
-	safeInitialStart bool
+	lock     sync.Mutex
+	sources  []controllerstatus.Interface
+	reported Reported
+	start    time.Time
 }
 
 func NewController(client configv1client.ConfigV1Interface, coreClient corev1client.CoreV1Interface, configurator Configurator, namespace string) *Controller {
@@ -94,18 +92,6 @@ func (c *Controller) SetLastReportedTime(at time.Time) {
 	}
 	c.reported.LastReportTime.Time = at
 	c.triggerStatusUpdate()
-}
-
-func (c *Controller) SafeInitialStart() bool {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	return c.safeInitialStart
-}
-
-func (c *Controller) SetSafeInitialStart(safe bool) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.safeInitialStart = safe
 }
 
 func (c *Controller) AddSources(sources ...controllerstatus.Interface) {
@@ -374,7 +360,6 @@ func (c *Controller) updateStatus(ctx context.Context, initial bool) error {
 		existing = nil
 	}
 	if initial {
-		ophealthy := false
 		if existing != nil {
 			var reported Reported
 			if len(existing.Status.Extension.Raw) > 0 {
@@ -386,35 +371,9 @@ func (c *Controller) updateStatus(ctx context.Context, initial bool) error {
 			if con := findOperatorStatusCondition(existing.Status.Conditions, configv1.OperatorDegraded); con == nil ||
 				con != nil && con.Status == configv1.ConditionFalse {
 				klog.Info("The initial operator extension status is healthy")
-				ophealthy = true
-			}
-		}
-		if os.Getenv("POD_NAME") != "" && ophealthy {
-			var pod *v1.Pod
-			pod, err = c.coreClient.Pods(os.Getenv("POD_NAMESPACE")).Get(ctx, os.Getenv("POD_NAME"), metav1.GetOptions{})
-			if err == nil {
-				for _, c := range pod.Status.ContainerStatuses {
-					// all containers has to be in running state to consider them healthy
-					if c.LastTerminationState.Terminated != nil || c.LastTerminationState.Waiting != nil {
-						klog.Info("The last pod state is unhealthy")
-						ophealthy = false
-						break
-					}
-				}
-			} else {
-				if !errors.IsNotFound(err) {
-					klog.Errorf("Couldn't get Insights Operator Pod to detect its status. Error: %v", err)
-					ophealthy = false
-				}
 			}
 		}
 
-		if existing == nil || ophealthy {
-			klog.Info("It is safe to use fast upload")
-			c.SetSafeInitialStart(true)
-		} else {
-			klog.Info("Not safe for fast upload")
-		}
 	}
 
 	updated := c.merge(existing)

--- a/pkg/controller/status/status_test.go
+++ b/pkg/controller/status/status_test.go
@@ -78,12 +78,8 @@ func TestSaveInitialStart(t *testing.T) {
 			ctrl := &Controller{name: "insights", client: client.ConfigV1(), configurator: configobserver.New(config.Controller{Report: true}, kubeclientsetclient)}
 
 			err := ctrl.updateStatus(context.Background(), tt.initialRun)
-			isSafe := ctrl.SafeInitialStart()
 			if err != tt.expErr {
 				t.Fatalf("updateStatus returned unexpected error: %s Expected %s", err, tt.expErr)
-			}
-			if isSafe != tt.expectedSafeInitialStart {
-				t.Fatalf("unexpected SafeInitialStart was: %t Expected %t", isSafe, tt.expectedSafeInitialStart)
 			}
 		})
 	}

--- a/test/integration/basic_test.go
+++ b/test/integration/basic_test.go
@@ -48,7 +48,6 @@ func TestIsIOHealthy(t *testing.T) {
 // Check if an archive is uploaded and insights results retrieved in a reasonable amount of time
 // This test can be performed on OCP 4.7 and newer
 func TestArchiveUploadedAndResultReceived(t *testing.T) {
-	t.Skip("Skipping until CCXDEV-3397 gets resolved")
 	start := logLineTime(t, `Reporting status periodically to .* every`)
 	end := logLineTime(t, `Successfully reported id=`)
 	uploadingTime := duration(t, start, end)


### PR DESCRIPTION
This is to replace initial upload delay (setting it to 0 actually) with gathering delay. What we are doing now is following:
1. Run gathering right after IO start
2. Check if IO is healthy (checked in https://github.com/openshift/insights-operator/blob/master/pkg/controller/status/status.go#L396)
   - if it's healthy then upload immediately
   - if it's not heatlhy then wait some time between (15min, 45min) - this happens quite often in CI clusters because of `E1104 14:09:52.697292       1 status.go:406] Couldn't get Insights Operator Pod to detect its status. Error: pods "insights-operator-6d5cf8b5ff-982dt" is forbidden: User "system:serviceaccount:openshift-insights:gather" cannot get resource "pods" in API group "" in the namespace "openshift-insights": RBAC: clusterrole.rbac.authorization.k8s.io "cluster-reader" not found` 
This doesn't make much sense IMHO. I mean to send something which is older than 20 minutes (and actually it may be from time when cluster was not up and ready. We can optionally add one more condition checking clusteroperators available=true, progressing= false)

This proposal is doing following:
1. Check we can read IO container status and the status is running. 
2. If step 1 is OK within 1 minute then run gathering and upload immediately
3. if step 1 is not OK then wait (`wait.Jitter(s.Controller.Interval/12, 1)`, which is (10min, 20min) for 2h interval) before first gathering (which in fact means delaying first upload as well AFAIK)
