### PR TITLE
Bug 1904413: Fix hostsubnet gathering and add to sample archive

### DIFF
--- a/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-master-0.json
+++ b/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-master-0.json
@@ -1,0 +1,38 @@
+{
+    "kind": "HostSubnet",
+    "apiVersion": "network.openshift.io/v1",
+    "metadata": {
+        "name": "ci-ln-iffptmb-f76d1-nhwgd-master-0",
+        "selfLink": "/apis/network.openshift.io/v1/hostsubnets/ci-ln-iffptmb-f76d1-nhwgd-master-0",
+        "uid": "ba02b433-fe1c-4558-bc30-47c1245cc7e8",
+        "resourceVersion": "3259",
+        "generation": 1,
+        "creationTimestamp": "2020-12-02T13:47:00Z",
+        "annotations": {
+            "pod.network.openshift.io/node-uid": "d392507b-5c7f-4332-8400-f0cb3ae2ea13"
+        },
+        "managedFields": [
+            {
+                "manager": "openshift-sdn-controller",
+                "operation": "Update",
+                "apiVersion": "network.openshift.io/v1",
+                "time": "2020-12-02T13:47:00Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:host": {},
+                    "f:hostIP": {},
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:pod.network.openshift.io/node-uid": {}
+                        }
+                    },
+                    "f:subnet": {}
+                }
+            }
+        ]
+    },
+    "host": "ci-ln-iffptmb-f76d1-nhwgd-master-0",
+    "hostIP": "xxxxxxxx",
+    "subnet": "xxxxxxxxxxxxx"
+}

--- a/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-master-1.json
+++ b/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-master-1.json
@@ -1,0 +1,38 @@
+{
+    "kind": "HostSubnet",
+    "apiVersion": "network.openshift.io/v1",
+    "metadata": {
+        "name": "ci-ln-iffptmb-f76d1-nhwgd-master-1",
+        "selfLink": "/apis/network.openshift.io/v1/hostsubnets/ci-ln-iffptmb-f76d1-nhwgd-master-1",
+        "uid": "8fb03f7e-daee-4ee7-85ea-c9e593f1df45",
+        "resourceVersion": "3300",
+        "generation": 1,
+        "creationTimestamp": "2020-12-02T13:47:01Z",
+        "annotations": {
+            "pod.network.openshift.io/node-uid": "ac4124f9-6413-43b7-874f-143d28d26515"
+        },
+        "managedFields": [
+            {
+                "manager": "openshift-sdn-controller",
+                "operation": "Update",
+                "apiVersion": "network.openshift.io/v1",
+                "time": "2020-12-02T13:47:01Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:host": {},
+                    "f:hostIP": {},
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:pod.network.openshift.io/node-uid": {}
+                        }
+                    },
+                    "f:subnet": {}
+                }
+            }
+        ]
+    },
+    "host": "ci-ln-iffptmb-f76d1-nhwgd-master-1",
+    "hostIP": "xxxxxxxx",
+    "subnet": "xxxxxxxxxxxxx"
+}

--- a/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-master-2.json
+++ b/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-master-2.json
@@ -1,0 +1,38 @@
+{
+    "kind": "HostSubnet",
+    "apiVersion": "network.openshift.io/v1",
+    "metadata": {
+        "name": "ci-ln-iffptmb-f76d1-nhwgd-master-2",
+        "selfLink": "/apis/network.openshift.io/v1/hostsubnets/ci-ln-iffptmb-f76d1-nhwgd-master-2",
+        "uid": "f4ee1029-f09c-42cf-a2ef-2a10361de269",
+        "resourceVersion": "3284",
+        "generation": 1,
+        "creationTimestamp": "2020-12-02T13:47:01Z",
+        "annotations": {
+            "pod.network.openshift.io/node-uid": "c12a71e5-ec7e-4534-99b0-fdd027d74460"
+        },
+        "managedFields": [
+            {
+                "manager": "openshift-sdn-controller",
+                "operation": "Update",
+                "apiVersion": "network.openshift.io/v1",
+                "time": "2020-12-02T13:47:01Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:host": {},
+                    "f:hostIP": {},
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:pod.network.openshift.io/node-uid": {}
+                        }
+                    },
+                    "f:subnet": {}
+                }
+            }
+        ]
+    },
+    "host": "ci-ln-iffptmb-f76d1-nhwgd-master-2",
+    "hostIP": "xxxxxxxx",
+    "subnet": "xxxxxxxxxxxxx"
+}

--- a/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-worker-b-56nwr.json
+++ b/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-worker-b-56nwr.json
@@ -1,0 +1,38 @@
+{
+    "kind": "HostSubnet",
+    "apiVersion": "network.openshift.io/v1",
+    "metadata": {
+        "name": "ci-ln-iffptmb-f76d1-nhwgd-worker-b-56nwr",
+        "selfLink": "/apis/network.openshift.io/v1/hostsubnets/ci-ln-iffptmb-f76d1-nhwgd-worker-b-56nwr",
+        "uid": "dd0abb76-6e1f-4e86-b8c1-4047d1d4da51",
+        "resourceVersion": "17494",
+        "generation": 1,
+        "creationTimestamp": "2020-12-02T13:55:23Z",
+        "annotations": {
+            "pod.network.openshift.io/node-uid": "98b24621-4b5a-41fe-82a8-c5992f66662d"
+        },
+        "managedFields": [
+            {
+                "manager": "openshift-sdn-controller",
+                "operation": "Update",
+                "apiVersion": "network.openshift.io/v1",
+                "time": "2020-12-02T13:55:23Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:host": {},
+                    "f:hostIP": {},
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:pod.network.openshift.io/node-uid": {}
+                        }
+                    },
+                    "f:subnet": {}
+                }
+            }
+        ]
+    },
+    "host": "ci-ln-iffptmb-f76d1-nhwgd-worker-b-56nwr",
+    "hostIP": "xxxxxxxxx",
+    "subnet": "xxxxxxxxxxxxx"
+}

