### PR TITLE
Adding a metrics report to IO gatherers

### DIFF
--- a/pkg/record/interface.go
+++ b/pkg/record/interface.go
@@ -48,15 +48,28 @@ func (m JSONMarshaller) GetExtension() string {
 	return "json"
 }
 
+type gatherStatusReport struct {
+	Name    string        `json:"name"`
+	Elapsed time.Duration `json:"elapsed"`
+	Report  int           `json:"report"`
+	Errors  []error       `json:"errors"`
+}
+
 // Collect is a helper for gathering a large set of records from generic functions.
 func Collect(ctx context.Context, recorder Interface, bulkFns ...func() ([]Record, []error)) error {
 	var errors []string
+	var gatherReport []interface{}
 	for _, bulkFn := range bulkFns {
 		gatherName := runtime.FuncForPC(reflect.ValueOf(bulkFn).Pointer()).Name()
 		klog.V(5).Infof("Gathering %s", gatherName)
+
 		start := time.Now()
 		records, errs := bulkFn()
-		klog.V(4).Infof("Gather %s took %s to process %d records", gatherName, time.Now().Sub(start).Truncate(time.Millisecond), len(records))
+		elapsed := time.Now().Sub(start).Truncate(time.Millisecond)
+
+		klog.V(4).Infof("Gather %s took %s to process %d records", gatherName, elapsed, len(records))
+		gatherReport = append(gatherReport, gatherStatusReport{gatherName, elapsed, len(records), errs})
+
 		for _, err := range errs {
 			errors = append(errors, err.Error())
 		}
@@ -70,12 +83,23 @@ func Collect(ctx context.Context, recorder Interface, bulkFns ...func() ([]Recor
 			return err
 		}
 	}
+
+	// Creates the gathering performance report
+	if err := recordGatherReport(recorder, gatherReport); err != nil {
+		errors = append(errors, fmt.Sprintf("unable to record io status reports: %v", err))
+	}
+
 	if len(errors) > 0 {
 		sort.Strings(errors)
 		errors = uniqueStrings(errors)
 		return fmt.Errorf("%s", strings.Join(errors, ", "))
 	}
 	return nil
+}
+
+func recordGatherReport(recorder Interface, report []interface{}) error {
+	r := Record{Name: "insights-operator/gathers", Item: JSONMarshaller{Object: report}}
+	return recorder.Record(r)
 }
 
 func uniqueStrings(arr []string) []string {

--- a/pkg/record/interface.go
+++ b/pkg/record/interface.go
@@ -52,8 +52,11 @@ func (m JSONMarshaller) GetExtension() string {
 func Collect(ctx context.Context, recorder Interface, bulkFns ...func() ([]Record, []error)) error {
 	var errors []string
 	for _, bulkFn := range bulkFns {
-		klog.V(5).Infof("Gathering %s", runtime.FuncForPC(reflect.ValueOf(bulkFn).Pointer()).Name())
+		gatherName := runtime.FuncForPC(reflect.ValueOf(bulkFn).Pointer()).Name()
+		klog.V(5).Infof("Gathering %s", gatherName)
+		start := time.Now()
 		records, errs := bulkFn()
+		klog.V(4).Infof("Gather %s took %s to process %d records", gatherName, time.Now().Sub(start).Truncate(time.Millisecond), len(records))
 		for _, err := range errs {
 			errors = append(errors, err.Error())
 		}


### PR DESCRIPTION
It adds some metrics to log and to generated archive that collects some information about the gathers executions:

- Elapsed time;
- Number of records generated;
- List of errors;

The report is stored at the archive, in the file `insights-operator\gathers.json`