### PR TITLE
Bug 1907876: Refactoring record and gatherer

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -6,3 +6,30 @@ interval: "5m"
 storagePath: /tmp/insights-operator
 endpoint: http://[::1]:8081
 impersonate: system:serviceaccount:openshift-insights:gather
+gather:
+  - pdbs
+  - metrics
+  - operators
+  - container_images
+  - nodes
+  - config_maps
+  - version
+  - id
+  - infrastructure
+  - network
+  - authentication
+  - image_registry
+  - image_pruner
+  - feature_gates
+  - oauth
+  - ingress
+  - proxy
+  - certificate_signing_requests
+  - crd
+  - host_subnet
+  - machine_set
+  - install_plans
+  - service_accounts
+  - machine_config_pool
+  - container_runtime_config
+#  - stateful_sets

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -7,29 +7,4 @@ storagePath: /tmp/insights-operator
 endpoint: http://[::1]:8081
 impersonate: system:serviceaccount:openshift-insights:gather
 gather:
-  - pdbs
-  - metrics
-  - operators
-  - container_images
-  - nodes
-  - config_maps
-  - version
-  - id
-  - infrastructure
-  - network
-  - authentication
-  - image_registry
-  - image_pruner
-  - feature_gates
-  - oauth
-  - ingress
-  - proxy
-  - certificate_signing_requests
-  - crd
-  - host_subnet
-  - machine_set
-  - install_plans
-  - service_accounts
-  - machine_config_pool
-  - container_runtime_config
-#  - stateful_sets
+  - ALL

--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -12,29 +12,4 @@ pull_report:
   timeout: "3000s"
   min_retry: "30s"
 gather:
-  - pdbs
-  - metrics
-  - operators
-  - container_images
-  - nodes
-  - config_maps
-  - version
-  - id
-  - infrastructure
-  - network
-  - authentication
-  - image_registry
-  - image_pruner
-  - feature_gates
-  - oauth
-  - ingress
-  - proxy
-  - certificate_signing_requests
-  - crd
-  - host_subnet
-  - machine_set
-  - install_plans
-  - service_accounts
-  - machine_config_pool
-  - container_runtime_config
-  - stateful_sets
+  - ALL

--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -11,3 +11,30 @@ pull_report:
   delay: "60s"
   timeout: "3000s"
   min_retry: "30s"