--- a/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-worker-c-wkwh7.json
+++ b/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-worker-c-wkwh7.json
@@ -1,0 +1,38 @@
+{
+    "kind": "HostSubnet",
+    "apiVersion": "network.openshift.io/v1",
+    "metadata": {
+        "name": "ci-ln-iffptmb-f76d1-nhwgd-worker-c-wkwh7",
+        "selfLink": "/apis/network.openshift.io/v1/hostsubnets/ci-ln-iffptmb-f76d1-nhwgd-worker-c-wkwh7",
+        "uid": "de2d7ef0-b92f-4c6b-b28d-a21f4637eb93",
+        "resourceVersion": "17560",
+        "generation": 1,
+        "creationTimestamp": "2020-12-02T13:55:23Z",
+        "annotations": {
+            "pod.network.openshift.io/node-uid": "4e4b280b-2b08-4fe4-91cb-463deee0a8d6"
+        },
+        "managedFields": [
+            {
+                "manager": "openshift-sdn-controller",
+                "operation": "Update",
+                "apiVersion": "network.openshift.io/v1",
+                "time": "2020-12-02T13:55:23Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:host": {},
+                    "f:hostIP": {},
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:pod.network.openshift.io/node-uid": {}
+                        }
+                    },
+                    "f:subnet": {}
+                }
+            }
+        ]
+    },
+    "host": "ci-ln-iffptmb-f76d1-nhwgd-worker-c-wkwh7",
+    "hostIP": "xxxxxxxxx",
+    "subnet": "xxxxxxxxxxxxx"
+}

--- a/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-worker-d-mdwl8.json
+++ b/docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-worker-d-mdwl8.json
@@ -1,0 +1,38 @@
+{
+    "kind": "HostSubnet",
+    "apiVersion": "network.openshift.io/v1",
+    "metadata": {
+        "name": "ci-ln-iffptmb-f76d1-nhwgd-worker-d-mdwl8",
+        "selfLink": "/apis/network.openshift.io/v1/hostsubnets/ci-ln-iffptmb-f76d1-nhwgd-worker-d-mdwl8",
+        "uid": "f6ea2075-e132-4d7f-a2be-3d62fae85f85",
+        "resourceVersion": "17142",
+        "generation": 1,
+        "creationTimestamp": "2020-12-02T13:55:17Z",
+        "annotations": {
+            "pod.network.openshift.io/node-uid": "01cbed7d-ca7c-48df-86dd-ea140b8b4c94"
+        },
+        "managedFields": [
+            {
+                "manager": "openshift-sdn-controller",
+                "operation": "Update",
+                "apiVersion": "network.openshift.io/v1",
+                "time": "2020-12-02T13:55:17Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:host": {},
+                    "f:hostIP": {},
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:pod.network.openshift.io/node-uid": {}
+                        }
+                    },
+                    "f:subnet": {}
+                }
+            }
+        ]
+    },
+    "host": "ci-ln-iffptmb-f76d1-nhwgd-worker-d-mdwl8",
+    "hostIP": "xxxxxxxxx",
+    "subnet": "xxxxxxxxxxxxx"
+}

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -483,16 +483,16 @@ func GatherClusterNetwork(i *Gatherer) func() ([]record.Record, []error) {
 // Location in archive: config/hostsubnet/
 func GatherHostSubnet(i *Gatherer) func() ([]record.Record, []error) {
 	return func() ([]record.Record, []error) {
-		hostSubnetList, err := i.networkClient.HostSubnets().List(metav1.ListOptions{})
+		hsList, err := i.networkClient.HostSubnets().List(metav1.ListOptions{})
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
 		if err != nil {
 			return nil, []error{err}
 		}
-		records := make([]record.Record, 0, len(hostSubnetList.Items))
-		for _, h := range hostSubnetList.Items {
-			records = append(records, record.Record{Name: fmt.Sprintf("config/hostsubnet/%s", h.Host), Item: HostSubnetAnonymizer{&h}})
+		records := make([]record.Record, 0, len(hsList.Items))
+		for i, h := range hsList.Items {
+			records = append(records, record.Record{Name: fmt.Sprintf("config/hostsubnet/%s", h.Host), Item: HostSubnetAnonymizer{&hsList.Items[i]}})
 		}
 		return records, nil
 	}


### PR DESCRIPTION
… in the hostsubnet gathering
… in the hostsubnet gathering

<!-- Short description of the PR. What does it do? -->
This is bugfixing for hostsubnet gathering

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-master-0.json`
- `docs/insights-archive-sample/config/hostsubnet/ci-ln-iffptmb-f76d1-nhwgd-master-1.json`
- and more ....

## Documentation
<!-- Are these changes reflected in documentation? -->
- no need to update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- no update

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->
IP addresses in the hostsubnet definition already anonymized

## References
<!-- What are related references for this PR? -->

https://bugzilla.redhat.com/show_bug.cgi?id=1904413

