### PR TITLE
[release-4.5] Bug 1905106: Collect spec config for clusteroperator resources

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -48,14 +48,14 @@ See: docs/insights-archive-sample/config/id
 
 fetches the image pruner configuration
 
-Location in archive: config/imagepruner/
+Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
 
 
 ## ClusterImageRegistry
 
 fetches the cluster Image Registry configuration
 
-Location in archive: config/imageregistry/
+Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 
 
 ## ClusterInfrastructure
@@ -104,7 +104,7 @@ See: docs/insights-archive-sample/config/oauth
 
 ## ClusterOperators
 
-collects all ClusterOperators.
+collects all ClusterOperators and their resources.
 It finds unhealthy Pods for unhealthy operators
 
 The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusteroperator.go#L62

--- a/docs/insights-archive-sample/config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
@@ -1,0 +1,187 @@
+{
+    "kind": "Config",
+    "apiVersion": "imageregistry.operator.openshift.io/v1",
+    "metadata": {
+        "name": "cluster",
+        "selfLink": "/apis/imageregistry.operator.openshift.io/v1/configs/cluster",
+        "uid": "8351f32e-5524-41f1-8de2-78984e6c0c67",
+        "resourceVersion": "244895",
+        "generation": 5,
+        "creationTimestamp": "2020-11-23T15:55:34Z",
+        "finalizers": [
+            "imageregistry.operator.openshift.io/finalizer"
+        ],
+        "managedFields": [
+            {
+                "manager": "kubectl-patch",
+                "operation": "Update",
+                "apiVersion": "imageregistry.operator.openshift.io/v1",
+                "time": "2020-11-23T16:03:40Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:spec": {
+                        "f:managementState": {}
+                    }
+                }
+            },
+            {
+                "manager": "cluster-image-registry-operator",
+                "operation": "Update",
+                "apiVersion": "imageregistry.operator.openshift.io/v1",
+                "time": "2020-11-24T08:00:19Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:finalizers": {}
+                    },
+                    "f:spec": {
+                        ".": {},
+                        "f:logLevel": {},
+                        "f:observedConfig": {},
+                        "f:operatorLogLevel": {},
+                        "f:proxy": {},
+                        "f:replicas": {},
+                        "f:requests": {
+                            ".": {},
+                            "f:read": {
+                                ".": {},
+                                "f:maxWaitInQueue": {}
+                            },
+                            "f:write": {
+                                ".": {},
+                                "f:maxWaitInQueue": {}
+                            }
+                        },
+                        "f:rolloutStrategy": {},
+                        "f:storage": {},
+                        "f:unsupportedConfigOverrides": {}
+                    },
+                    "f:status": {
+                        ".": {},
+                        "f:conditions": {},
+                        "f:generations": {},
+                        "f:observedGeneration": {},
+                        "f:readyReplicas": {},
+                        "f:storage": {
+                            ".": {},
+                            "f:emptyDir": {},
+                            "f:managementState": {}
+                        },
+                        "f:storageManaged": {}
+                    }
+                }
+            },
+            {
+                "manager": "oc",
+                "operation": "Update",
+                "apiVersion": "imageregistry.operator.openshift.io/v1",
+                "time": "2020-11-24T08:00:19Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:spec": {
+                        "f:storage": {
+                            "f:gcs": {
+                                ".": {},
+                                "f:bucket": {},
+                                "f:projectID": {},
+                                "f:region": {}
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    },
+    "spec": {
+        "managementState": "Managed",
+        "httpSecret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "proxy": {},
+        "storage": {
+            "gcs": {
+                "bucket": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                "region": "us-east1",
+                "projectID": "xxxxxxxxxxxxxxxxxxxxxx"
+            }
+        },
+        "requests": {
+            "read": {
+                "maxWaitInQueue": "0s"
+            },
+            "write": {
+                "maxWaitInQueue": "0s"
+            }
+        },
+        "replicas": 1,
+        "logging": 0,
+        "rolloutStrategy": "RollingUpdate"
+    },
+    "status": {
+        "observedGeneration": 5,
+        "conditions": [
+            {
+                "type": "ImageRegistryCertificatesControllerDegraded",
+                "status": "False",
+                "lastTransitionTime": "2020-11-23T15:55:34Z",
+                "reason": "AsExpected"
+            },
+            {
+                "type": "NodeCADaemonControllerDegraded",
+                "status": "False",
+                "lastTransitionTime": "2020-11-23T15:55:34Z",
+                "reason": "AsExpected"
+            },
+            {
+                "type": "ImageConfigControllerDegraded",
+                "status": "False",
+                "lastTransitionTime": "2020-11-23T15:55:34Z",
+                "reason": "AsExpected"
+            },
+            {
+                "type": "Progressing",
+                "status": "True",
+                "lastTransitionTime": "2020-11-24T08:00:19Z",
+                "reason": "Error",
+                "message": "Unable to apply resources: unable to sync storage configuration: unable to get cluster minted credentials \"openshift-image-registry/installer-cloud-credentials\": secret \"installer-cloud-credentials\" not found"
+            },
+            {
+                "type": "Available",
+                "status": "True",
+                "lastTransitionTime": "2020-11-23T16:03:47Z",
+                "reason": "Ready",
+                "message": "The registry is ready"
+            },
+            {
+                "type": "Degraded",
+                "status": "False",
+                "lastTransitionTime": "2020-11-23T15:55:35Z"
+            },
+            {
+                "type": "Removed",
+                "status": "False",
+                "lastTransitionTime": "2020-11-23T16:03:40Z"
+            },
+            {
+                "type": "StorageExists",
+                "status": "Unknown",
+                "lastTransitionTime": "2020-11-24T08:00:19Z",
+                "reason": "GCS Configuration Changed",
+                "message": "GCS storage is in an unknown state"
+            }
+        ],
+        "readyReplicas": 0,
+        "generations": [
+            {
+                "group": "apps",
+                "resource": "deployments",
+                "namespace": "openshift-image-registry",
+                "name": "image-registry",
+                "lastGeneration": 2,
+                "hash": ""
+            }
+        ],
+        "storageManaged": true,
+        "storage": {
+            "emptyDir": {}
+        }
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
@@ -1,0 +1,77 @@
+{
+    "kind": "ImagePruner",
+    "apiVersion": "imageregistry.operator.openshift.io/v1",
+    "metadata": {
+        "name": "cluster",
+        "selfLink": "/apis/imageregistry.operator.openshift.io/v1/imagepruners/cluster",
+        "uid": "031c8096-d729-4104-9ac9-c679e71554f5",
+        "resourceVersion": "14600",
+        "generation": 1,
+        "creationTimestamp": "2020-11-23T15:48:19Z",
+        "managedFields": [
+            {
+                "manager": "cluster-image-registry-operator",
+                "operation": "Update",
+                "apiVersion": "imageregistry.operator.openshift.io/v1",
+                "time": "2020-11-23T15:55:34Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:spec": {
+                        ".": {},
+                        "f:failedJobsHistoryLimit": {},
+                        "f:ignoreInvalidImageReferences": {},
+                        "f:keepTagRevisions": {},
+                        "f:logLevel": {},
+                        "f:schedule": {},
+                        "f:successfulJobsHistoryLimit": {},
+                        "f:suspend": {}
+                    },
+                    "f:status": {
+                        ".": {},
+                        "f:conditions": {},
+                        "f:observedGeneration": {}
+                    }
+                }
+            }
+        ]
+    },
+    "spec": {
+        "schedule": "",
+        "suspend": false,
+        "keepTagRevisions": 3,
+        "successfulJobsHistoryLimit": 3,
+        "failedJobsHistoryLimit": 3
+    },
+    "status": {
+        "observedGeneration": 1,
+        "conditions": [
+            {
+                "type": "Available",
+                "status": "True",
+                "lastTransitionTime": "2020-11-23T15:55:34Z",
+                "reason": "AsExpected",
+                "message": "Pruner CronJob has been created"
+            },
+            {
+                "type": "Failed",
+                "status": "False",
+                "lastTransitionTime": "2020-11-23T15:48:19Z",
+                "reason": "Complete",
+                "message": "Pruner completed successfully"
+            },
+            {
+                "type": "Scheduled",
+                "status": "True",
+                "lastTransitionTime": "2020-11-23T15:48:19Z",
+                "reason": "Scheduled",
+                "message": "The pruner job has been scheduled"
+            },
+            {
+                "type": "Degraded",
+                "status": "False",
+                "lastTransitionTime": "2020-11-23T15:55:34Z",
+                "reason": "AsExpected"
+            }
+        ]
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/authentication/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/authentication/cluster.json
@@ -1,0 +1,80 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "Authentication",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": {
+            "oauthAPIServer": {
+                "apiServerArguments": {
+                    "audit-policy-file": [
+                        "/var/run/configmaps/audit/secure-oauth-storage-default.yaml"
+                    ],
+                    "cors-allowed-origins": [
+                        "//127\\.0\\.0\\.1(:|$)",
+                        "//localhost(:|$)"
+                    ],
+                    "etcd-servers": [
+                        "xxxxxxxxxxxxxxxxxxxxxxx"
+                    ],
+                    "tls-cipher-suites": [
+                        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+                    ],
+                    "tls-min-version": "VersionTLS12"
+                }
+            },
+            "oauthServer": {
+                "corsAllowedOrigins": [
+                    "//127\\.0\\.0\\.1(:|$)",
+                    "//localhost(:|$)"
+                ],
+                "oauthConfig": {
+                    "assetPublicURL": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                    "loginURL": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                    "templates": {
+                        "error": "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/errors.html",
+                        "login": "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/login.html",
+                        "providerSelection": "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/providers.html"
+                    },
+                    "tokenConfig": {
+                        "accessTokenMaxAgeSeconds": 86400,
+                        "authorizeTokenMaxAgeSeconds": 300
+                    }
+                },
+                "servingInfo": {
+                    "cipherSuites": [
+                        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                        "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                        "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+                    ],
+                    "minTLSVersion": "VersionTLS12",
+                    "namedCertificates": [
+                        {
+                            "certFile": "/var/config/system/secrets/v4-0-config-system-router-certs/apps.tremes.lab.upshift.rdu2.redhat.com",
+                            "keyFile": "/var/config/system/secrets/v4-0-config-system-router-certs/apps.tremes.lab.upshift.rdu2.redhat.com",
+                            "names": [
+                                "*.apps.tremes.lab.upshift.rdu2.redhat.com"
+                            ]
+                        }
+                    ]
+                },
+                "volumesToMount": {
+                    "identityProviders": "{}"
+                }
+            }
+        },
+        "operatorLogLevel": "Normal",
+        "unsupportedConfigOverrides": {
+            "useUnsupportedUnsafeNonHANonProductionUnstableOAuthServer": true
+        }
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/cloudcredential/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/cloudcredential/cluster.json
@@ -1,0 +1,9 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "CloudCredential",
+    "Name": "cluster",
+    "Spec": {
+        "credentialsMode": "",
+        "logLevel": "Normal"
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/config/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/config/cluster.json
@@ -1,0 +1,10 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "Config",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "operatorLogLevel": "Normal"
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/console/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/console/cluster.json
@@ -1,0 +1,10 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "Console",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "operatorLogLevel": "Normal"
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/csisnapshotcontroller/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/csisnapshotcontroller/cluster.json
@@ -1,0 +1,10 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "CSISnapshotController",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "operatorLogLevel": "Normal"
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/dns/default.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/dns/default.json
@@ -1,0 +1,6 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "DNS",
+    "Name": "default",
+    "Spec": {}
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/etcd/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/etcd/cluster.json
@@ -1,0 +1,13 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "Etcd",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "operatorLogLevel": "Normal",
+        "unsupportedConfigOverrides": {
+            "useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true
+        }
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubeapiserver/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubeapiserver/cluster.json
@@ -1,0 +1,98 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "KubeAPIServer",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": {
+            "admission": {
+                "pluginConfig": {
+                    "network.openshift.io/ExternalIPRanger": {
+                        "configuration": {
+                            "allowIngressIP": false,
+                            "apiVersion": "network.openshift.io/v1",
+                            "kind": "ExternalIPRangerAdmissionConfig"
+                        }
+                    },
+                    "network.openshift.io/RestrictedEndpointsAdmission": {
+                        "configuration": {
+                            "apiVersion": "network.openshift.io/v1",
+                            "kind": "RestrictedEndpointsAdmissionConfig",
+                            "restrictedCIDRs": [
+                                "xxxxxxxxxx/14",
+                                "xxxxxxxxxx/16"
+                            ]
+                        }
+                    }
+                }
+            },
+            "apiServerArguments": {
+                "audit-policy-file": [
+                    "/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-audit-policies/default.yaml"
+                ],
+                "etcd-servers": [
+                    "xxxxxxxxxxxxxxxxxxxxxxx",
+                    "xxxxxxxxxxxxxxxxxxxxxx"
+                ],
+                "feature-gates": [
+                    "APIPriorityAndFairness=true",
+                    "RotateKubeletServerCertificate=true",
+                    "SupportPodPidsLimit=true",
+                    "NodeDisruptionExclusion=true",
+                    "ServiceNodeExclusion=true",
+                    "SCTPSupport=true",
+                    "LegacyNodeRoleBehavior=false"
+                ]
+            },
+            "authConfig": {
+                "oauthMetadataFile": "/etc/kubernetes/static-pod-resources/configmaps/oauth-metadata/oauthMetadata"
+            },
+            "corsAllowedOrigins": [
+                "//127\\.0\\.0\\.1(:|$)",
+                "//localhost(:|$)"
+            ],
+            "imagePolicyConfig": {
+                "internalRegistryHostname": "image-registry.openshift-image-registry.svc:5000"
+            },
+            "servicesSubnet": "xxxxxxxxxx/16",
+            "servingInfo": {
+                "bindAddress": "xxxxxxx:6443",
+                "bindNetwork": "tcp4",
+                "cipherSuites": [
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+                ],
+                "minTLSVersion": "VersionTLS12",
+                "namedCertificates": [
+                    {
+                        "certFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.crt",
+                        "keyFile": "/etc/kubernetes/static-pod-certs/secrets/localhost-serving-cert-certkey/tls.key"
+                    },
+                    {
+                        "certFile": "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt",
+                        "keyFile": "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key"
+                    },
+                    {
+                        "certFile": "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.crt",
+                        "keyFile": "/etc/kubernetes/static-pod-certs/secrets/external-loadbalancer-serving-certkey/tls.key"
+                    },
+                    {
+                        "certFile": "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.crt",
+                        "keyFile": "/etc/kubernetes/static-pod-certs/secrets/internal-loadbalancer-serving-certkey/tls.key"
+                    },
+                    {
+                        "certFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.crt",
+                        "keyFile": "/etc/kubernetes/static-pod-resources/secrets/localhost-recovery-serving-certkey/tls.key"
+                    }
+                ]
+            }
+        },
+        "operatorLogLevel": "Normal",
+        "unsupportedConfigOverrides": null
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubecontrollermanager/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubecontrollermanager/cluster.json
@@ -1,0 +1,36 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "KubeControllerManager",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": {
+            "extendedArguments": {
+                "cluster-cidr": [
+                    "xxxxxxxxxx/14"
+                ],
+                "cluster-name": [
+                    "tremes-5f2nt"
+                ],
+                "feature-gates": [
+                    "APIPriorityAndFairness=true",
+                    "RotateKubeletServerCertificate=true",
+                    "SupportPodPidsLimit=true",
+                    "NodeDisruptionExclusion=true",
+                    "ServiceNodeExclusion=true",
+                    "SCTPSupport=true",
+                    "LegacyNodeRoleBehavior=false"
+                ],
+                "service-cluster-ip-range": [
+                    "xxxxxxxxxx/16"
+                ]
+            },
+            "serviceServingCert": {
+                "certFile": "/etc/kubernetes/static-pod-resources/configmaps/service-ca/ca-bundle.crt"
+            }
+        },
+        "operatorLogLevel": "Normal",
+        "unsupportedConfigOverrides": null
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubescheduler/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubescheduler/cluster.json
@@ -1,0 +1,10 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "KubeScheduler",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "operatorLogLevel": "Normal"
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubestorageversionmigrator/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubestorageversionmigrator/cluster.json
@@ -1,0 +1,10 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "KubeStorageVersionMigrator",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "operatorLogLevel": "Normal"
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/openshiftapiserver/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/openshiftapiserver/cluster.json
@@ -1,0 +1,43 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "OpenShiftAPIServer",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": {
+            "apiServerArguments": {
+                "audit-policy-file": [
+                    "/var/run/configmaps/audit/secure-oauth-storage-default.yaml"
+                ]
+            },
+            "imagePolicyConfig": {
+                "internalRegistryHostname": "image-registry.openshift-image-registry.svc:5000"
+            },
+            "projectConfig": {
+                "projectRequestMessage": ""
+            },
+            "routingConfig": {
+                "subdomain": "apps.tremes.lab.upshift.rdu2.redhat.com"
+            },
+            "servingInfo": {
+                "cipherSuites": [
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+                ],
+                "minTLSVersion": "VersionTLS12"
+            },
+            "storageConfig": {
+                "urls": [
+                    "xxxxxxxxxxxxxxxxxxxxxxx"
+                ]
+            }
+        },
+        "operatorLogLevel": "Normal",
+        "unsupportedConfigOverrides": null
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/openshiftcontrollermanager/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/openshiftcontrollermanager/cluster.json
@@ -1,0 +1,32 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "OpenShiftControllerManager",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": {
+            "build": {
+                "buildDefaults": {
+                    "resources": {}
+                },
+                "imageTemplateFormat": {
+                    "format": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:2986a09ed686a571312bcb20d648baac46b422efa072f8b68eb41c7996e94610"
+                }
+            },
+            "deployer": {
+                "imageTemplateFormat": {
+                    "format": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f42509c18cf5e41201d64cf3a9c1994ffa5318f8d7cee5de45fa2da914e68bbc"
+                }
+            },
+            "dockerPullSecret": {
+                "internalRegistryHostname": "image-registry.openshift-image-registry.svc:5000"
+            },
+            "ingress": {
+                "ingressIPNetworkCIDR": ""
+            }
+        },
+        "operatorLogLevel": "Normal",
+        "unsupportedConfigOverrides": null
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/serviceca/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/serviceca/cluster.json
@@ -1,0 +1,10 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "ServiceCA",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "operatorLogLevel": "Normal"
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/storage/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/storage/cluster.json
@@ -1,0 +1,10 @@
+{
+    "APIVersion": "operator.openshift.io/v1",
+    "Kind": "Storage",
+    "Name": "cluster",
+    "Spec": {
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "operatorLogLevel": "Normal"
+    }
+}

--- a/docs/insights-archive-sample/config/clusteroperator/samples.operator.openshift.io/config/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/samples.operator.openshift.io/config/cluster.json
@@ -1,0 +1,11 @@
+{
+    "APIVersion": "samples.operator.openshift.io/v1",
+    "Kind": "Config",
+    "Name": "cluster",
+    "Spec": {
+        "architectures": [
+            "x86_64"
+        ],
+        "managementState": "Managed"
+    }
+}

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -144,6 +144,14 @@ rules:
     - get
     - list
     - watch
+- apiGroups:  
+  - operator.openshift.io
+  resources:
+  - "*"
+  verbs:
+  - get
+  - list
+  - watch 
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	kubescheme "k8s.io/client-go/kubernetes/scheme"
 	certificatesv1beta1 "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
@@ -90,31 +92,40 @@ func init() {
 
 // Gatherer is a driving instance invoking collection of data
 type Gatherer struct {
-	ctx            context.Context
-	client         configv1client.ConfigV1Interface
-	coreClient     corev1client.CoreV1Interface
-	networkClient  networkv1client.NetworkV1Interface
-	dynamicClient  dynamic.Interface
-	metricsClient  rest.Interface
-	certClient     certificatesv1beta1.CertificatesV1beta1Interface
-	registryClient imageregistryv1.ImageregistryV1Interface
-	policyClient   policyclient.PolicyV1beta1Interface
-	lock           sync.Mutex
-	lastVersion    *configv1.ClusterVersion
+	ctx             context.Context
+	client          configv1client.ConfigV1Interface
+	coreClient      corev1client.CoreV1Interface
+	networkClient   networkv1client.NetworkV1Interface
+	dynamicClient   dynamic.Interface
+	metricsClient   rest.Interface
+	certClient      certificatesv1beta1.CertificatesV1beta1Interface
+	registryClient  imageregistryv1.ImageregistryV1Interface
+	policyClient    policyclient.PolicyV1beta1Interface
+	lock            sync.Mutex
+	lastVersion     *configv1.ClusterVersion
+	discoveryClient discovery.DiscoveryInterface
+}
+
+type clusterOperatorResource struct {
+	APIVersion string      `json:"apiVersion"`
+	Kind       string      `json:"kind"`
+	Name       string      `json:"name"`
+	Spec       interface{} `json:"spec"`
 }
 
 // New creates new Gatherer
 func New(client configv1client.ConfigV1Interface, coreClient corev1client.CoreV1Interface, certClient certificatesv1beta1.CertificatesV1beta1Interface, metricsClient rest.Interface,
-	registryClient imageregistryv1.ImageregistryV1Interface, networkClient networkv1client.NetworkV1Interface, dynamicClient dynamic.Interface, policyClient policyclient.PolicyV1beta1Interface) *Gatherer {
+	registryClient imageregistryv1.ImageregistryV1Interface, networkClient networkv1client.NetworkV1Interface, dynamicClient dynamic.Interface, policyClient policyclient.PolicyV1beta1Interface, discoveryClient discovery.DiscoveryInterface) *Gatherer {
 	return &Gatherer{
-		client:         client,
-		coreClient:     coreClient,
-		certClient:     certClient,
-		metricsClient:  metricsClient,
-		registryClient: registryClient,
-		policyClient:   policyClient,
-		networkClient:  networkClient,
-		dynamicClient:  dynamicClient,
+		client:          client,
+		coreClient:      coreClient,
+		certClient:      certClient,
+		metricsClient:   metricsClient,
+		registryClient:  registryClient,
+		policyClient:    policyClient,
+		networkClient:   networkClient,
+		dynamicClient:   dynamicClient,
+		discoveryClient: discoveryClient,
 	}
 }
 
@@ -235,7 +246,7 @@ func GatherMostRecentMetrics(i *Gatherer) func() ([]record.Record, []error) {
 	}
 }
 
-// GatherClusterOperators collects all ClusterOperators.
+// GatherClusterOperators collects all ClusterOperators and their resource.
 // It finds unhealthy Pods for unhealthy operators
 //
 // The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusteroperator.go#L62
@@ -253,9 +264,28 @@ func GatherClusterOperators(i *Gatherer) func() ([]record.Record, []error) {
 		if err != nil {
 			return nil, []error{err}
 		}
+		resVer, _ := getOperatorResourcesVersions(i.discoveryClient)
 		records := make([]record.Record, 0, len(config.Items))
-		for i := range config.Items {
-			records = append(records, record.Record{Name: fmt.Sprintf("config/clusteroperator/%s", config.Items[i].Name), Item: ClusterOperatorAnonymizer{&config.Items[i]}})
+		for idx, co := range config.Items {
+			records = append(records, record.Record{Name: fmt.Sprintf("config/clusteroperator/%s", config.Items[idx].Name), Item: ClusterOperatorAnonymizer{&config.Items[idx]}})
+			if resVer == nil {
+				continue
+			}
+			relRes := collectClusterOperatorResources(i.ctx, i.dynamicClient, co, resVer)
+			for _, rr := range relRes {
+				// imageregistry resources (config, pruner) are gathered in image_registries.go, image_pruners.go
+				if strings.Contains(rr.APIVersion, "imageregistry") {
+					continue
+				}
+				gv, err := schema.ParseGroupVersion(rr.APIVersion)
+				if err != nil {
+					klog.Warningf("Unable to parse group version %s: %s", rr.APIVersion, err)
+				}
+				records = append(records, record.Record{
+					Name: fmt.Sprintf("config/clusteroperator/%s/%s/%s", gv.Group, strings.ToLower(rr.Kind), rr.Name),
+					Item: ClusterOperatorResourceAnonymizer{rr},
+				})
+			}
 		}
 		namespaceEventsCollected := sets.NewString()
 		now := time.Now()
@@ -353,12 +383,75 @@ func collectContainerLogs(i *Gatherer, pod *corev1.Pod, buf *bytes.Buffer, conta
 	return nil
 }
 
-// GatherNodes collects all unhealthy Nodes.
-//
-// The node is unhealthy when:
-// the operator.Status.Conditions.Condition Type
-//   is OperatorDegrated and Status is True or
-//      OperatorAvailable and Status is False
+func collectClusterOperatorResources(ctx context.Context, dynamicClient dynamic.Interface, co configv1.ClusterOperator, resVer map[string][]string) []clusterOperatorResource {
+	var relObj []configv1.ObjectReference
+	for _, ro := range co.Status.RelatedObjects {
+		if strings.Contains(ro.Group, "operator.openshift.io") {
+			relObj = append(relObj, ro)
+		}
+	}
+	if len(relObj) == 0 {
+		return nil
+	}
+	var res []clusterOperatorResource
+	for _, ro := range relObj {
+		key := fmt.Sprintf("%s-%s", ro.Group, strings.ToLower(ro.Resource))
+		versions, _ := resVer[key]
+		for _, v := range versions {
+			gvr := schema.GroupVersionResource{Group: ro.Group, Version: v, Resource: strings.ToLower(ro.Resource)}
+			clusterResource, err := dynamicClient.Resource(gvr).Get(ctx, ro.Name, metav1.GetOptions{})
+			if err != nil {
+				klog.V(2).Infof("Unable to list %s resource due to: %s", gvr, err)
+			}
+			if clusterResource == nil {
+				continue
+			}
+			var kind, name, apiVersion string
+			err = failEarly(
+				func() error { return parseJSONQuery(clusterResource.Object, "kind", &kind) },
+				func() error { return parseJSONQuery(clusterResource.Object, "apiVersion", &apiVersion) },
+				func() error { return parseJSONQuery(clusterResource.Object, "metadata.name", &name) },
+			)
+			if err != nil {
+				continue
+			}
+			spec, ok := clusterResource.Object["spec"]
+			if !ok {
+				klog.Warningf("Can't find spec for cluster operator resource %s", name)
+			}
+			res = append(res, clusterOperatorResource{Spec: spec, Kind: kind, Name: name, APIVersion: apiVersion})
+		}
+	}
+	return res
+}
+
+func getOperatorResourcesVersions(discoveryClient discovery.DiscoveryInterface) (map[string][]string, error) {
+	resources, err := discoveryClient.ServerPreferredResources()
+	if err != nil {
+		return nil, err
+	}
+	resourceVersionMap := make(map[string][]string)
+	for _, v := range resources {
+		if strings.Contains(v.GroupVersion, "operator.openshift.io") {
+			gv, err := schema.ParseGroupVersion(v.GroupVersion)
+			if err != nil {
+				continue
+			}
+			for _, ar := range v.APIResources {
+				key := fmt.Sprintf("%s-%s", gv.Group, ar.Name)
+				r, ok := resourceVersionMap[key]
+				if !ok {
+					resourceVersionMap[key] = []string{gv.Version}
+				} else {
+					r = append(r, gv.Version)
+				}
+			}
+		}
+	}
+	return resourceVersionMap, nil
+}
+
+// GatherNodes collects all Nodes.
 //
 // The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/node.go#L78
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core
@@ -533,7 +626,7 @@ func GatherClusterAuthentication(i *Gatherer) func() ([]record.Record, []error) 
 
 // GatherClusterImagePruner fetches the image pruner configuration
 //
-// Location in archive: config/imagepruner/
+// Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
 func GatherClusterImagePruner(i *Gatherer) func() ([]record.Record, []error) {
 	return func() ([]record.Record, []error) {
 		pruner, err := i.registryClient.ImagePruners().Get(i.ctx, "cluster", metav1.GetOptions{})
@@ -543,13 +636,25 @@ func GatherClusterImagePruner(i *Gatherer) func() ([]record.Record, []error) {
 		if err != nil {
 			return nil, []error{err}
 		}
-		return []record.Record{{Name: "config/imagepruner", Item: ImagePrunerAnonymizer{pruner}}}, nil
+		// TypeMeta is empty - see https://github.com/kubernetes/kubernetes/issues/3030
+		kinds, _, err := registryScheme.ObjectKinds(pruner)
+		if err != nil {
+			return nil, []error{err}
+		}
+		if len(kinds) > 1 {
+			klog.Warningf("More kinds for image registry pruner operator resource %s", kinds)
+		}
+		objKind := kinds[0]
+		return []record.Record{{
+			Name: fmt.Sprintf("config/clusteroperator/%s/%s/%s", objKind.Group, strings.ToLower(objKind.Kind), pruner.Name),
+			Item: ImagePrunerAnonymizer{pruner},
+		}}, nil
 	}
 }
 
 // GatherClusterImageRegistry fetches the cluster Image Registry configuration
 //
-// Location in archive: config/imageregistry/
+// Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 func GatherClusterImageRegistry(i *Gatherer) func() ([]record.Record, []error) {
 	return func() ([]record.Record, []error) {
 		config, err := i.registryClient.Configs().Get(i.ctx, "cluster", metav1.GetOptions{})
@@ -559,7 +664,19 @@ func GatherClusterImageRegistry(i *Gatherer) func() ([]record.Record, []error) {
 		if err != nil {
 			return nil, []error{err}
 		}
-		return []record.Record{{Name: "config/imageregistry", Item: ImageRegistryAnonymizer{config}}}, nil
+		// TypeMeta is empty - see https://github.com/kubernetes/kubernetes/issues/3030
+		kinds, _, err := registryScheme.ObjectKinds(config)
+		if err != nil {
+			return nil, []error{err}
+		}
+		if len(kinds) > 1 {
+			klog.Warningf("More kinds for image registry config operator resource %s", kinds)
+		}
+		objKind := kinds[0]
+		return []record.Record{{
+			Name: fmt.Sprintf("config/clusteroperator/%s/%s/%s", objKind.Group, strings.ToLower(objKind.Kind), config.Name),
+			Item: ImageRegistryAnonymizer{config},
+		}}, nil
 	}
 }
 
@@ -734,6 +851,53 @@ func (i *Gatherer) gatherNamespaceEvents(namespace string) ([]record.Record, []e
 		return compactedEvents.Items[i].LastTimestamp.Before(compactedEvents.Items[j].LastTimestamp)
 	})
 	return []record.Record{{Name: fmt.Sprintf("events/%s", namespace), Item: EventAnonymizer{&compactedEvents}}}, nil
+}
+
+func failEarly(fns ...func() error) error {
+	for _, f := range fns {
+		err := f()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseJSONQuery(j map[string]interface{}, jq string, o interface{}) error {
+	for _, k := range strings.Split(jq, ".") {
+		// optional field
+		opt := false
+		sz := len(k)
+		if sz > 0 && k[sz-1] == '?' {
+			opt = true
+			k = k[:sz-1]
+		}
+
+		if uv, ok := j[k]; ok {
+			if v, ok := uv.(map[string]interface{}); ok {
+				j = v
+				continue
+			}
+			// ValueOf to enter reflect-land
+			dstPtrValue := reflect.ValueOf(o)
+			dstValue := reflect.Indirect(dstPtrValue)
+			dstValue.Set(reflect.ValueOf(uv))
+
+			return nil
+		}
+		if opt {
+			return nil
+		}
+		// otherwise key was not found
+		// keys are case sensitive, because maps are
+		for ki := range j {
+			if strings.ToLower(k) == strings.ToLower(ki) {
+				return fmt.Errorf("key %s wasn't found, but %s was ", k, ki)
+			}
+		}
+		return fmt.Errorf("key %s wasn't found in %v ", k, j)
+	}
+	return fmt.Errorf("query didn't match the structure")
 }
 
 // RawByte is skipping Marshalling from byte slice
@@ -1247,4 +1411,35 @@ func countLines(r io.Reader) (int, error) {
 			return lineCount, err
 		}
 	}
+}
+
+// ClusterOperatorResourceAnonymizer implements serialization of clusterOperatorResource
+type ClusterOperatorResourceAnonymizer struct{ resource clusterOperatorResource }
+
+// Marshal serializes clusterOperatorResource with IP address anonymization
+func (a ClusterOperatorResourceAnonymizer) Marshal(_ context.Context) ([]byte, error) {
+	bytes, err := json.Marshal(a.resource)
+	if err != nil {
+		return nil, err
+	}
+	resStr := string(bytes)
+	//anonymize URLs
+	re := regexp.MustCompile(`"(https|http)://(.*?)"`)
+	urlMatches := re.FindAllString(resStr, -1)
+	for _, m := range urlMatches {
+		m = strings.ReplaceAll(m, "\"", "")
+		resStr = strings.ReplaceAll(resStr, m, anonymizeString(m))
+	}
+	// anonymize IP addresses
+	re = regexp.MustCompile(`(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}`)
+	ipMatches := re.FindAllString(resStr, -1)
+	for _, m := range ipMatches {
+		resStr = strings.ReplaceAll(resStr, m, anonymizeString(m))
+	}
+	return []byte(resStr), nil
+}
+
+// GetExtension returns extension for anonymized cluster operator objects
+func (a ClusterOperatorResourceAnonymizer) GetExtension() string {
+	return "json"
 }

--- a/pkg/gather/clusterconfig/clusterconfig_examples.go
+++ b/pkg/gather/clusterconfig/clusterconfig_examples.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	clsetfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -56,7 +57,10 @@ func ExampleClusterOperators() (string, error) {
 			return true, sv, nil
 		})
 
-	g := &Gatherer{client: kube.ConfigV1()}
+	g := &Gatherer{
+		client:          kube.ConfigV1(),
+		discoveryClient: kube.Discovery(),
+		dynamicClient:   dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())}
 	d, errs := GatherClusterOperators(g)()
 	if len(errs) > 0 {
 		return "", errs[0]

--- a/test/integration/bugs_test.go
+++ b/test/integration/bugs_test.go
@@ -199,7 +199,7 @@ func TestArchiveContains(t *testing.T) {
 	t.Run("ImageRegistry",
 		genLatestArchiveCheckPattern(
 			"image registry", matchingFileExists,
-			`^config/imageregistry\.json$`))
+			`^config/clusteroperator/imageregistry.operator.openshift.io/config/cluster\.json$`))
 
 	// not backported to 4.5 yet
 	////https://bugzilla.redhat.com/show_bug.cgi?id=1873101


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR backports IO enhancement to gather complete spec defintion for clusteroperator `operator.openshift.io` resources

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json`
- `docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/authentication/cluster.json`
- `docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/console/cluster.json` 
- and more .....

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md` - minor update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gather/clusterconfig/clusterconfig_test.go` - basic test added

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Anonymization considered. IP addresses, buckets, etc. anonymized - see e.g https://github.com/openshift/insights-operator/pull/287/files#diff-e0e8d2778274ee7ccca623c59f06a4d9720242acb010907d8417caadd17085d7R96

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/INSIGHTOCP-159
https://issues.redhat.com/browse/INSIGHTOCP-54
https://issues.redhat.com/browse/INSIGHTOCP-49
https://access.redhat.com/solutions/5448851


