### PR TITLE
Bug 1907378: Gather netnamespaces network info

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -234,6 +234,16 @@ Output raw size: 148
 #### MostRecentMetrics
 [{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAojIEFMRVJUUyAyLzEwMDAKSGVsbG8sIGNsaWVudAo="}]
 
+## NetNamespace
+
+collects NetNamespaces networking information
+
+The Kubernetes api https://github.com/openshift/client-go/blob/master/network/clientset/versioned/typed/network/v1/netnamespace.go
+Response is an array of netNamespaces. Netnamespace contains Name, EgressIPs and NetID attributes.
+
+Location in archive: config/netnamespaces
+
+
 ## Nodes
 
 collects all Nodes.

--- a/docs/insights-archive-sample/config/netnamespaces.json
+++ b/docs/insights-archive-sample/config/netnamespaces.json
@@ -1,0 +1,300 @@
+[
+    {
+        "name": "default",
+        "egressIPs": null,
+        "netID": 0
+    },
+    {
+        "name": "kube-node-lease",
+        "egressIPs": null,
+        "netID": 2795067
+    },
+    {
+        "name": "kube-public",
+        "egressIPs": null,
+        "netID": 13073630
+    },
+    {
+        "name": "kube-system",
+        "egressIPs": null,
+        "netID": 16631919
+    },
+    {
+        "name": "openshift",
+        "egressIPs": null,
+        "netID": 14362778
+    },
+    {
+        "name": "openshift-apiserver",
+        "egressIPs": null,
+        "netID": 9577157
+    },
+    {
+        "name": "openshift-apiserver-operator",
+        "egressIPs": null,
+        "netID": 2581983
+    },
+    {
+        "name": "openshift-authentication",
+        "egressIPs": null,
+        "netID": 10774892
+    },
+    {
+        "name": "openshift-authentication-operator",
+        "egressIPs": null,
+        "netID": 3426150
+    },
+    {
+        "name": "openshift-cloud-credential-operator",
+        "egressIPs": null,
+        "netID": 13908726
+    },
+    {
+        "name": "openshift-cluster-csi-drivers",
+        "egressIPs": null,
+        "netID": 6749949
+    },
+    {
+        "name": "openshift-cluster-machine-approver",
+        "egressIPs": null,
+        "netID": 7225590
+    },
+    {
+        "name": "openshift-cluster-node-tuning-operator",
+        "egressIPs": null,
+        "netID": 9123147
+    },
+    {
+        "name": "openshift-cluster-samples-operator",
+        "egressIPs": null,
+        "netID": 10870345
+    },
+    {
+        "name": "openshift-cluster-storage-operator",
+        "egressIPs": null,
+        "netID": 14153285
+    },
+    {
+        "name": "openshift-cluster-version",
+        "egressIPs": null,
+        "netID": 14700582
+    },
+    {
+        "name": "openshift-config",
+        "egressIPs": null,
+        "netID": 3909207
+    },
+    {
+        "name": "openshift-config-managed",
+        "egressIPs": null,
+        "netID": 4698971
+    },
+    {
+        "name": "openshift-config-operator",
+        "egressIPs": null,
+        "netID": 15989555
+    },
+    {
+        "name": "openshift-console",
+        "egressIPs": null,
+        "netID": 15325655
+    },
+    {
+        "name": "openshift-console-operator",
+        "egressIPs": null,
+        "netID": 769593
+    },
+    {
+        "name": "openshift-controller-manager",
+        "egressIPs": null,
+        "netID": 2509272
+    },
+    {
+        "name": "openshift-controller-manager-operator",
+        "egressIPs": null,
+        "netID": 15276924
+    },
+    {
+        "name": "openshift-dns",
+        "egressIPs": null,
+        "netID": 5152056
+    },
+    {
+        "name": "openshift-dns-operator",
+        "egressIPs": null,
+        "netID": 6917210
+    },
+    {
+        "name": "openshift-etcd",
+        "egressIPs": null,
+        "netID": 15057570
+    },
+    {
+        "name": "openshift-etcd-operator",
+        "egressIPs": null,
+        "netID": 9571833
+    },
+    {
+        "name": "openshift-image-registry",
+        "egressIPs": null,
+        "netID": 12058587
+    },
+    {
+        "name": "openshift-infra",
+        "egressIPs": null,
+        "netID": 12805550
+    },
+    {
+        "name": "openshift-ingress",
+        "egressIPs": null,
+        "netID": 3739224
+    },
+    {
+        "name": "openshift-ingress-operator",
+        "egressIPs": null,
+        "netID": 3588270
+    },
+    {
+        "name": "openshift-insights",
+        "egressIPs": null,
+        "netID": 4028556
+    },
+    {
+        "name": "openshift-kni-infra",
+        "egressIPs": null,
+        "netID": 6215975
+    },
+    {
+        "name": "openshift-kube-apiserver",
+        "egressIPs": null,
+        "netID": 1239247
+    },
+    {
+        "name": "openshift-kube-apiserver-operator",
+        "egressIPs": null,
+        "netID": 14163022
+    },
+    {
+        "name": "openshift-kube-controller-manager",
+        "egressIPs": null,
+        "netID": 13084441
+    },
+    {
+        "name": "openshift-kube-controller-manager-operator",
+        "egressIPs": null,
+        "netID": 2024599
+    },
+    {
+        "name": "openshift-kube-scheduler",
+        "egressIPs": null,
+        "netID": 7968492
+    },
+    {
+        "name": "openshift-kube-scheduler-operator",
+        "egressIPs": null,
+        "netID": 14616566
+    },
+    {
+        "name": "openshift-kube-storage-version-migrator",
+        "egressIPs": null,
+        "netID": 8037837
+    },
+    {
+        "name": "openshift-kube-storage-version-migrator-operator",
+        "egressIPs": null,
+        "netID": 10407813
+    },
+    {
+        "name": "openshift-machine-api",
+        "egressIPs": null,
+        "netID": 13163983
+    },
+    {
+        "name": "openshift-machine-config-operator",
+        "egressIPs": null,
+        "netID": 13746264
+    },
+    {
+        "name": "openshift-marketplace",
+        "egressIPs": null,
+        "netID": 90989
+    },
+    {
+        "name": "openshift-monitoring",
+        "egressIPs": null,
+        "netID": 16411305
+    },
+    {
+        "name": "openshift-multus",
+        "egressIPs": null,
+        "netID": 11052026
+    },
+    {
+        "name": "openshift-network-operator",
+        "egressIPs": null,
+        "netID": 8799386
+    },
+    {
+        "name": "openshift-node",
+        "egressIPs": null,
+        "netID": 6691746
+    },
+    {
+        "name": "openshift-oauth-apiserver",
+        "egressIPs": null,
+        "netID": 13420319
+    },
+    {
+        "name": "openshift-openstack-infra",
+        "egressIPs": null,
+        "netID": 10994738
+    },
+    {
+        "name": "openshift-operator-lifecycle-manager",
+        "egressIPs": null,
+        "netID": 6122231
+    },
+    {
+        "name": "openshift-operators",
+        "egressIPs": null,
+        "netID": 1635018
+    },
+    {
+        "name": "openshift-ovirt-infra",
+        "egressIPs": null,
+        "netID": 15628967
+    },
+    {
+        "name": "openshift-sdn",
+        "egressIPs": null,
+        "netID": 7506485
+    },
+    {
+        "name": "openshift-service-ca",
+        "egressIPs": null,
+        "netID": 15247878
+    },
+    {
+        "name": "openshift-service-ca-operator",
+        "egressIPs": null,
+        "netID": 11604380
+    },
+    {
+        "name": "openshift-user-workload-monitoring",
+        "egressIPs": null,
+        "netID": 13785378
+    },
+    {
+        "name": "openshift-vsphere-infra",
+        "egressIPs": null,
+        "netID": 15355316
+    },
+    {
+        "name": "test",
+        "egressIPs": [
+            "10.128.0.0",
+            "127.0.0.1"
+        ],
+        "netID": 16248289
+    }
+]

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -61,6 +61,7 @@ func (g *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherMachineConfigPool(g),
 		GatherContainerRuntimeConfig(g),
 		GatherStatefulSets(g),
+		GatherNetNamespace(g),
 	)
 }
 

--- a/pkg/gather/clusterconfig/netnamespaces.go
+++ b/pkg/gather/clusterconfig/netnamespaces.go
@@ -1,0 +1,73 @@
+package clusterconfig
+
+import (
+	"context"
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	networkv1 "github.com/openshift/api/network/v1"
+	networkv1client "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
+	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+type netNamespace struct {
+	Name      string                           `json:"name"`
+	EgressIPs []networkv1.NetNamespaceEgressIP `json:"egressIPs"`
+	NetID     uint32                           `json:"netID"`
+}
+
+// GatherNetNamespace collects NetNamespaces networking information
+//
+// The Kubernetes api https://github.com/openshift/client-go/blob/master/network/clientset/versioned/typed/network/v1/netnamespace.go
+// Response is an array of netNamespaces. Netnamespace contains Name, EgressIPs and NetID attributes.
+//
+// Location in archive: config/netnamespaces
+func GatherNetNamespace(g *Gatherer) func() ([]record.Record, []error) {
+	return func() ([]record.Record, []error) {
+		gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
+		if err != nil {
+			return nil, []error{err}
+		}
+		return gatherNetNamespace(g.ctx, gatherNetworkClient)
+	}
+}
+func gatherNetNamespace(ctx context.Context, networkClient networkv1client.NetworkV1Interface) ([]record.Record, []error) {
+	nsList, err := networkClient.NetNamespaces().List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	namespaces := []*netNamespace{}
+	for _, n := range nsList.Items {
+		netNS := &netNamespace{
+			Name:      n.Name,
+			EgressIPs: n.EgressIPs,
+			NetID:     n.NetID,
+		}
+		namespaces = append(namespaces, netNS)
+	}
+	r := record.Record{
+		Name: "config/netnamespaces",
+		Item: NetNamespaceAnonymizer{namespaces: namespaces},
+	}
+	return []record.Record{r}, nil
+}
+
+// NetNamespaceAnonymizer implements NetNamespace serialization
+type NetNamespaceAnonymizer struct{ namespaces []*netNamespace }
+
+// Marshal implements NetNamespace serialization
+func (a NetNamespaceAnonymizer) Marshal(_ context.Context) ([]byte, error) {
+	return json.Marshal(a.namespaces)
+}
+
+// GetExtension returns extension for NetNamespace object
+func (a NetNamespaceAnonymizer) GetExtension() string {
+	return "json"
+}

--- a/pkg/gather/clusterconfig/netnamespaces_test.go
+++ b/pkg/gather/clusterconfig/netnamespaces_test.go
@@ -1,0 +1,84 @@
+package clusterconfig
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	networkv1 "github.com/openshift/api/network/v1"
+	networkfake "github.com/openshift/client-go/network/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGatherNetNamespaces(t *testing.T) {
+	ns1 := &networkv1.NetNamespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespaces-1",
+		},
+		EgressIPs: []networkv1.NetNamespaceEgressIP{"10.10.10.10"},
+		NetID:     12345,
+	}
+	ns2 := &networkv1.NetNamespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespaces-2",
+		},
+		EgressIPs: []networkv1.NetNamespaceEgressIP{"11.11.11.11"},
+		NetID:     67891,
+	}
+	ctx := context.Background()
+	cs := networkfake.NewSimpleClientset()
+	createNetNamespaces(ctx, t, cs, ns1, ns2)
+	rec, errs := gatherNetNamespace(ctx, cs.NetworkV1())
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %#v", errs)
+		return
+	}
+	if len(rec) != 1 {
+		t.Fatalf("unexpected number or records %d", len(rec))
+	}
+	it1 := rec[0].Item
+	it1Bytes, err := it1.Marshal(context.TODO())
+	if err != nil {
+		t.Fatalf("unable to marshal: %v", err)
+	}
+	var netNamespaces []netNamespace
+	err = json.Unmarshal(it1Bytes, &netNamespaces)
+	if err != nil {
+		t.Fatalf("failed to decode object: %v", err)
+	}
+	if len(netNamespaces) != 2 {
+		t.Fatalf("unexpected number of namespaces gathered %d", len(netNamespaces))
+	}
+	if !equalNetNamespaceS(*ns1, netNamespaces[0]) {
+		t.Fatalf("unexpected netnamespace %v ", netNamespaces[0])
+	}
+
+	if !equalNetNamespaceS(*ns2, netNamespaces[1]) {
+		t.Fatalf("unexpected netnamespace %v ", netNamespaces[1])
+	}
+}
+
+func equalNetNamespaceS(ns1 networkv1.NetNamespace, ns2 netNamespace) bool {
+	if ns1.Name != ns2.Name {
+		return false
+	}
+	if ns1.NetID != ns2.NetID {
+		return false
+	}
+	if !reflect.DeepEqual(ns1.EgressIPs, ns2.EgressIPs) {
+		return false
+	}
+	return true
+}
+
+func createNetNamespaces(ctx context.Context, t *testing.T, n *networkfake.Clientset, namespaces ...*networkv1.NetNamespace) {
+	for _, ns := range namespaces {
+		_, err := n.NetworkV1().NetNamespaces().Create(ctx, ns, metav1.CreateOptions{})
+		if err != nil {
+			if err != nil {
+				t.Fatal("unable to create fake netnamespace", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is a new data enhancement for gathering interesting networking info about netnamespaces.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- Adding `docs/insights-archive-sample/config/netnamespaces.json `

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md` updated

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- Added `pkg/gather/clusterconfig/netnamespaces_test.go `

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

The obfuscation of IP addresses and hostnames will be adressed with https://issues.redhat.com/browse/CCXDEV-3655. It's still being discussed.

## References
<!-- What are related references for this PR? -->

https://bugzilla.redhat.com/show_bug.cgi?id=1907378