### PR TITLE
Update initial waiting times and give TestIsIOHealthy more time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test-unit:
 .PHONY: test-unit
 
 test-e2e:
-	go test ./test/integration -v -run ^\(TestIsIOHealthy\)$$ ^\(TestPullSecretExists\)$$ -timeout 1m
+	go test ./test/integration -v -run ^\(TestIsIOHealthy\)$$ ^\(TestPullSecretExists\)$$ -timeout 6m30s
 	test/integration/resource_samples/apply.sh
 	go test ./test/integration -v -timeout 20m $(TEST_OPTIONS)
 .PHONY: test-e2e

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -129,9 +129,9 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 	statusReporter.AddSources(periodic.Sources()...)
 
 	// check we can read IO container status and we are not in crash loop
-	err = wait.PollImmediate(20*time.Second, wait.Jitter(s.Controller.Interval/12, 0.1), isRunning(ctx, gatherKubeConfig))
+	err = wait.PollImmediate(20*time.Second, wait.Jitter(s.Controller.Interval/24, 0.1), isRunning(ctx, gatherKubeConfig))
 	if err != nil {
-		initialDelay = wait.Jitter(s.Controller.Interval/12, 1)
+		initialDelay = wait.Jitter(s.Controller.Interval/12, 0.5)
 		klog.Infof("Unable to check insights-operator pod status. Setting initial delay to %s", initialDelay)
 	}
 	go periodic.Run(4, ctx.Done(), initialDelay)


### PR DESCRIPTION
`TestIsIOHealthy` was failing, because we were waiting too long (more than 10 min) in case of the previous container state was not healthy. 
This is to shorten the waiting time to max 330 seconds (five and a half minutes) and add more time to `TestIsIOHealthy` test