+gather:
+  - pdbs
+  - metrics
+  - operators
+  - container_images
+  - nodes
+  - config_maps
+  - version
+  - id
+  - infrastructure
+  - network
+  - authentication
+  - image_registry
+  - image_pruner
+  - feature_gates
+  - oauth
+  - ingress
+  - proxy
+  - certificate_signing_requests
+  - crd
+  - host_subnet
+  - machine_set
+  - install_plans
+  - service_accounts
+  - machine_config_pool
+  - container_runtime_config
+  - stateful_sets

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -284,3 +284,10 @@ health_statuses_insights{metric="low"} 1
 health_statuses_insights{metric="moderate"} 1
 health_statuses_insights{metric="total"} 2
 ```
+
+## Configuring what to gather
+In the yaml config there is a field named `gather` it expects a list of strings, each string is an id that is connected to a gather function.
+Adding such an id to the list means that that certain gather function needs to be run.
+If nothing is set in the `gather` list then no gathering will take place and an error will be raised.
+There is a special id named `ALL` which if in the list then every gather function will be run.
+The id of each gather function can be found in the `docs/gathered-data.md` beside the `Id in config:` text for each section.

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -291,3 +291,40 @@ Adding such an id to the list means that that certain gather function needs to b
 If nothing is set in the `gather` list then no gathering will take place and an error will be raised.
 There is a special id named `ALL` which if in the list then every gather function will be run.
 The id of each gather function can be found in the `docs/gathered-data.md` beside the `Id in config:` text for each section.
+
+#### Example for using special id `ALL`
+```
+gather:
+  - ALL
+```
+
+#### Example for using individual ids
+```
+gather:
+ - pdbs
+ - metrics
+ - operators
+ - container_images
+ - nodes
+ - config_maps
+ - version
+ - id
+ - infrastructures
+ - networks
+ - authentication
+ - image_registries
+ - image_pruners
+ - feature_gates
+ - oauths
+ - ingress
+ - proxies
+ - certificate_signing_requests
+ - crds
+ - host_subnets
+ - machine_sets
+ - install_plans
+ - service_accounts
+ - machine_config_pools
+ - container_runtime_configs
+ - stateful_sets
+```

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -11,6 +11,7 @@ The following CRDs are gathered:
 The CRD sizes above are in the raw (uncompressed) state.
 
 Location in archive: config/crd/
+Id in config: crds
 
 
 ## CertificateSigningRequests
@@ -22,6 +23,7 @@ The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernete
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#certificatesigningrequestlist-v1beta1certificates
 
 Location in archive: config/certificatesigningrequests/
+Id in config: certificate_signing_requests
 
 
 ## ClusterAuthentication
@@ -33,6 +35,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/authentication/
 See: docs/insights-archive-sample/config/authentication
+Id in config: authentication
 
 
 ## ClusterFeatureGates
@@ -44,6 +47,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/featuregate/
 See: docs/insights-archive-sample/config/featuregate
+Id in config: feature_gates
 
 
 ## ClusterID
@@ -55,6 +59,7 @@ Response see https://github.com/openshift/api/blob/master/config/v1/types_cluste
 
 Location in archive: config/id/
 See: docs/insights-archive-sample/config/id
+Id in config: id
 
 
 ## ClusterImagePruner
@@ -62,6 +67,7 @@ See: docs/insights-archive-sample/config/id
 fetches the image pruner configuration
 
 Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
+Id in config: image_pruners
 
 
 ## ClusterImageRegistry
@@ -69,6 +75,7 @@ Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/
 fetches the cluster Image Registry configuration
 
 Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
+Id in config: image_registries
 
 
 ## ClusterInfrastructure
@@ -80,6 +87,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/infrastructure/
 See: docs/insights-archive-sample/config/infrastructure
+Id in config: infrastructures
 
 
 ## ClusterIngress
@@ -91,6 +99,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/ingress/
 See: docs/insights-archive-sample/config/ingress
+Id in config: ingress
 
 
 ## ClusterNetwork
@@ -102,6 +111,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/network/
 See: docs/insights-archive-sample/config/network
+Id in config: networks
 
 
 ## ClusterOAuth
@@ -113,6 +123,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/oauth/
 See: docs/insights-archive-sample/config/oauth
+Id in config: oauths
 
 
 ## ClusterOperators
@@ -126,6 +137,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 Location of operators in archive: config/clusteroperator/
 See: docs/insights-archive-sample/config/clusteroperator
 Location of pods in archive: config/pod/
+Id in config: operators
 
 
 Output raw size: 245
@@ -144,6 +156,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/proxy/
 See: docs/insights-archive-sample/config/proxy
+Id in config: proxies
 
 
 ## ClusterVersion
@@ -155,6 +168,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/version/
 See: docs/insights-archive-sample/config/version
+Id in config: version
 
 
 ## ConfigMaps
@@ -170,6 +184,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location in archive: config/configmaps/
 See: docs/insights-archive-sample/config/configmaps
+Id in config: config_maps
 
 
 ## ContainerImages
@@ -178,6 +193,18 @@ collects essential information about running containers.
 Specifically, the age of pods, the set of running images and the container names are collected.
 
 Location in archive: config/running_containers.json
+Id in config: container_images
+
+
+## ContainerRuntimeConfig
+
+collects ContainerRuntimeConfig  information
+
+The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L402
+Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
+
+Location in archive: config/containerruntimeconfigs/
+Id in config: container_runtime_configs
 
 
 ## HostSubnet
@@ -188,6 +215,7 @@ The Kubernetes api https://github.com/openshift/client-go/blob/master/network/cl
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#hostsubnet-v1-network-openshift-io
 
 Location in archive: config/hostsubnet/
+Id in config: host_subnets
 
 
 ## InstallPlans
@@ -200,6 +228,18 @@ It also collects Total number of all installplans and all non-unique installplan
 The Operators-Framework api https://github.com/operator-framework/api/blob/master/pkg/operators/v1alpha1/installplan_types.go#L26
 
 Location in archive: config/installplans/
+Id in config: install_plans
+
+
+## MachineConfigPool
+
+collects MachineConfigPool information
+
+The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L197
+Response see https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.html
+
+Location in archive: config/machineconfigpools/
+Id in config: machine_config_pools
 
 
 ## MachineSet
@@ -210,6 +250,7 @@ The Kubernetes api https://github.com/openshift/machine-api-operator/blob/master
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machineset-v1beta1-machine-openshift-io
 
 Location in archive: machinesets/
+Id in config: machine_sets
 
 
 ## MostRecentMetrics
@@ -225,6 +266,7 @@ Gathered metrics:
 
 Location in archive: config/metrics/
 See: docs/insights-archive-sample/config/metrics
+Id in config: metrics
 
 
 Output raw size: 148
@@ -252,6 +294,7 @@ The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernete
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core
 
 Location in archive: config/node/
+Id in config: nodes
 
 
 Output raw size: 491
@@ -270,16 +313,7 @@ Response see https://docs.okd.io/latest/rest_api/policy_apis/poddisruptionbudget
 
 Location in archive: config/pdbs/
 See: docs/insights-archive-sample/config/pdbs
-
-## MachineConfigPool
-
-gathers the cluster's MachineConfigPools.
-
-The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L197
-Response see https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.html
-
-Location in archive: config/machineconfigpools/
-See: docs/insights-archive-sample/config/machineconfigpools/
+Id in config: pdbs
 
 
 ## ServiceAccounts
@@ -292,17 +326,8 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 Location of serviceaccounts in archive: config/serviceaccounts
 See: docs/insights-archive-sample/config/serviceaccounts
+Id in config: service_accounts
 
-
-## ContainerRuntimeConfig
-
-collects ContainerRuntimeConfig information
-
-The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L402
-Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
-
-Location in archive: config/containerruntimeconfigs/
-See: docs/insights-archive-sample/config/containerruntimeconfigs
 
 ## StatefulSets
 
@@ -312,4 +337,6 @@ The Kubernetes API https://github.com/kubernetes/api/blob/master/apps/v1/types.g
 Response see https://docs.openshift.com/container-platform/4.5/rest_api/workloads_apis/statefulset-apps-v1.html#statefulset-apps-v1
 
 Location in archive: config/statefulsets/
+Id in config: stateful_sets
+
 

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -284,6 +284,7 @@ The Kubernetes api https://github.com/openshift/client-go/blob/master/network/cl
 Response is an array of netNamespaces. Netnamespace contains Name, EgressIPs and NetID attributes.
 
 Location in archive: config/netnamespaces
+Id in config: netnamespaces
 
 
 ## Nodes

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ type Serialized struct {
 		MinRetryTime string `json:"min_retry"`
 	} `json:"pull_report"`
 	Impersonate string `json:"impersonate"`
+	Gather []string `json:"gather"`
 }
 
 func (s *Serialized) ToController(cfg *Controller) (*Controller, error) {
@@ -28,6 +29,7 @@ func (s *Serialized) ToController(cfg *Controller) (*Controller, error) {
 	cfg.StoragePath = s.StoragePath
 	cfg.Endpoint = s.Endpoint
 	cfg.Impersonate = s.Impersonate
+	cfg.Gather = s.Gather
 
 	if len(s.Interval) > 0 {
 		d, err := time.ParseDuration(s.Interval)
@@ -98,6 +100,7 @@ type Controller struct {
 	ReportMinRetryTime   time.Duration
 	ReportPullingTimeout time.Duration
 	Impersonate          string
+	Gather				 []string
 
 	Username string
 	Password string

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -137,7 +137,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 	go periodic.Run(4, ctx.Done(), initialDelay)
 
 	authorizer := clusterauthorizer.New(configObserver)
-	insightsClient := insightsclient.New(nil, 0, "default", authorizer, clusterConfigGatherer)
+	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherKubeConfig)
 
 	// upload results to the provided client - if no client is configured reporting
 	// is permanently disabled, but if a client does exist the server may still disable reporting

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -76,7 +76,7 @@ func (c *Controller) sync(name string) error {
 		}
 	}()
 	klog.V(4).Infof("Running %s", name)
-	return gatherer.Gather(ctx, c.recorder)
+	return gatherer.Gather(ctx, c.config.Config().Gather, c.recorder)
 }
 
 // Run starts gathering with initialDelay

--- a/pkg/gather/clusterconfig/0_gahterer_test.go
+++ b/pkg/gather/clusterconfig/0_gahterer_test.go
@@ -11,9 +11,8 @@ func Test_uniqueStrings(t *testing.T) {
 		arr  []string
 		want []string
 	}{
-		{arr: []string{}, want: []string{}},
 		{arr: nil, want: nil},
-		{arr: []string{"a", "b", "a"}, want: []string{"a", "b", "a"}},
+		{arr: []string{}, want: []string{}},
 		{arr: []string{"a", "a", "a"}, want: []string{"a"}},
 		{arr: []string{"a", "b", "b"}, want: []string{"a", "b"}},
 		{arr: []string{"a", "a", "b"}, want: []string{"a", "b"}},

--- a/pkg/gather/clusterconfig/0_gahterer_test.go
+++ b/pkg/gather/clusterconfig/0_gahterer_test.go
@@ -1,4 +1,4 @@
-package record
+package clusterconfig
 
 import (
 	"reflect"

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -34,6 +34,8 @@ type Gatherer struct {
 
 type gatherFunction func(g *Gatherer) ([]record.Record, []error)
 
+const gatherAll = "ALL"
+
 var gatherFunctions = map[string]gatherFunction{
 	"pdbs": GatherPodDisruptionBudgets,
 	"metrics": GatherMostRecentMetrics,
@@ -43,23 +45,23 @@ var gatherFunctions = map[string]gatherFunction{
 	"config_maps": GatherConfigMaps,
 	"version": GatherClusterVersion,
 	"id": GatherClusterID,
-	"infrastructure": GatherClusterInfrastructure,
-	"network": GatherClusterNetwork,
+	"infrastructures": GatherClusterInfrastructure,
+	"networks": GatherClusterNetwork,
 	"authentication": GatherClusterAuthentication,
-	"image_registry": GatherClusterImageRegistry,
-	"image_pruner": GatherClusterImagePruner,
+	"image_registries": GatherClusterImageRegistry,
+	"image_pruners": GatherClusterImagePruner,
 	"feature_gates": GatherClusterFeatureGates,
-	"oauth": GatherClusterOAuth,
+	"oauths": GatherClusterOAuth,
 	"ingress": GatherClusterIngress,
-	"proxy": GatherClusterProxy,
+	"proxies": GatherClusterProxy,
 	"certificate_signing_requests": GatherCertificateSigningRequests,
-	"crd": GatherCRD,
-	"host_subnet": GatherHostSubnet,
-	"machine_set": GatherMachineSet,
+	"crds": GatherCRD,
+	"host_subnets": GatherHostSubnet,
+	"machine_sets": GatherMachineSet,
 	"install_plans": GatherInstallPlans,
 	"service_accounts": GatherServiceAccounts,
-	"machine_config_pool": GatherMachineConfigPool,
-	"container_runtime_config": GatherContainerRuntimeConfig,
+	"machine_config_pools": GatherMachineConfigPool,
+	"container_runtime_configs": GatherContainerRuntimeConfig,
 	"stateful_sets": GatherStatefulSets,
 	"netnamepaces": GatherNetNamespace,
 }
@@ -81,6 +83,13 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 
 	if len(gatherList) == 0 {
 		errors = append(errors, "no gather functions are specified to run")
+	}
+
+	if contains(gatherList, gatherAll) {
+		gatherList = make([]string, 0, len(gatherFunctions))
+		for k := range gatherFunctions {
+			gatherList = append(gatherList, k)
+		}
 	}
 
 	for _, gatherId := range gatherList {
@@ -146,4 +155,13 @@ func uniqueStrings(arr []string) []string {
 		last++
 	}
 	return arr[:last]
+}
+
+func contains(s []string, e string) bool {
+    for _, a := range s {
+        if a == e {
+            return true
+        }
+    }
+    return false
 }

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -63,7 +63,7 @@ var gatherFunctions = map[string]gatherFunction{
 	"machine_config_pools": GatherMachineConfigPool,
 	"container_runtime_configs": GatherContainerRuntimeConfig,
 	"stateful_sets": GatherStatefulSets,
-	"netnamepaces": GatherNetNamespace,
+	"netnamespaces": GatherNetNamespace,
 }
 
 // New creates new Gatherer

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -2,15 +2,27 @@ package clusterconfig
 
 import (
 	"context"
-	"sync"
+	"fmt"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
 
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 
-	configv1 "github.com/openshift/api/config/v1"
 	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )
+
+type gatherStatusReport struct {
+	Name    string        `json:"name"`
+	Elapsed time.Duration `json:"elapsed"`
+	Report  int           `json:"report"`
+	Errors  []error       `json:"errors"`
+}
 
 // Gatherer is a driving instance invoking collection of data
 type Gatherer struct {
@@ -18,8 +30,6 @@ type Gatherer struct {
 	gatherKubeConfig        *rest.Config
 	gatherProtoKubeConfig   *rest.Config
 	metricsGatherKubeConfig *rest.Config
-	lock                    sync.Mutex
-	lastVersion             *configv1.ClusterVersion
 }
 
 // New creates new Gatherer
@@ -34,7 +44,7 @@ func New(gatherKubeConfig *rest.Config, gatherProtoKubeConfig *rest.Config, metr
 // Gather is hosting and calling all the recording functions
 func (g *Gatherer) Gather(ctx context.Context, recorder record.Interface) error {
 	g.ctx = ctx
-	return record.Collect(ctx, recorder,
+	bulkFns := []func() ([]record.Record, []error){
 		GatherPodDisruptionBudgets(g),
 		GatherMostRecentMetrics(g),
 		GatherClusterOperators(g),
@@ -62,21 +72,66 @@ func (g *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherContainerRuntimeConfig(g),
 		GatherStatefulSets(g),
 		GatherNetNamespace(g),
-	)
-}
-
-func (g *Gatherer) setClusterVersion(version *configv1.ClusterVersion) {
-	g.lock.Lock()
-	defer g.lock.Unlock()
-	if g.lastVersion != nil && g.lastVersion.ResourceVersion == version.ResourceVersion {
-		return
 	}
-	g.lastVersion = version.DeepCopy()
+
+	var errors []string
+	var gatherReport []interface{}
+	for _, bulkFn := range bulkFns {
+		gatherName := runtime.FuncForPC(reflect.ValueOf(bulkFn).Pointer()).Name()
+		klog.V(5).Infof("Gathering %s", gatherName)
+
+		start := time.Now()
+		records, errs := bulkFn()
+		elapsed := time.Now().Sub(start).Truncate(time.Millisecond)
+
+		klog.V(4).Infof("Gather %s took %s to process %d records", gatherName, elapsed, len(records))
+		gatherReport = append(gatherReport, gatherStatusReport{gatherName, elapsed, len(records), errs})
+
+		for _, err := range errs {
+			errors = append(errors, err.Error())
+		}
+		for _, record := range records {
+			if err := recorder.Record(record); err != nil {
+				errors = append(errors, fmt.Sprintf("unable to record %s: %v", record.Name, err))
+				continue
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+
+	// Creates the gathering performance report
+	if err := recordGatherReport(recorder, gatherReport); err != nil {
+		errors = append(errors, fmt.Sprintf("unable to record io status reports: %v", err))
+	}
+
+	if len(errors) > 0 {
+		sort.Strings(errors)
+		errors = uniqueStrings(errors)
+		return fmt.Errorf("%s", strings.Join(errors, ", "))
+	}
+	return nil
 }
 
-// ClusterVersion returns Version for this cluster, which is set by running version during Gathering
-func (g *Gatherer) ClusterVersion() *configv1.ClusterVersion {
-	g.lock.Lock()
-	defer g.lock.Unlock()
-	return g.lastVersion
+func recordGatherReport(recorder record.Interface, report []interface{}) error {
+	r := record.Record{Name: "insights-operator/gathers", Item: record.JSONMarshaller{Object: report}}
+	return recorder.Record(r)
+}
+
+func uniqueStrings(arr []string) []string {
+	var last int
+	for i := 1; i < len(arr); i++ {
+		if arr[i] == arr[last] {
+			continue
+		}
+		last++
+		if last != i {
+			arr[last] = arr[i]
+		}
+	}
+	if last < len(arr) {
+		last++
+	}
+	return arr[:last]
 }

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -140,21 +140,19 @@ func recordGatherReport(recorder record.Interface, report []interface{}) error {
 	return recorder.Record(r)
 }
 
-func uniqueStrings(arr []string) []string {
-	var last int
-	for i := 1; i < len(arr); i++ {
-		if arr[i] == arr[last] {
-			continue
-		}
-		last++
-		if last != i {
-			arr[last] = arr[i]
-		}
+func uniqueStrings(list []string) []string {
+	if len(list) < 2 {
+		return list
 	}
-	if last < len(arr) {
-		last++
-	}
-	return arr[:last]
+    keys := make(map[string]bool)
+    set := []string{}
+    for _, entry := range list {
+        if _, value := keys[entry]; !value {
+            keys[entry] = true
+            set = append(set, entry)
+        }
+    }
+    return set
 }
 
 func contains(s []string, e string) bool {

--- a/pkg/gather/clusterconfig/authentications.go
+++ b/pkg/gather/clusterconfig/authentications.go
@@ -18,14 +18,12 @@ import (
 //
 // Location in archive: config/authentication/
 // See: docs/insights-archive-sample/config/authentication
-func GatherClusterAuthentication(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterAuthentication(g.ctx, gatherConfigClient)
+func GatherClusterAuthentication(g *Gatherer) ([]record.Record, []error) {
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterAuthentication(g.ctx, gatherConfigClient)
 }
 func gatherClusterAuthentication(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {
 	config, err := configClient.Authentications().Get(ctx, "cluster", metav1.GetOptions{})

--- a/pkg/gather/clusterconfig/authentications.go
+++ b/pkg/gather/clusterconfig/authentications.go
@@ -18,6 +18,7 @@ import (
 //
 // Location in archive: config/authentication/
 // See: docs/insights-archive-sample/config/authentication
+// Id in config: authentication
 func GatherClusterAuthentication(g *Gatherer) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/certificate_signing_requests.go
+++ b/pkg/gather/clusterconfig/certificate_signing_requests.go
@@ -34,6 +34,7 @@ const csrGatherLimit = 5000
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#certificatesigningrequestlist-v1beta1certificates
 //
 // Location in archive: config/certificatesigningrequests/
+// Id in config: certificate_signing_requests
 func GatherCertificateSigningRequests(g *Gatherer) ([]record.Record, []error) {
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/certificate_signing_requests.go
+++ b/pkg/gather/clusterconfig/certificate_signing_requests.go
@@ -34,14 +34,12 @@ const csrGatherLimit = 5000
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#certificatesigningrequestlist-v1beta1certificates
 //
 // Location in archive: config/certificatesigningrequests/
-func GatherCertificateSigningRequests(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherCertificateSigningRequests(g.ctx, gatherKubeClient.CertificatesV1beta1())
+func GatherCertificateSigningRequests(g *Gatherer) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherCertificateSigningRequests(g.ctx, gatherKubeClient.CertificatesV1beta1())
 }
 
 func gatherCertificateSigningRequests(ctx context.Context, certClient certificatesv1beta1.CertificatesV1beta1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/config_maps.go
+++ b/pkg/gather/clusterconfig/config_maps.go
@@ -27,14 +27,12 @@ import (
 //
 // Location in archive: config/configmaps/
 // See: docs/insights-archive-sample/config/configmaps
-func GatherConfigMaps(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherConfigMaps(g.ctx, gatherKubeClient.CoreV1())
+func GatherConfigMaps(g *Gatherer) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherConfigMaps(g.ctx, gatherKubeClient.CoreV1())
 }
 
 func gatherConfigMaps(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/config_maps.go
+++ b/pkg/gather/clusterconfig/config_maps.go
@@ -27,6 +27,7 @@ import (
 //
 // Location in archive: config/configmaps/
 // See: docs/insights-archive-sample/config/configmaps
+// Id in config: config_maps
 func GatherConfigMaps(g *Gatherer) ([]record.Record, []error) {
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/container_images.go
+++ b/pkg/gather/clusterconfig/container_images.go
@@ -35,14 +35,12 @@ const (
 // Specifically, the age of pods, the set of running images and the container names are collected.
 //
 // Location in archive: config/running_containers.json
-func GatherContainerImages(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherContainerImages(gatherKubeClient.CoreV1(), g.ctx)
+func GatherContainerImages(g *Gatherer) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherContainerImages(gatherKubeClient.CoreV1(), g.ctx)
 }
 
 func gatherContainerImages(coreClient corev1client.CoreV1Interface, ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/container_images.go
+++ b/pkg/gather/clusterconfig/container_images.go
@@ -35,6 +35,7 @@ const (
 // Specifically, the age of pods, the set of running images and the container names are collected.
 //
 // Location in archive: config/running_containers.json
+// Id in config: container_images
 func GatherContainerImages(g *Gatherer) ([]record.Record, []error) {
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/container_runtime_configs.go
+++ b/pkg/gather/clusterconfig/container_runtime_configs.go
@@ -20,6 +20,7 @@ import (
 // Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
 //
 // Location in archive: config/containerruntimeconfigs/
+// Id in config: container_runtime_configs
 func GatherContainerRuntimeConfig(g *Gatherer) ([]record.Record, []error) {
 	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/container_runtime_configs.go
+++ b/pkg/gather/clusterconfig/container_runtime_configs.go
@@ -20,14 +20,13 @@ import (
 // Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
 //
 // Location in archive: config/containerruntimeconfigs/
-func GatherContainerRuntimeConfig(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherContainerRuntimeConfig(g.ctx, dynamicClient)
+func GatherContainerRuntimeConfig(g *Gatherer) ([]record.Record, []error) {
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherContainerRuntimeConfig(g.ctx, dynamicClient)
+
 }
 
 func gatherContainerRuntimeConfig(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/custom_resource_definitions.go
+++ b/pkg/gather/clusterconfig/custom_resource_definitions.go
@@ -23,14 +23,12 @@ import (
 // The CRD sizes above are in the raw (uncompressed) state.
 //
 // Location in archive: config/crd/
-func GatherCRD(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		crdClient, err := apixv1beta1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherCRD(g.ctx, crdClient)
+func GatherCRD(g *Gatherer) ([]record.Record, []error) {
+	crdClient, err := apixv1beta1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherCRD(g.ctx, crdClient)
 }
 
 func gatherCRD(ctx context.Context, crdClient apixv1beta1client.ApiextensionsV1beta1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/custom_resource_definitions.go
+++ b/pkg/gather/clusterconfig/custom_resource_definitions.go
@@ -23,6 +23,7 @@ import (
 // The CRD sizes above are in the raw (uncompressed) state.
 //
 // Location in archive: config/crd/
+// Id in config: crds
 func GatherCRD(g *Gatherer) ([]record.Record, []error) {
 	crdClient, err := apixv1beta1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/feature_gates.go
+++ b/pkg/gather/clusterconfig/feature_gates.go
@@ -21,15 +21,14 @@ import (
 //
 // Location in archive: config/featuregate/
 // See: docs/insights-archive-sample/config/featuregate
-func GatherClusterFeatureGates(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterFeatureGates(g.ctx, gatherConfigClient)
+func GatherClusterFeatureGates(g *Gatherer) ([]record.Record, []error) {
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterFeatureGates(g.ctx, gatherConfigClient)
 }
+
 func gatherClusterFeatureGates(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {
 	config, err := configClient.FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
 	if errors.IsNotFound(err) {

--- a/pkg/gather/clusterconfig/feature_gates.go
+++ b/pkg/gather/clusterconfig/feature_gates.go
@@ -21,6 +21,7 @@ import (
 //
 // Location in archive: config/featuregate/
 // See: docs/insights-archive-sample/config/featuregate
+// Id in config: feature_gates
 func GatherClusterFeatureGates(g *Gatherer) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/host_subnets.go
+++ b/pkg/gather/clusterconfig/host_subnets.go
@@ -21,6 +21,7 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#hostsubnet-v1-network-openshift-io
 //
 // Location in archive: config/hostsubnet/
+// Id in config: host_subnets
 func GatherHostSubnet(g *Gatherer) ([]record.Record, []error) {
 	gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/host_subnets.go
+++ b/pkg/gather/clusterconfig/host_subnets.go
@@ -21,15 +21,14 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#hostsubnet-v1-network-openshift-io
 //
 // Location in archive: config/hostsubnet/
-func GatherHostSubnet(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherHostSubnet(g.ctx, gatherNetworkClient)
+func GatherHostSubnet(g *Gatherer) ([]record.Record, []error) {
+	gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherHostSubnet(g.ctx, gatherNetworkClient)
 }
+
 func gatherHostSubnet(ctx context.Context, networkClient networkv1client.NetworkV1Interface) ([]record.Record, []error) {
 	hostSubnetList, err := networkClient.HostSubnets().List(ctx, metav1.ListOptions{})
 	if errors.IsNotFound(err) {

--- a/pkg/gather/clusterconfig/image_pruners.go
+++ b/pkg/gather/clusterconfig/image_pruners.go
@@ -21,6 +21,7 @@ import (
 // GatherClusterImagePruner fetches the image pruner configuration
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
+// Id in config: image_pruners
 func GatherClusterImagePruner(g *Gatherer) ([]record.Record, []error) {
 	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/image_pruners.go
+++ b/pkg/gather/clusterconfig/image_pruners.go
@@ -21,14 +21,12 @@ import (
 // GatherClusterImagePruner fetches the image pruner configuration
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
-func GatherClusterImagePruner(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterImagePruner(g.ctx, registryClient.ImageregistryV1())
+func GatherClusterImagePruner(g *Gatherer) ([]record.Record, []error) {
+	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterImagePruner(g.ctx, registryClient.ImageregistryV1())
 }
 
 func gatherClusterImagePruner(ctx context.Context, registryClient imageregistryv1.ImageregistryV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/image_registries.go
+++ b/pkg/gather/clusterconfig/image_registries.go
@@ -21,6 +21,7 @@ import (
 // GatherClusterImageRegistry fetches the cluster Image Registry configuration
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
+// Id in config: image_registries
 func GatherClusterImageRegistry(g *Gatherer) ([]record.Record, []error) {
 	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/image_registries.go
+++ b/pkg/gather/clusterconfig/image_registries.go
@@ -21,14 +21,12 @@ import (
 // GatherClusterImageRegistry fetches the cluster Image Registry configuration
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
-func GatherClusterImageRegistry(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterImageRegistry(g.ctx, registryClient.ImageregistryV1())
+func GatherClusterImageRegistry(g *Gatherer) ([]record.Record, []error) {
+	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterImageRegistry(g.ctx, registryClient.ImageregistryV1())
 }
 
 func gatherClusterImageRegistry(ctx context.Context, registryClient imageregistryv1.ImageregistryV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/infrastructures.go
+++ b/pkg/gather/clusterconfig/infrastructures.go
@@ -21,14 +21,12 @@ import (
 //
 // Location in archive: config/infrastructure/
 // See: docs/insights-archive-sample/config/infrastructure
-func GatherClusterInfrastructure(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterInfrastructure(g.ctx, gatherConfigClient)
+func GatherClusterInfrastructure(g *Gatherer) ([]record.Record, []error) {
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterInfrastructure(g.ctx, gatherConfigClient)
 }
 
 func gatherClusterInfrastructure(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/infrastructures.go
+++ b/pkg/gather/clusterconfig/infrastructures.go
@@ -21,6 +21,7 @@ import (
 //
 // Location in archive: config/infrastructure/
 // See: docs/insights-archive-sample/config/infrastructure
+// Id in config: infrastructures
 func GatherClusterInfrastructure(g *Gatherer) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/ingresses.go
+++ b/pkg/gather/clusterconfig/ingresses.go
@@ -21,14 +21,12 @@ import (
 //
 // Location in archive: config/ingress/
 // See: docs/insights-archive-sample/config/ingress
-func GatherClusterIngress(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterIngress(g.ctx, gatherConfigClient)
+func GatherClusterIngress(g *Gatherer) ([]record.Record, []error) {
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterIngress(g.ctx, gatherConfigClient)
 }
 
 func gatherClusterIngress(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/ingresses.go
+++ b/pkg/gather/clusterconfig/ingresses.go
@@ -21,6 +21,7 @@ import (
 //
 // Location in archive: config/ingress/
 // See: docs/insights-archive-sample/config/ingress
+// Id in config: ingress
 func GatherClusterIngress(g *Gatherer) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/install_plans.go
+++ b/pkg/gather/clusterconfig/install_plans.go
@@ -31,6 +31,7 @@ const InstallPlansTopX = 100
 // The Operators-Framework api https://github.com/operator-framework/api/blob/master/pkg/operators/v1alpha1/installplan_types.go#L26
 //
 // Location in archive: config/installplans/
+// Id in config: install_plans
 func GatherInstallPlans(g *Gatherer) ([]record.Record, []error) {
 	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/install_plans.go
+++ b/pkg/gather/clusterconfig/install_plans.go
@@ -31,18 +31,16 @@ const InstallPlansTopX = 100
 // The Operators-Framework api https://github.com/operator-framework/api/blob/master/pkg/operators/v1alpha1/installplan_types.go#L26
 //
 // Location in archive: config/installplans/
-func GatherInstallPlans(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherInstallPlans(g.ctx, dynamicClient, gatherKubeClient.CoreV1())
+func GatherInstallPlans(g *Gatherer) ([]record.Record, []error) {
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherInstallPlans(g.ctx, dynamicClient, gatherKubeClient.CoreV1())
 }
 
 func gatherInstallPlans(ctx context.Context, dynamicClient dynamic.Interface, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/machine_config_pools.go
+++ b/pkg/gather/clusterconfig/machine_config_pools.go
@@ -20,14 +20,12 @@ import (
 // Response see https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.html
 //
 // Location in archive: config/machineconfigpools/
-func GatherMachineConfigPool(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherMachineConfigPool(g.ctx, dynamicClient)
+func GatherMachineConfigPool(g *Gatherer) ([]record.Record, []error) {
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherMachineConfigPool(g.ctx, dynamicClient)
 }
 
 func gatherMachineConfigPool(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/machine_config_pools.go
+++ b/pkg/gather/clusterconfig/machine_config_pools.go
@@ -20,6 +20,7 @@ import (
 // Response see https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.html
 //
 // Location in archive: config/machineconfigpools/
+// Id in config: machine_config_pools
 func GatherMachineConfigPool(g *Gatherer) ([]record.Record, []error) {
 	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/machine_sets.go
+++ b/pkg/gather/clusterconfig/machine_sets.go
@@ -20,14 +20,12 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machineset-v1beta1-machine-openshift-io
 //
 // Location in archive: machinesets/
-func GatherMachineSet(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherMachineSet(g.ctx, dynamicClient)
+func GatherMachineSet(g *Gatherer) ([]record.Record, []error) {
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherMachineSet(g.ctx, dynamicClient)
 }
 
 func gatherMachineSet(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/machine_sets.go
+++ b/pkg/gather/clusterconfig/machine_sets.go
@@ -20,6 +20,7 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machineset-v1beta1-machine-openshift-io
 //
 // Location in archive: machinesets/
+// Id in config: machine_sets
 func GatherMachineSet(g *Gatherer) ([]record.Record, []error) {
 	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/netnamespaces.go
+++ b/pkg/gather/clusterconfig/netnamespaces.go
@@ -26,15 +26,14 @@ type netNamespace struct {
 // Response is an array of netNamespaces. Netnamespace contains Name, EgressIPs and NetID attributes.
 //
 // Location in archive: config/netnamespaces
-func GatherNetNamespace(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherNetNamespace(g.ctx, gatherNetworkClient)
+func GatherNetNamespace(g *Gatherer) ([]record.Record, []error) {
+	gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherNetNamespace(g.ctx, gatherNetworkClient)
 }
+
 func gatherNetNamespace(ctx context.Context, networkClient networkv1client.NetworkV1Interface) ([]record.Record, []error) {
 	nsList, err := networkClient.NetNamespaces().List(ctx, metav1.ListOptions{})
 	if errors.IsNotFound(err) {

--- a/pkg/gather/clusterconfig/netnamespaces.go
+++ b/pkg/gather/clusterconfig/netnamespaces.go
@@ -26,6 +26,7 @@ type netNamespace struct {
 // Response is an array of netNamespaces. Netnamespace contains Name, EgressIPs and NetID attributes.
 //
 // Location in archive: config/netnamespaces
+// Id in config: netnamespaces
 func GatherNetNamespace(g *Gatherer) ([]record.Record, []error) {
 	gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/networks.go
+++ b/pkg/gather/clusterconfig/networks.go
@@ -19,14 +19,12 @@ import (
 //
 // Location in archive: config/network/
 // See: docs/insights-archive-sample/config/network
-func GatherClusterNetwork(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterNetwork(g.ctx, gatherConfigClient)
+func GatherClusterNetwork(g *Gatherer) ([]record.Record, []error) {
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterNetwork(g.ctx, gatherConfigClient)
 }
 
 func gatherClusterNetwork(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/networks.go
+++ b/pkg/gather/clusterconfig/networks.go
@@ -19,6 +19,7 @@ import (
 //
 // Location in archive: config/network/
 // See: docs/insights-archive-sample/config/network
+// Id in config: networks
 func GatherClusterNetwork(g *Gatherer) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/nodes.go
+++ b/pkg/gather/clusterconfig/nodes.go
@@ -22,14 +22,12 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core
 //
 // Location in archive: config/node/
-func GatherNodes(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherNodes(g.ctx, gatherKubeClient.CoreV1())
+func GatherNodes(g *Gatherer) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherNodes(g.ctx, gatherKubeClient.CoreV1())
 }
 
 func gatherNodes(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/nodes.go
+++ b/pkg/gather/clusterconfig/nodes.go
@@ -22,6 +22,7 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core
 //
 // Location in archive: config/node/
+// Id in config: nodes
 func GatherNodes(g *Gatherer) ([]record.Record, []error) {
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/oauths.go
+++ b/pkg/gather/clusterconfig/oauths.go
@@ -19,6 +19,7 @@ import (
 //
 // Location in archive: config/oauth/
 // See: docs/insights-archive-sample/config/oauth
+// Id in config: oauths
 func GatherClusterOAuth(g *Gatherer) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/oauths.go
+++ b/pkg/gather/clusterconfig/oauths.go
@@ -19,14 +19,12 @@ import (
 //
 // Location in archive: config/oauth/
 // See: docs/insights-archive-sample/config/oauth
-func GatherClusterOAuth(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterOAuth(g.ctx, gatherConfigClient)
+func GatherClusterOAuth(g *Gatherer) ([]record.Record, []error) {
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterOAuth(g.ctx, gatherConfigClient)
 }
 
 func gatherClusterOAuth(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/operators.go
+++ b/pkg/gather/clusterconfig/operators.go
@@ -54,6 +54,7 @@ type clusterOperatorResource struct {
 // Location of operators in archive: config/clusteroperator/
 // See: docs/insights-archive-sample/config/clusteroperator
 // Location of pods in archive: config/pod/
+// Id in config: operators
 func GatherClusterOperators(g *Gatherer) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/operators.go
+++ b/pkg/gather/clusterconfig/operators.go
@@ -54,26 +54,24 @@ type clusterOperatorResource struct {
 // Location of operators in archive: config/clusteroperator/
 // See: docs/insights-archive-sample/config/clusteroperator
 // Location of pods in archive: config/pod/
-func GatherClusterOperators(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		discoveryClient, err := discovery.NewDiscoveryClientForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterOperators(g.ctx, gatherConfigClient, gatherKubeClient.CoreV1(), discoveryClient, dynamicClient)
+func GatherClusterOperators(g *Gatherer) ([]record.Record, []error) {
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherClusterOperators(g.ctx, gatherConfigClient, gatherKubeClient.CoreV1(), discoveryClient, dynamicClient)
 }
 
 func gatherClusterOperators(ctx context.Context, configClient configv1client.ConfigV1Interface, coreClient corev1client.CoreV1Interface, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/pod_disruption_budgets.go
+++ b/pkg/gather/clusterconfig/pod_disruption_budgets.go
@@ -31,14 +31,12 @@ var (
 //
 // Location in archive: config/pdbs/
 // See: docs/insights-archive-sample/config/pdbs
-func GatherPodDisruptionBudgets(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherPodDisruptionBudgets(g.ctx, gatherPolicyClient)
+func GatherPodDisruptionBudgets(g *Gatherer) ([]record.Record, []error) {
+	gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherPodDisruptionBudgets(g.ctx, gatherPolicyClient)
 }
 
 func gatherPodDisruptionBudgets(ctx context.Context, policyClient policyclient.PolicyV1beta1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/pod_disruption_budgets.go
+++ b/pkg/gather/clusterconfig/pod_disruption_budgets.go
@@ -31,6 +31,7 @@ var (
 //
 // Location in archive: config/pdbs/
 // See: docs/insights-archive-sample/config/pdbs
+// Id in config: pdbs
 func GatherPodDisruptionBudgets(g *Gatherer) ([]record.Record, []error) {
 	gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/proxies.go
+++ b/pkg/gather/clusterconfig/proxies.go
@@ -21,14 +21,12 @@ import (
 //
 // Location in archive: config/proxy/
 // See: docs/insights-archive-sample/config/proxy
-func GatherClusterProxy(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherClusterProxy(g.ctx, gatherConfigClient)
+func GatherClusterProxy(g *Gatherer) ([]record.Record, []error) {
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherClusterProxy(g.ctx, gatherConfigClient)
 }
 
 func gatherClusterProxy(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/proxies.go
+++ b/pkg/gather/clusterconfig/proxies.go
@@ -21,6 +21,7 @@ import (
 //
 // Location in archive: config/proxy/
 // See: docs/insights-archive-sample/config/proxy
+// Id in config: proxies
 func GatherClusterProxy(g *Gatherer) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/recent_metrics.go
+++ b/pkg/gather/clusterconfig/recent_metrics.go
@@ -31,6 +31,7 @@ const (
 //
 // Location in archive: config/metrics/
 // See: docs/insights-archive-sample/config/metrics
+// Id in config: metrics
 func GatherMostRecentMetrics(g *Gatherer) ([]record.Record, []error) {
 	var metricsClient rest.Interface
 	metricsRESTClient, err := rest.RESTClientFor(g.metricsGatherKubeConfig)

--- a/pkg/gather/clusterconfig/recent_metrics.go
+++ b/pkg/gather/clusterconfig/recent_metrics.go
@@ -31,20 +31,18 @@ const (
 //
 // Location in archive: config/metrics/
 // See: docs/insights-archive-sample/config/metrics
-func GatherMostRecentMetrics(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		var metricsClient rest.Interface
-		metricsRESTClient, err := rest.RESTClientFor(g.metricsGatherKubeConfig)
-		if err != nil {
-			klog.Warningf("Unable to load metrics client, no metrics will be collected: %v", err)
-		} else {
-			metricsClient = metricsRESTClient
-		}
-		if metricsClient == nil {
-			return nil, nil
-		}
-		return gatherMostRecentMetrics(g.ctx, metricsClient)
+func GatherMostRecentMetrics(g *Gatherer) ([]record.Record, []error) {
+	var metricsClient rest.Interface
+	metricsRESTClient, err := rest.RESTClientFor(g.metricsGatherKubeConfig)
+	if err != nil {
+		klog.Warningf("Unable to load metrics client, no metrics will be collected: %v", err)
+	} else {
+		metricsClient = metricsRESTClient
 	}
+	if metricsClient == nil {
+		return nil, nil
+	}
+	return gatherMostRecentMetrics(g.ctx, metricsClient)
 }
 
 func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/service_accounts.go
+++ b/pkg/gather/clusterconfig/service_accounts.go
@@ -29,6 +29,7 @@ const maxServiceAccountsLimit = 1000
 //
 // Location of serviceaccounts in archive: config/serviceaccounts
 // See: docs/insights-archive-sample/config/serviceaccounts
+// Id in config: service_accounts
 func GatherServiceAccounts(g *Gatherer) ([]record.Record, []error) {
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/service_accounts.go
+++ b/pkg/gather/clusterconfig/service_accounts.go
@@ -29,14 +29,12 @@ const maxServiceAccountsLimit = 1000
 //
 // Location of serviceaccounts in archive: config/serviceaccounts
 // See: docs/insights-archive-sample/config/serviceaccounts
-func GatherServiceAccounts(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherServiceAccounts(g.ctx, gatherKubeClient.CoreV1())
+func GatherServiceAccounts(g *Gatherer) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return gatherServiceAccounts(g.ctx, gatherKubeClient.CoreV1())
 }
 
 func gatherServiceAccounts(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/stateful_sets.go
+++ b/pkg/gather/clusterconfig/stateful_sets.go
@@ -25,6 +25,7 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.5/rest_api/workloads_apis/statefulset-apps-v1.html#statefulset-apps-v1
 //
 // Location in archive: config/statefulsets/
+// Id in config: stateful_sets
 func GatherStatefulSets(g *Gatherer) ([]record.Record, []error) {
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/stateful_sets.go
+++ b/pkg/gather/clusterconfig/stateful_sets.go
@@ -25,18 +25,16 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.5/rest_api/workloads_apis/statefulset-apps-v1.html#statefulset-apps-v1
 //
 // Location in archive: config/statefulsets/
-func GatherStatefulSets(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		appsClient, err := appsclient.NewForConfig(g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return gatherStatefulSets(g.ctx, gatherKubeClient.CoreV1(), appsClient)
+func GatherStatefulSets(g *Gatherer) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	appsClient, err := appsclient.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherStatefulSets(g.ctx, gatherKubeClient.CoreV1(), appsClient)
 }
 
 func gatherStatefulSets(ctx context.Context, coreClient corev1client.CoreV1Interface, appsClient appsclient.AppsV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/version.go
+++ b/pkg/gather/clusterconfig/version.go
@@ -22,14 +22,12 @@ import (
 //
 // Location in archive: config/version/
 // See: docs/insights-archive-sample/config/version
-func GatherClusterVersion(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		config, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		return []record.Record{{Name: "config/version", Item: ClusterVersionAnonymizer{config}}}, nil
+func GatherClusterVersion(g *Gatherer) ([]record.Record, []error) {
+	config, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	return []record.Record{{Name: "config/version", Item: ClusterVersionAnonymizer{config}}}, nil
 }
 
 func GetClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.ClusterVersion, error) {
@@ -47,7 +45,6 @@ func GetClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.
 	return config, nil
 }
 
-
 // GatherClusterID stores ClusterID from ClusterVersion version
 // This method uses data already collected by Get ClusterVersion. In particular field .Spec.ClusterID
 // The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusterversion.go#L50
@@ -55,17 +52,15 @@ func GetClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.
 //
 // Location in archive: config/id/
 // See: docs/insights-archive-sample/config/id
-func GatherClusterID(g *Gatherer) func() ([]record.Record, []error) {
-	return func() ([]record.Record, []error) {
-		version, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
-		if version == nil {
-			return nil, nil
-		}
-		return []record.Record{{Name: "config/id", Item: Raw{string(version.Spec.ClusterID)}}}, nil
+func GatherClusterID(g *Gatherer) ([]record.Record, []error) {
+	version, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
 	}
+	if version == nil {
+		return nil, nil
+	}
+	return []record.Record{{Name: "config/id", Item: Raw{string(version.Spec.ClusterID)}}}, nil
 }
 
 // ClusterVersionAnonymizer is serializing ClusterVersion with anonymization

--- a/pkg/gather/clusterconfig/version.go
+++ b/pkg/gather/clusterconfig/version.go
@@ -22,6 +22,7 @@ import (
 //
 // Location in archive: config/version/
 // See: docs/insights-archive-sample/config/version
+// Id in config: version
 func GatherClusterVersion(g *Gatherer) ([]record.Record, []error) {
 	config, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
 	if err != nil {
@@ -52,6 +53,7 @@ func GetClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.
 //
 // Location in archive: config/id/
 // See: docs/insights-archive-sample/config/id
+// Id in config: id
 func GatherClusterID(g *Gatherer) ([]record.Record, []error) {
 	version, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/interface.go
+++ b/pkg/gather/interface.go
@@ -7,5 +7,6 @@ import (
 )
 
 type Interface interface {
-	Gather(context.Context, record.Interface) error
+	Gather(context.Context, []string, record.Interface) error
 }
+

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/pkg/version"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -28,6 +29,7 @@ import (
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 
 	"github.com/openshift/insights-operator/pkg/authorizer"
+	clusterconfig "github.com/openshift/insights-operator/pkg/gather/clusterconfig"
 )
 
 const (
@@ -35,21 +37,18 @@ const (
 )
 
 type Client struct {
-	client      *http.Client
-	maxBytes    int64
-	metricsName string
+	client      		*http.Client
+	maxBytes    		int64
+	metricsName 		string
 
-	authorizer  Authorizer
-	clusterInfo ClusterVersionInfo
+	authorizer  		Authorizer
+	gatherKubeConfig	*rest.Config
+	clusterVersion  	*configv1.ClusterVersion
 }
 
 type Authorizer interface {
 	Authorize(req *http.Request) error
 	NewSystemOrConfiguredProxy() func(*http.Request) (*url.URL, error)
-}
-
-type ClusterVersionInfo interface {
-	ClusterVersion() *configv1.ClusterVersion
 }
 
 type Source struct {
@@ -61,7 +60,7 @@ type Source struct {
 var ErrWaitingForVersion = fmt.Errorf("waiting for the cluster version to be loaded")
 
 // New creates a Client
-func New(client *http.Client, maxBytes int64, metricsName string, authorizer Authorizer, clusterInfo ClusterVersionInfo) *Client {
+func New(client *http.Client, maxBytes int64, metricsName string, authorizer Authorizer, gatherKubeConfig *rest.Config) *Client {
 	if client == nil {
 		client = &http.Client{}
 	}
@@ -69,11 +68,11 @@ func New(client *http.Client, maxBytes int64, metricsName string, authorizer Aut
 		maxBytes = 10 * 1024 * 1024
 	}
 	return &Client{
-		client:      client,
-		maxBytes:    maxBytes,
-		metricsName: metricsName,
-		authorizer:  authorizer,
-		clusterInfo: clusterInfo,
+		client:      		client,
+		maxBytes:    		maxBytes,
+		metricsName: 		metricsName,
+		authorizer:  		authorizer,
+		gatherKubeConfig:	gatherKubeConfig,
 	}
 }
 
@@ -130,6 +129,19 @@ func userAgent(releaseVersionEnv string, v apimachineryversion.Info, cv *configv
 	return fmt.Sprintf("insights-operator/%s cluster/%s", gitVersion, cv.Spec.ClusterID)
 }
 
+func (c *Client) getClusterVersion() (*configv1.ClusterVersion, error) {
+	if c.clusterVersion != nil {
+		return c.clusterVersion, nil
+	}
+	ctx := context.Background()
+	cv, err := clusterconfig.GetClusterVersion(ctx, c.gatherKubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	c.clusterVersion = cv
+	return cv, nil
+}
+
 func (c Client) prepareRequest(ctx context.Context, method string, endpoint string, cv *configv1.ClusterVersion) (*http.Request, error) {
 	req, err := http.NewRequest(method, endpoint, nil)
 	if err != nil {
@@ -152,7 +164,10 @@ func (c Client) prepareRequest(ctx context.Context, method string, endpoint stri
 
 // Send uploads archives to Ingress service
 func (c *Client) Send(ctx context.Context, endpoint string, source Source) error {
-	cv := c.clusterInfo.ClusterVersion()
+	cv, err := c.getClusterVersion()
+	if err != nil {
+		return err
+	}
 	if cv == nil {
 		return ErrWaitingForVersion
 	}
@@ -238,7 +253,10 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 
 // RecvReport perform a request to Insights Results Smart Proxy endpoint
 func (c Client) RecvReport(ctx context.Context, endpoint string) (*io.ReadCloser, error) {
-	cv := c.clusterInfo.ClusterVersion()
+	cv, err := c.getClusterVersion()
+	if err != nil {
+		return nil, err
+	}
 	if cv == nil {
 		return nil, ErrWaitingForVersion
 	}

--- a/pkg/record/interface.go
+++ b/pkg/record/interface.go
@@ -3,14 +3,7 @@ package record
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"reflect"
-	"runtime"
-	"sort"
-	"strings"
 	"time"
-
-	"k8s.io/klog"
 )
 
 type Interface interface {
@@ -46,75 +39,4 @@ func (m JSONMarshaller) Marshal(_ context.Context) ([]byte, error) {
 // GetExtension return extension for json marshaller
 func (m JSONMarshaller) GetExtension() string {
 	return "json"
-}
-
-type gatherStatusReport struct {
-	Name    string        `json:"name"`
-	Elapsed time.Duration `json:"elapsed"`
-	Report  int           `json:"report"`
-	Errors  []error       `json:"errors"`
-}
-
-// Collect is a helper for gathering a large set of records from generic functions.
-func Collect(ctx context.Context, recorder Interface, bulkFns ...func() ([]Record, []error)) error {
-	var errors []string
-	var gatherReport []interface{}
-	for _, bulkFn := range bulkFns {
-		gatherName := runtime.FuncForPC(reflect.ValueOf(bulkFn).Pointer()).Name()
-		klog.V(5).Infof("Gathering %s", gatherName)
-
-		start := time.Now()
-		records, errs := bulkFn()
-		elapsed := time.Now().Sub(start).Truncate(time.Millisecond)
-
-		klog.V(4).Infof("Gather %s took %s to process %d records", gatherName, elapsed, len(records))
-		gatherReport = append(gatherReport, gatherStatusReport{gatherName, elapsed, len(records), errs})
-
-		for _, err := range errs {
-			errors = append(errors, err.Error())
-		}
-		for _, record := range records {
-			if err := recorder.Record(record); err != nil {
-				errors = append(errors, fmt.Sprintf("unable to record %s: %v", record.Name, err))
-				continue
-			}
-		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-	}
-
-	// Creates the gathering performance report
-	if err := recordGatherReport(recorder, gatherReport); err != nil {
-		errors = append(errors, fmt.Sprintf("unable to record io status reports: %v", err))
-	}
-
-	if len(errors) > 0 {
-		sort.Strings(errors)
-		errors = uniqueStrings(errors)
-		return fmt.Errorf("%s", strings.Join(errors, ", "))
-	}
-	return nil
-}
-
-func recordGatherReport(recorder Interface, report []interface{}) error {
-	r := Record{Name: "insights-operator/gathers", Item: JSONMarshaller{Object: report}}
-	return recorder.Record(r)
-}
-
-func uniqueStrings(arr []string) []string {
-	var last int
-	for i := 1; i < len(arr); i++ {
-		if arr[i] == arr[last] {
-			continue
-		}
-		last++
-		if last != i {
-			arr[last] = arr[i]
-		}
-	}
-	if last < len(arr) {
-		last++
-	}
-	return arr[:last]
 }


### PR DESCRIPTION
The `record` package is currently is the place where the gather-functions are actually run and it also responsible for storing the output. This is to much responsibility for one component and we have the `Gatherer` which only collects the gather-functions but not actually runs them.

So the `record`package should only care about the storing of the data and not actually creating it, and the `Gatherer` should be responsible for managing the the gather-functions. (by managing I mean: deciding which to run, handling errors for gathering, [in the future] syncing up the multi-threaded workloads of the gather-functions)

This will allow us to have greater control over how the gathering is done, and will simplify the code base.

Also insightsclient is somewhat linked to  GatherClusterVersion, it undoes this link.

Furthermore makes the gathering configurable via the yaml config.

## Categories
- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample archive
- Not necessary

## Documentation
- `docs/arch.md` and `docs/gathered-data.md`  have been updated

## Unit Tests
- No new unit tests, old ones have been moved and renamed. (`record/interface_test.go` --> `gather/clusterconfig/0_gatherer_test.go`)

## Privacy
No new data is collected.

## References
https://issues.redhat.com/browse/CCXDEV-3506