### PR TITLE
Bug 1917367: Refactor periodic.go

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -134,7 +134,7 @@ func (s *Support) Run(ctx context.Context, controller *controllercmd.ControllerC
 		initialDelay = wait.Jitter(s.Controller.Interval/12, 0.5)
 		klog.Infof("Unable to check insights-operator pod status. Setting initial delay to %s", initialDelay)
 	}
-	go periodic.Run(4, ctx.Done(), initialDelay)
+	go periodic.Run(ctx.Done(), initialDelay)
 
 	authorizer := clusterauthorizer.New(configObserver)
 	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherKubeConfig)

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -133,7 +133,7 @@ func (c *Controller) periodicTrigger(stopCh <-chan struct{}) {
 			interval = newInterval
 			klog.Infof("Gathering cluster info every %s", interval)
 
-		case <-time.After(wait.Jitter(interval/4, 2)):
+		case <-time.After(interval):
 			c.Gather()
 		}
 	}

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -29,7 +29,6 @@ type Controller struct {
 	statuses     map[string]*controllerstatus.Simple
 
 	initialDelay time.Duration
-
 }
 
 func New(configurator Configurator, recorder record.FlushInterface, gatherers map[string]gather.Interface) *Controller {
@@ -59,7 +58,6 @@ func (c *Controller) Sources() []controllerstatus.Interface {
 	return sources
 }
 
-
 func (c *Controller) Run(stopCh <-chan struct{}, initialDelay time.Duration) {
 	defer utilruntime.HandleCrash()
 	defer klog.Info("Shutting down")
@@ -83,7 +81,6 @@ func (c *Controller) Gather() {
 		c.statuses[name].UpdateStatus(controllerstatus.Summary{Reason: "PeriodicGatherFailed", Message: fmt.Sprintf("Source %s could not be retrieved: %v", name, err)})
 	}
 }
-
 
 func (c *Controller) runGatherer(name string) error {
 	gatherer, ok := c.gatherers[name]

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -10,7 +10,6 @@ import (
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/controllerstatus"
@@ -24,51 +23,77 @@ type Configurator interface {
 }
 
 type Controller struct {
-	config    Configurator
-	recorder  record.FlushInterface
-	gatherers map[string]gather.Interface
-	status    map[string]*controllerstatus.Simple
-	queue     workqueue.RateLimitingInterface
+	configurator Configurator
+	recorder     record.FlushInterface
+	gatherers    map[string]gather.Interface
+	statuses     map[string]*controllerstatus.Simple
+
+	workers		 int  // Not used, but I have plans for it
+	initialDelay time.Duration
+
 }
 
-func New(config Configurator, recorder record.FlushInterface, gatherers map[string]gather.Interface) *Controller {
-	status := make(map[string]*controllerstatus.Simple)
+func New(configurator Configurator, recorder record.FlushInterface, gatherers map[string]gather.Interface) *Controller {
+	statuses := make(map[string]*controllerstatus.Simple)
 	for k := range gatherers {
-		status[k] = &controllerstatus.Simple{Name: fmt.Sprintf("periodic-%s", k)}
+		statuses[k] = &controllerstatus.Simple{Name: fmt.Sprintf("periodic-%s", k)}
 	}
 	c := &Controller{
-		config:    config,
-		recorder:  recorder,
-		gatherers: gatherers,
-		status:    status,
-
-		// TODO: tune rate limiter here for non-aggressive action
-		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "gatherer"),
+		configurator: configurator,
+		recorder:     recorder,
+		gatherers:    gatherers,
+		statuses:     statuses,
 	}
 	return c
 }
 
 func (c *Controller) Sources() []controllerstatus.Interface {
-	keys := make([]string, 0, len(c.status))
-	for key := range c.status {
+	keys := make([]string, 0, len(c.statuses))
+	for key := range c.statuses {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	sources := make([]controllerstatus.Interface, 0, len(keys))
 	for _, key := range keys {
-		sources = append(sources, c.status[key])
+		sources = append(sources, c.statuses[key])
 	}
 	return sources
 }
 
-// sync gathers data from the cluster periodically
-func (c *Controller) sync(name string) error {
+
+func (c *Controller) Run(workers int, stopCh <-chan struct{}, initialDelay time.Duration) {
+	defer utilruntime.HandleCrash()
+	defer klog.Info("Shutting down")
+	c.workers = workers
+	c.initialDelay = initialDelay
+
+	go wait.Until(func() { c.periodicTrigger(stopCh) }, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *Controller) Gather() {
+	for name := range c.gatherers {
+		start := time.Now()
+		err := c.runGatherer(name)
+		if err == nil {
+			klog.V(4).Infof("Periodic gather %s completed in %s", name, time.Since(start).Truncate(time.Millisecond))
+			c.statuses[name].UpdateStatus(controllerstatus.Summary{Healthy: true})
+			return
+		}
+		utilruntime.HandleError(fmt.Errorf("%v failed after %s with: %v", name, time.Since(start).Truncate(time.Millisecond), err))
+		c.statuses[name].UpdateStatus(controllerstatus.Summary{Reason: "PeriodicGatherFailed", Message: fmt.Sprintf("Source %s could not be retrieved: %v", name, err)})
+	}
+}
+
+
+func (c *Controller) runGatherer(name string) error {
 	gatherer, ok := c.gatherers[name]
 	if !ok {
 		klog.V(2).Infof("No such gatherer %s", name)
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), c.config.Config().Interval/2)
+	ctx, cancel := context.WithTimeout(context.Background(), c.configurator.Config().Interval/2)
 	defer cancel()
 	defer func() {
 		if err := c.recorder.Flush(ctx); err != nil {
@@ -76,49 +101,24 @@ func (c *Controller) sync(name string) error {
 		}
 	}()
 	klog.V(4).Infof("Running %s", name)
-	return gatherer.Gather(ctx, c.config.Config().Gather, c.recorder)
-}
-
-// Run starts gathering with initialDelay
-func (c *Controller) Run(workers int, stopCh <-chan struct{}, initialDelay time.Duration) {
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-	defer klog.Info("Shutting down")
-
-	// start watching for version changes
-	go wait.Until(func() { c.periodicTrigger(stopCh) }, time.Second, stopCh)
-
-	for i := 0; i < workers; i++ {
-		go wait.Until(func() {
-			if initialDelay > 0 {
-				select {
-				case <-stopCh:
-					return
-				case <-time.After(initialDelay):
-					c.runWorker()
-				}
-			}
-			c.runWorker()
-		}, time.Second, stopCh)
-	}
-
-	// seed the queue
-	c.Gather()
-
-	<-stopCh
-}
-
-func (c *Controller) Gather() {
-	for name := range c.gatherers {
-		c.queue.Add(name)
-	}
+	return gatherer.Gather(ctx, c.configurator.Config().Gather, c.recorder)
 }
 
 func (c *Controller) periodicTrigger(stopCh <-chan struct{}) {
-	configCh, closeFn := c.config.ConfigChanged()
+	configCh, closeFn := c.configurator.ConfigChanged()
 	defer closeFn()
 
-	interval := c.config.Config().Interval
+	if c.initialDelay > 0 {
+		select {
+		case <-stopCh:
+			return
+		case <-time.After(c.initialDelay):
+			c.initialDelay = 0
+			c.Gather()
+		}
+	}
+
+	interval := c.configurator.Config().Interval
 	expireCh := time.After(wait.Jitter(interval, 0.5))
 	klog.Infof("Gathering cluster info every %s", interval)
 	for {
@@ -127,46 +127,18 @@ func (c *Controller) periodicTrigger(stopCh <-chan struct{}) {
 			return
 
 		case <-configCh:
-			newInterval := c.config.Config().Interval
+			newInterval := c.configurator.Config().Interval
 			if newInterval == interval {
 				continue
 			}
 			interval = newInterval
 			klog.Infof("Gathering cluster info every %s", interval)
-		case <-expireCh:
-		}
 
-		for name := range c.gatherers {
-			c.queue.AddAfter(name, wait.Jitter(interval/4, 2))
+		case <-time.After(wait.Jitter(interval/4, 2)):
+			c.Gather()
+
+		case <-expireCh:
 		}
 		expireCh = time.After(wait.Jitter(interval, 0.5))
 	}
-}
-
-func (c *Controller) runWorker() {
-	for c.processNextWorkItem() {
-	}
-}
-
-func (c *Controller) processNextWorkItem() bool {
-	dsKey, quit := c.queue.Get()
-	if quit {
-		return false
-	}
-	defer c.queue.Done(dsKey)
-	name := dsKey.(string)
-	start := time.Now()
-	err := c.sync(name)
-	if err == nil {
-		klog.V(4).Infof("Periodic gather %s completed in %s", name, time.Now().Sub(start).Truncate(time.Millisecond))
-		c.queue.Forget(dsKey)
-		c.status[name].UpdateStatus(controllerstatus.Summary{Healthy: true})
-		return true
-	}
-
-	utilruntime.HandleError(fmt.Errorf("%v failed after %s with: %v", dsKey, time.Now().Sub(start).Truncate(time.Millisecond), err))
-	c.queue.AddRateLimited(dsKey)
-	c.status[name].UpdateStatus(controllerstatus.Summary{Reason: "PeriodicGatherFailed", Message: fmt.Sprintf("Source %s could not be retrieved: %v", name, err)})
-
-	return true
 }

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -28,7 +28,6 @@ type Controller struct {
 	gatherers    map[string]gather.Interface
 	statuses     map[string]*controllerstatus.Simple
 
-	workers		 int  // Not used, but I have plans for it
 	initialDelay time.Duration
 
 }
@@ -61,10 +60,9 @@ func (c *Controller) Sources() []controllerstatus.Interface {
 }
 
 
-func (c *Controller) Run(workers int, stopCh <-chan struct{}, initialDelay time.Duration) {
+func (c *Controller) Run(stopCh <-chan struct{}, initialDelay time.Duration) {
 	defer utilruntime.HandleCrash()
 	defer klog.Info("Shutting down")
-	c.workers = workers
 	c.initialDelay = initialDelay
 
 	go wait.Until(func() { c.periodicTrigger(stopCh) }, time.Second, stopCh)

--- a/pkg/gather/clusterconfig/0_gahterer_test.go
+++ b/pkg/gather/clusterconfig/0_gahterer_test.go
@@ -1,9 +1,99 @@
 package clusterconfig
 
 import (
+	"context"
 	"reflect"
 	"testing"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"k8s.io/apimachinery/pkg/api/errors"
 )
+
+func mockGatherFunction1(g *Gatherer, c chan<- gatherResult) {
+	c <- gatherResult{[]record.Record{{
+		Name: "config/mock1",
+		Item: Raw{"mock1"},
+	}}, nil}
+}
+
+func mockGatherFunction2(g *Gatherer, c chan<- gatherResult) {
+	c <- gatherResult{[]record.Record{{
+		Name: "config/mock2",
+		Item: Raw{"mock2"},
+	}}, nil}
+}
+
+func mockGatherFunctionError(g *Gatherer, c chan<- gatherResult) {
+	c <- gatherResult{nil, []error{&errors.StatusError{}}}
+}
+
+func init_test() Gatherer {
+	gatherFunctions = map[string]gatherFunction{
+		"mock1": mockGatherFunction1,
+		"mock2": mockGatherFunction2,
+		"error": mockGatherFunctionError,
+	}
+	return Gatherer{ctx: context.Background()}
+}
+
+func clean_up(cases []reflect.SelectCase) {
+	remaining := len(cases)
+	for remaining > 0 {
+		chosen, _, _ := reflect.Select(cases)
+		cases[chosen].Chan = reflect.ValueOf(nil)
+		remaining -= 1
+	}
+}
+
+func Test_startGathering_empty(t *testing.T) {
+	var gatherList []string
+	var errors []string
+	g := init_test()
+	cases, starts, err := g.startGathering(gatherList, &errors)
+	if cases != nil || starts != nil || err != nil {
+		t.Fatalf("unexpected return values, expected: nil, nil, nil, got: %p, %p, %s", cases, starts, err)
+	}
+
+}
+
+func Test_startGathering(t *testing.T) {
+	var errors []string
+	g := init_test()
+	gatherList := fullGatherList()
+	expected := len(gatherList)
+
+	cases, starts, err := g.startGathering(gatherList, &errors)
+	l_starts := len(starts)
+	l_cases := len(cases)
+	clean_up(cases)
+
+	if l_cases != expected || l_starts != expected || err != nil {
+		t.Fatalf("unexpected return values: \nExpected %d cases got %d \nExpected %d starts got %d \n Err should be nil got %s", expected, l_cases, expected, l_starts, err)
+	}
+
+}
+
+func Test_fullGatherList(t *testing.T) {
+	init_test()
+	gatherList := fullGatherList()
+	expected := 3
+	if got := len(gatherList); got != expected {
+		t.Fatalf("unexpected number of gather functions returned, expected: %d received: %d", expected, got)
+	}
+}
+
+func Test_sumErrors(t *testing.T) {
+	errors := []string {
+		"Error1",
+		"Error2",
+		"Error1",
+		"Error3",
+	}
+	expected := "Error1, Error2, Error3"
+	if got := sumErrors(errors).Error(); expected != got {
+		t.Fatalf("unexpected error sum returned, expected: %s received: %s", expected, got)
+	}
+}
 
 func Test_uniqueStrings(t *testing.T) {
 	tests := []struct {

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -144,7 +144,7 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 	return nil
 }
 
-func (g *Gatherer) startGathering(gatherList []string, errors* []string) ([]reflect.SelectCase, []time.Time, error) {
+func (g *Gatherer) startGathering(gatherList []string, errors *[]string) ([]reflect.SelectCase, []time.Time, error) {
 	var cases []reflect.SelectCase
 	var starts []time.Time
 	// Starts the gathers in Go routines

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -32,7 +32,12 @@ type Gatherer struct {
 	metricsGatherKubeConfig *rest.Config
 }
 
-type gatherFunction func(g *Gatherer) ([]record.Record, []error)
+type gatherResult struct {
+	records []record.Record
+	errors  []error
+}
+
+type gatherFunction func(g *Gatherer, c chan<- gatherResult)
 
 const gatherAll = "ALL"
 
@@ -88,40 +93,59 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 	}
 
 	if contains(gatherList, gatherAll) {
-		gatherList = make([]string, 0, len(gatherFunctions))
-		for k := range gatherFunctions {
-			gatherList = append(gatherList, k)
-		}
+		gatherList = fullGatherList()
 	}
 
+	var chans []chan gatherResult
+	var cases []reflect.SelectCase
+	var starts []time.Time
+
+	// Starts the gathers in Go routines
 	for _, gatherId := range gatherList {
 		gFn, ok := gatherFunctions[gatherId]
 		if !ok {
 			errors = append(errors, fmt.Sprintf("unknown gatherId in config: %s", gatherId))
 			continue
 		}
+		ch := make(chan gatherResult)
+		chans = append(chans, ch)
+		cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch)})
 		gatherName := runtime.FuncForPC(reflect.ValueOf(gFn).Pointer()).Name()
+
 		klog.V(5).Infof("Gathering %s", gatherName)
+		starts = append(starts, time.Now())
+		go gFn(g, ch)
 
-		start := time.Now()
-		records, errs := gFn(g)
-		elapsed := time.Since(start).Truncate(time.Millisecond)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
 
-		klog.V(4).Infof("Gather %s took %s to process %d records", gatherName, elapsed, len(records))
-		gatherReport = append(gatherReport, gatherStatusReport{gatherName, elapsed, len(records), errs})
+	// Gets the info from the Go routines
+	remaining := len(cases)
+	for remaining > 0 {
+		chosen, value, _ := reflect.Select(cases)
+		// The chosen channel has been closed, so zero out the channel to disable the case
+		cases[chosen].Chan = reflect.ValueOf(nil)
+		remaining -= 1
 
-		for _, err := range errs {
+		elapsed := time.Since(starts[chosen]).Truncate(time.Millisecond)
+
+		gatherResults, _ := value.Interface().(gatherResult)
+		gatherName := runtime.FuncForPC(reflect.ValueOf(gatherFunctions[gatherList[chosen]]).Pointer()).Name()
+		klog.V(4).Infof("Gather %s took %s to process %d records", gatherName, elapsed, len(gatherResults.records))
+		gatherReport = append(gatherReport, gatherStatusReport{gatherName, elapsed, len(gatherResults.records), gatherResults.errors})
+
+		for _, err := range gatherResults.errors {
 			errors = append(errors, err.Error())
 		}
-		for _, record := range records {
+		for _, record := range gatherResults.records {
 			if err := recorder.Record(record); err != nil {
 				errors = append(errors, fmt.Sprintf("unable to record %s: %v", record.Name, err))
 				continue
 			}
 		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+		fmt.Printf("Read from channel %#v and received %s\n", chans[chosen], value.String())
 	}
 
 	// Creates the gathering performance report
@@ -130,9 +154,7 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 	}
 
 	if len(errors) > 0 {
-		sort.Strings(errors)
-		errors = uniqueStrings(errors)
-		return fmt.Errorf("%s", strings.Join(errors, ", "))
+		return sumErrors(errors)
 	}
 	return nil
 }
@@ -140,6 +162,20 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 func recordGatherReport(recorder record.Interface, report []interface{}) error {
 	r := record.Record{Name: "insights-operator/gathers", Item: record.JSONMarshaller{Object: report}}
 	return recorder.Record(r)
+}
+
+func sumErrors(errors []string) error {
+	sort.Strings(errors)
+	errors = uniqueStrings(errors)
+	return fmt.Errorf("%s", strings.Join(errors, ", "))
+}
+
+func fullGatherList() []string {
+	gatherList := make([]string, 0, len(gatherFunctions))
+	for k := range gatherFunctions {
+		gatherList = append(gatherList, k)
+	}
+	return gatherList
 }
 
 func uniqueStrings(list []string) []string {

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -126,7 +126,7 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 				continue
 			}
 		}
-		fmt.Printf("Read from %s's channel and received %s\n", gatherName, value.String())
+		klog.V(4).Infof("Read from %s's channel and received %s\n", gatherName, value.String())
 	}
 
 	// Creates the gathering performance report

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -96,12 +96,8 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 		gatherList = fullGatherList()
 	}
 
-	var cases []reflect.SelectCase
-	var starts []time.Time
-	var err error
-
 	// Starts the gathers in Go routines
-	cases, starts, err = g.startGathering(gatherList, &errors)
+	cases, starts, err := g.startGathering(gatherList, &errors)
 	if err != nil {
 		return err
 	}

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -140,6 +140,10 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 	return nil
 }
 
+// Runs each gather functions in a goroutine.
+// Every gather function is given its own channel to send back the results.
+// 1. return value: `cases` list, used for dynamically reading from the channels.
+// 2. return value: `starts` list, contains that start time of each gather function.
 func (g *Gatherer) startGathering(gatherList []string, errors *[]string) ([]reflect.SelectCase, []time.Time, error) {
 	var cases []reflect.SelectCase
 	var starts []time.Time

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -126,7 +126,7 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 				continue
 			}
 		}
-		klog.V(4).Infof("Read from %s's channel and received %s\n", gatherName, value.String())
+		klog.V(5).Infof("Read from %s's channel and received %s\n", gatherName, value.String())
 	}
 
 	// Creates the gathering performance report

--- a/pkg/gather/clusterconfig/container_images.go
+++ b/pkg/gather/clusterconfig/container_images.go
@@ -36,12 +36,15 @@ const (
 //
 // Location in archive: config/running_containers.json
 // Id in config: container_images
-func GatherContainerImages(g *Gatherer) ([]record.Record, []error) {
+func GatherContainerImages(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherContainerImages(gatherKubeClient.CoreV1(), g.ctx)
+	records, errors := gatherContainerImages(gatherKubeClient.CoreV1(), g.ctx)
+	c <- gatherResult{records, errors}
 }
 
 func gatherContainerImages(coreClient corev1client.CoreV1Interface, ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/container_runtime_configs.go
+++ b/pkg/gather/clusterconfig/container_runtime_configs.go
@@ -21,13 +21,15 @@ import (
 //
 // Location in archive: config/containerruntimeconfigs/
 // Id in config: container_runtime_configs
-func GatherContainerRuntimeConfig(g *Gatherer) ([]record.Record, []error) {
+func GatherContainerRuntimeConfig(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherContainerRuntimeConfig(g.ctx, dynamicClient)
-
+	records, errors := gatherContainerRuntimeConfig(g.ctx, dynamicClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherContainerRuntimeConfig(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/custom_resource_definitions.go
+++ b/pkg/gather/clusterconfig/custom_resource_definitions.go
@@ -24,12 +24,15 @@ import (
 //
 // Location in archive: config/crd/
 // Id in config: crds
-func GatherCRD(g *Gatherer) ([]record.Record, []error) {
+func GatherCRD(g *Gatherer, c chan<- gatherResult){
+	defer close(c)
 	crdClient, err := apixv1beta1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherCRD(g.ctx, crdClient)
+	records, errors := gatherCRD(g.ctx, crdClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherCRD(ctx context.Context, crdClient apixv1beta1client.ApiextensionsV1beta1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/feature_gates.go
+++ b/pkg/gather/clusterconfig/feature_gates.go
@@ -22,12 +22,15 @@ import (
 // Location in archive: config/featuregate/
 // See: docs/insights-archive-sample/config/featuregate
 // Id in config: feature_gates
-func GatherClusterFeatureGates(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterFeatureGates(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherClusterFeatureGates(g.ctx, gatherConfigClient)
+	records, errors := gatherClusterFeatureGates(g.ctx, gatherConfigClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherClusterFeatureGates(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/host_subnets.go
+++ b/pkg/gather/clusterconfig/host_subnets.go
@@ -22,12 +22,15 @@ import (
 //
 // Location in archive: config/hostsubnet/
 // Id in config: host_subnets
-func GatherHostSubnet(g *Gatherer) ([]record.Record, []error) {
+func GatherHostSubnet(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherHostSubnet(g.ctx, gatherNetworkClient)
+	records, errors := gatherHostSubnet(g.ctx, gatherNetworkClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherHostSubnet(ctx context.Context, networkClient networkv1client.NetworkV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/image_pruners.go
+++ b/pkg/gather/clusterconfig/image_pruners.go
@@ -22,12 +22,15 @@ import (
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
 // Id in config: image_pruners
-func GatherClusterImagePruner(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterImagePruner(g *Gatherer, c chan<- gatherResult){
+	defer close(c)
 	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherClusterImagePruner(g.ctx, registryClient.ImageregistryV1())
+	records, errors := gatherClusterImagePruner(g.ctx, registryClient.ImageregistryV1())
+	c <- gatherResult{records, errors}
 }
 
 func gatherClusterImagePruner(ctx context.Context, registryClient imageregistryv1.ImageregistryV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/image_registries.go
+++ b/pkg/gather/clusterconfig/image_registries.go
@@ -22,12 +22,15 @@ import (
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 // Id in config: image_registries
-func GatherClusterImageRegistry(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterImageRegistry(g *Gatherer, c chan<- gatherResult){
+	defer close(c)
 	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherClusterImageRegistry(g.ctx, registryClient.ImageregistryV1())
+	records, errors := gatherClusterImageRegistry(g.ctx, registryClient.ImageregistryV1())
+	c <- gatherResult{records, errors}
 }
 
 func gatherClusterImageRegistry(ctx context.Context, registryClient imageregistryv1.ImageregistryV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/infrastructures.go
+++ b/pkg/gather/clusterconfig/infrastructures.go
@@ -22,12 +22,15 @@ import (
 // Location in archive: config/infrastructure/
 // See: docs/insights-archive-sample/config/infrastructure
 // Id in config: infrastructures
-func GatherClusterInfrastructure(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterInfrastructure(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherClusterInfrastructure(g.ctx, gatherConfigClient)
+	records, errors := gatherClusterInfrastructure(g.ctx, gatherConfigClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherClusterInfrastructure(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/ingresses.go
+++ b/pkg/gather/clusterconfig/ingresses.go
@@ -22,12 +22,15 @@ import (
 // Location in archive: config/ingress/
 // See: docs/insights-archive-sample/config/ingress
 // Id in config: ingress
-func GatherClusterIngress(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterIngress(g *Gatherer, c chan<- gatherResult){
+	defer close(c)
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherClusterIngress(g.ctx, gatherConfigClient)
+	records, errors := gatherClusterIngress(g.ctx, gatherConfigClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherClusterIngress(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/machine_config_pools.go
+++ b/pkg/gather/clusterconfig/machine_config_pools.go
@@ -21,12 +21,15 @@ import (
 //
 // Location in archive: config/machineconfigpools/
 // Id in config: machine_config_pools
-func GatherMachineConfigPool(g *Gatherer) ([]record.Record, []error) {
+func GatherMachineConfigPool(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherMachineConfigPool(g.ctx, dynamicClient)
+	records, errors := gatherMachineConfigPool(g.ctx, dynamicClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherMachineConfigPool(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/machine_sets.go
+++ b/pkg/gather/clusterconfig/machine_sets.go
@@ -21,12 +21,15 @@ import (
 //
 // Location in archive: machinesets/
 // Id in config: machine_sets
-func GatherMachineSet(g *Gatherer) ([]record.Record, []error) {
+func GatherMachineSet(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherMachineSet(g.ctx, dynamicClient)
+	records, errors := gatherMachineSet(g.ctx, dynamicClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherMachineSet(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/netnamespaces.go
+++ b/pkg/gather/clusterconfig/netnamespaces.go
@@ -27,12 +27,15 @@ type netNamespace struct {
 //
 // Location in archive: config/netnamespaces
 // Id in config: netnamespaces
-func GatherNetNamespace(g *Gatherer) ([]record.Record, []error) {
+func GatherNetNamespace(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherNetworkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherNetNamespace(g.ctx, gatherNetworkClient)
+	records, errors := gatherNetNamespace(g.ctx, gatherNetworkClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherNetNamespace(ctx context.Context, networkClient networkv1client.NetworkV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/networks.go
+++ b/pkg/gather/clusterconfig/networks.go
@@ -20,12 +20,15 @@ import (
 // Location in archive: config/network/
 // See: docs/insights-archive-sample/config/network
 // Id in config: networks
-func GatherClusterNetwork(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterNetwork(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherClusterNetwork(g.ctx, gatherConfigClient)
+	records, errors := gatherClusterNetwork(g.ctx, gatherConfigClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherClusterNetwork(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/oauths.go
+++ b/pkg/gather/clusterconfig/oauths.go
@@ -20,12 +20,15 @@ import (
 // Location in archive: config/oauth/
 // See: docs/insights-archive-sample/config/oauth
 // Id in config: oauths
-func GatherClusterOAuth(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterOAuth(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherClusterOAuth(g.ctx, gatherConfigClient)
+	records, errors := gatherClusterOAuth(g.ctx, gatherConfigClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherClusterOAuth(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/openshift_apiserver_operator_logs.go
+++ b/pkg/gather/clusterconfig/openshift_apiserver_operator_logs.go
@@ -2,8 +2,6 @@ package clusterconfig
 
 import (
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/openshift/insights-operator/pkg/record"
 )
 
 // GatherOpenShiftAPIServerOperatorLogs collects logs from openshift-apiserver-operator with following substrings:

--- a/pkg/gather/clusterconfig/openshift_apiserver_operator_logs.go
+++ b/pkg/gather/clusterconfig/openshift_apiserver_operator_logs.go
@@ -14,8 +14,8 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 //
 // Location in archive: config/pod/{namespace-name}/logs/{pod-name}/errors.log
-func GatherOpenShiftAPIServerOperatorLogs(g *Gatherer, ch chan<- gatherResult) {
-	defer close(ch)
+func GatherOpenShiftAPIServerOperatorLogs(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	messagesToSearch := []string{
 		"the server has received too many requests and has asked us",
 		"because serving request timed out and response had been started",
@@ -23,7 +23,7 @@ func GatherOpenShiftAPIServerOperatorLogs(g *Gatherer, ch chan<- gatherResult) {
 
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {
-		ch <- gatherResult{nil, []error{err}}
+		c <- gatherResult{nil, []error{err}}
 		return
 	}
 
@@ -40,9 +40,9 @@ func GatherOpenShiftAPIServerOperatorLogs(g *Gatherer, ch chan<- gatherResult) {
 		"app=openshift-apiserver-operator",
 	)
 	if err != nil {
-		ch <- gatherResult{nil, []error{err}}
+		c <- gatherResult{nil, []error{err}}
 		return
 	}
 
-	ch <- gatherResult{records, nil}
+	c <- gatherResult{records, nil}
 }

--- a/pkg/gather/clusterconfig/pod_disruption_budgets.go
+++ b/pkg/gather/clusterconfig/pod_disruption_budgets.go
@@ -32,12 +32,15 @@ var (
 // Location in archive: config/pdbs/
 // See: docs/insights-archive-sample/config/pdbs
 // Id in config: pdbs
-func GatherPodDisruptionBudgets(g *Gatherer) ([]record.Record, []error) {
+func GatherPodDisruptionBudgets(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherPodDisruptionBudgets(g.ctx, gatherPolicyClient)
+	records, errors := gatherPodDisruptionBudgets(g.ctx, gatherPolicyClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherPodDisruptionBudgets(ctx context.Context, policyClient policyclient.PolicyV1beta1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/proxies.go
+++ b/pkg/gather/clusterconfig/proxies.go
@@ -22,12 +22,15 @@ import (
 // Location in archive: config/proxy/
 // See: docs/insights-archive-sample/config/proxy
 // Id in config: proxies
-func GatherClusterProxy(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterProxy(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherClusterProxy(g.ctx, gatherConfigClient)
+	records, errors := gatherClusterProxy(g.ctx, gatherConfigClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherClusterProxy(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/recent_metrics.go
+++ b/pkg/gather/clusterconfig/recent_metrics.go
@@ -32,7 +32,8 @@ const (
 // Location in archive: config/metrics/
 // See: docs/insights-archive-sample/config/metrics
 // Id in config: metrics
-func GatherMostRecentMetrics(g *Gatherer) ([]record.Record, []error) {
+func GatherMostRecentMetrics(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	var metricsClient rest.Interface
 	metricsRESTClient, err := rest.RESTClientFor(g.metricsGatherKubeConfig)
 	if err != nil {
@@ -41,9 +42,11 @@ func GatherMostRecentMetrics(g *Gatherer) ([]record.Record, []error) {
 		metricsClient = metricsRESTClient
 	}
 	if metricsClient == nil {
-		return nil, nil
+		c <- gatherResult{nil, nil}
+		return
 	}
-	return gatherMostRecentMetrics(g.ctx, metricsClient)
+	records, errors := gatherMostRecentMetrics(g.ctx, metricsClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/version.go
+++ b/pkg/gather/clusterconfig/version.go
@@ -23,12 +23,14 @@ import (
 // Location in archive: config/version/
 // See: docs/insights-archive-sample/config/version
 // Id in config: version
-func GatherClusterVersion(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterVersion(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	config, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return []record.Record{{Name: "config/version", Item: ClusterVersionAnonymizer{config}}}, nil
+	c <- gatherResult{[]record.Record{{Name: "config/version", Item: ClusterVersionAnonymizer{config}}}, nil}
 }
 
 func GetClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.ClusterVersion, error) {
@@ -54,15 +56,18 @@ func GetClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.
 // Location in archive: config/id/
 // See: docs/insights-archive-sample/config/id
 // Id in config: id
-func GatherClusterID(g *Gatherer) ([]record.Record, []error) {
+func GatherClusterID(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	version, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
 	if version == nil {
-		return nil, nil
+		c <- gatherResult{nil, nil}
+		return
 	}
-	return []record.Record{{Name: "config/id", Item: Raw{string(version.Spec.ClusterID)}}}, nil
+	c <- gatherResult{[]record.Record{{Name: "config/id", Item: Raw{string(version.Spec.ClusterID)}}}, nil}
 }
 
 // ClusterVersionAnonymizer is serializing ClusterVersion with anonymization


### PR DESCRIPTION
Refactors `periodic.go` in a way that it doesn't use overly complicated workload management (it should be the responsibility of the gatherers to manage the workloads) and as it was written ~2 years ago and wasn't changed since so it doesn't fit how the actual codebase developed since then. (we only have 1 Gatherer but that has multiple independent gather functions, yet `periodic.go` tries to manage multiple Gatherers)

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample archive
- Shouldn't change

## Documentation
<!-- Are these changes reflected in documentation? -->

- TBD

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- TBD

## Privacy
Has no effect on privacy

## References
None