### PR TITLE
Check context status when checking container is running OK

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -175,6 +175,11 @@ func isRunning(ctx context.Context, config *rest.Config) wait.ConditionFunc {
 		if err != nil {
 			return false, err
 		}
+		// check if context hasn't been cancelled or done meanwhile
+		err = ctx.Err()
+		if err != nil {
+			return false, err
+		}
 		pod, err := c.Pods(os.Getenv("POD_NAMESPACE")).Get(ctx, os.Getenv("POD_NAME"), metav1.GetOptions{})
 		if err != nil {
 			if !errors.IsNotFound(err) {


### PR DESCRIPTION
This is additional commit for https://github.com/openshift/insights-operator/commit/b7da048d7375d1ebf5dc0750926637dcdf3b046f. 
We shouldn't check the condition if the context was cancelled or done meanwhile. This is unnecessary waiting and can lead to error state. 