### PR TITLE
[release-4.6] Bug 1913645: Improved Red Hat image and crashlooping OpenShift pod collection

### DIFF
--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digest.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digest.go
@@ -1,0 +1,138 @@
+package digest
+
+import (
+	"fmt"
+	"hash"
+	"io"
+	"regexp"
+	"strings"
+)
+
+const (
+	// DigestSha256EmptyTar is the canonical sha256 digest of empty data
+	DigestSha256EmptyTar = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// Digest allows simple protection of hex formatted digest strings, prefixed
+// by their algorithm. Strings of type Digest have some guarantee of being in
+// the correct format and it provides quick access to the components of a
+// digest string.
+//
+// The following is an example of the contents of Digest types:
+//
+// 	sha256:7173b809ca12ec5dee4506cd86be934c4596dd234ee82c0662eac04a8c2c71dc
+//
+// This allows to abstract the digest behind this type and work only in those
+// terms.
+type Digest string
+
+// NewDigest returns a Digest from alg and a hash.Hash object.
+func NewDigest(alg Algorithm, h hash.Hash) Digest {
+	return NewDigestFromBytes(alg, h.Sum(nil))
+}
+
+// NewDigestFromBytes returns a new digest from the byte contents of p.
+// Typically, this can come from hash.Hash.Sum(...) or xxx.SumXXX(...)
+// functions. This is also useful for rebuilding digests from binary
+// serializations.
+func NewDigestFromBytes(alg Algorithm, p []byte) Digest {
+	return Digest(fmt.Sprintf("%s:%x", alg, p))
+}
+
+// NewDigestFromHex returns a Digest from alg and a the hex encoded digest.
+func NewDigestFromHex(alg, hex string) Digest {
+	return Digest(fmt.Sprintf("%s:%s", alg, hex))
+}
+
+// DigestRegexp matches valid digest types.
+var DigestRegexp = regexp.MustCompile(`[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+`)
+
+// DigestRegexpAnchored matches valid digest types, anchored to the start and end of the match.
+var DigestRegexpAnchored = regexp.MustCompile(`^` + DigestRegexp.String() + `$`)
+
+var (
+	// ErrDigestInvalidFormat returned when digest format invalid.
+	ErrDigestInvalidFormat = fmt.Errorf("invalid checksum digest format")
+
+	// ErrDigestInvalidLength returned when digest has invalid length.
+	ErrDigestInvalidLength = fmt.Errorf("invalid checksum digest length")
+
+	// ErrDigestUnsupported returned when the digest algorithm is unsupported.
+	ErrDigestUnsupported = fmt.Errorf("unsupported digest algorithm")
+)
+
+// ParseDigest parses s and returns the validated digest object. An error will
+// be returned if the format is invalid.
+func ParseDigest(s string) (Digest, error) {
+	d := Digest(s)
+
+	return d, d.Validate()
+}
+
+// FromReader returns the most valid digest for the underlying content using
+// the canonical digest algorithm.
+func FromReader(rd io.Reader) (Digest, error) {
+	return Canonical.FromReader(rd)
+}
+
+// FromBytes digests the input and returns a Digest.
+func FromBytes(p []byte) Digest {
+	return Canonical.FromBytes(p)
+}
+
+// Validate checks that the contents of d is a valid digest, returning an
+// error if not.
+func (d Digest) Validate() error {
+	s := string(d)
+
+	if !DigestRegexpAnchored.MatchString(s) {
+		return ErrDigestInvalidFormat
+	}
+
+	i := strings.Index(s, ":")
+	if i < 0 {
+		return ErrDigestInvalidFormat
+	}
+
+	// case: "sha256:" with no hex.
+	if i+1 == len(s) {
+		return ErrDigestInvalidFormat
+	}
+
+	switch algorithm := Algorithm(s[:i]); algorithm {
+	case SHA256, SHA384, SHA512:
+		if algorithm.Size()*2 != len(s[i+1:]) {
+			return ErrDigestInvalidLength
+		}
+	default:
+		return ErrDigestUnsupported
+	}
+
+	return nil
+}
+
+// Algorithm returns the algorithm portion of the digest. This will panic if
+// the underlying digest is not in a valid format.
+func (d Digest) Algorithm() Algorithm {
+	return Algorithm(d[:d.sepIndex()])
+}
+
+// Hex returns the hex digest portion of the digest. This will panic if the
+// underlying digest is not in a valid format.
+func (d Digest) Hex() string {
+	return string(d[d.sepIndex()+1:])
+}
+
+func (d Digest) String() string {
+	return string(d)
+}
+
+func (d Digest) sepIndex() int {
+	i := strings.Index(string(d), ":")
+
+	if i < 0 {
+		panic("could not find ':' in digest: " + d)
+	}
+
+	return i
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digester.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/digester.go
@@ -1,0 +1,155 @@
+package digest
+
+import (
+	"crypto"
+	"fmt"
+	"hash"
+	"io"
+)
+
+// Algorithm identifies and implementation of a digester by an identifier.
+// Note the that this defines both the hash algorithm used and the string
+// encoding.
+type Algorithm string
+
+// supported digest types
+const (
+	SHA256 Algorithm = "sha256" // sha256 with hex encoding
+	SHA384 Algorithm = "sha384" // sha384 with hex encoding
+	SHA512 Algorithm = "sha512" // sha512 with hex encoding
+
+	// Canonical is the primary digest algorithm used with the distribution
+	// project. Other digests may be used but this one is the primary storage
+	// digest.
+	Canonical = SHA256
+)
+
+var (
+	// TODO(stevvooe): Follow the pattern of the standard crypto package for
+	// registration of digests. Effectively, we are a registerable set and
+	// common symbol access.
+
+	// algorithms maps values to hash.Hash implementations. Other algorithms
+	// may be available but they cannot be calculated by the digest package.
+	algorithms = map[Algorithm]crypto.Hash{
+		SHA256: crypto.SHA256,
+		SHA384: crypto.SHA384,
+		SHA512: crypto.SHA512,
+	}
+)
+
+// Available returns true if the digest type is available for use. If this
+// returns false, New and Hash will return nil.
+func (a Algorithm) Available() bool {
+	h, ok := algorithms[a]
+	if !ok {
+		return false
+	}
+
+	// check availability of the hash, as well
+	return h.Available()
+}
+
+func (a Algorithm) String() string {
+	return string(a)
+}
+
+// Size returns number of bytes returned by the hash.
+func (a Algorithm) Size() int {
+	h, ok := algorithms[a]
+	if !ok {
+		return 0
+	}
+	return h.Size()
+}
+
+// Set implemented to allow use of Algorithm as a command line flag.
+func (a *Algorithm) Set(value string) error {
+	if value == "" {
+		*a = Canonical
+	} else {
+		// just do a type conversion, support is queried with Available.
+		*a = Algorithm(value)
+	}
+
+	return nil
+}
+
+// New returns a new digester for the specified algorithm. If the algorithm
+// does not have a digester implementation, nil will be returned. This can be
+// checked by calling Available before calling New.
+func (a Algorithm) New() Digester {
+	return &digester{
+		alg:  a,
+		hash: a.Hash(),
+	}
+}
+
+// Hash returns a new hash as used by the algorithm. If not available, the
+// method will panic. Check Algorithm.Available() before calling.
+func (a Algorithm) Hash() hash.Hash {
+	if !a.Available() {
+		// NOTE(stevvooe): A missing hash is usually a programming error that
+		// must be resolved at compile time. We don't import in the digest
+		// package to allow users to choose their hash implementation (such as
+		// when using stevvooe/resumable or a hardware accelerated package).
+		//
+		// Applications that may want to resolve the hash at runtime should
+		// call Algorithm.Available before call Algorithm.Hash().
+		panic(fmt.Sprintf("%v not available (make sure it is imported)", a))
+	}
+
+	return algorithms[a].New()
+}
+
+// FromReader returns the digest of the reader using the algorithm.
+func (a Algorithm) FromReader(rd io.Reader) (Digest, error) {
+	digester := a.New()
+
+	if _, err := io.Copy(digester.Hash(), rd); err != nil {
+		return "", err
+	}
+
+	return digester.Digest(), nil
+}
+
+// FromBytes digests the input and returns a Digest.
+func (a Algorithm) FromBytes(p []byte) Digest {
+	digester := a.New()
+
+	if _, err := digester.Hash().Write(p); err != nil {
+		// Writes to a Hash should never fail. None of the existing
+		// hash implementations in the stdlib or hashes vendored
+		// here can return errors from Write. Having a panic in this
+		// condition instead of having FromBytes return an error value
+		// avoids unnecessary error handling paths in all callers.
+		panic("write to hash function returned error: " + err.Error())
+	}
+
+	return digester.Digest()
+}
+
+// TODO(stevvooe): Allow resolution of verifiers using the digest type and
+// this registration system.
+
+// Digester calculates the digest of written data. Writes should go directly
+// to the return value of Hash, while calling Digest will return the current
+// value of the digest.
+type Digester interface {
+	Hash() hash.Hash // provides direct access to underlying hash instance.
+	Digest() Digest
+}
+
+// digester provides a simple digester definition that embeds a hasher.
+type digester struct {
+	alg  Algorithm
+	hash hash.Hash
+}
+
+func (d *digester) Hash() hash.Hash {
+	return d.hash
+}
+
+func (d *digester) Digest() Digest {
+	return NewDigest(d.alg, d.hash)
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/digest/doc.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/digest/doc.go
@@ -1,0 +1,5 @@
+// digest is a copy from "github.com/docker/distribution/digest" that is kept because we want to avoid the godep,
+// this package has no non-standard dependencies, and if it changes lots of other docker registry stuff breaks.
+// Don't try this at home!
+// Changes here require sign-off from openshift/api-reviewers and they will be rejected.
+package digest

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/doc.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/doc.go
@@ -1,0 +1,5 @@
+// reference is a copy from "github.com/docker/distribution/reference" that is kept because we want to avoid the godep,
+// this package has no non-standard dependencies, and if it changes lots of other docker registry stuff breaks.
+// Don't try this at home!
+// Changes here require sign-off from openshift/api-reviewers and they will be rejected.
+package reference

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/reference.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/reference.go
@@ -1,0 +1,370 @@
+// Package reference provides a general type to represent any way of referencing images within the registry.
+// Its main purpose is to abstract tags and digests (content-addressable hash).
+//
+// Grammar
+//
+// 	reference                       := name [ ":" tag ] [ "@" digest ]
+//	name                            := [hostname '/'] component ['/' component]*
+//	hostname                        := hostcomponent ['.' hostcomponent]* [':' port-number]
+//	hostcomponent                   := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
+//	port-number                     := /[0-9]+/
+//	component                       := alpha-numeric [separator alpha-numeric]*
+// 	alpha-numeric                   := /[a-z0-9]+/
+//	separator                       := /[_.]|__|[-]*/
+//
+//	tag                             := /[\w][\w.-]{0,127}/
+//
+//	digest                          := digest-algorithm ":" digest-hex
+//	digest-algorithm                := digest-algorithm-component [ digest-algorithm-separator digest-algorithm-component ]
+//	digest-algorithm-separator      := /[+.-_]/
+//	digest-algorithm-component      := /[A-Za-z][A-Za-z0-9]*/
+//	digest-hex                      := /[0-9a-fA-F]{32,}/ ; At least 128 bit digest value
+package reference
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/image/internal/digest"
+)
+
+const (
+	// NameTotalLengthMax is the maximum total number of characters in a repository name.
+	NameTotalLengthMax = 255
+)
+
+var (
+	// ErrReferenceInvalidFormat represents an error while trying to parse a string as a reference.
+	ErrReferenceInvalidFormat = errors.New("invalid reference format")
+
+	// ErrTagInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrTagInvalidFormat = errors.New("invalid tag format")
+
+	// ErrDigestInvalidFormat represents an error while trying to parse a string as a tag.
+	ErrDigestInvalidFormat = errors.New("invalid digest format")
+
+	// ErrNameContainsUppercase is returned for invalid repository names that contain uppercase characters.
+	ErrNameContainsUppercase = errors.New("repository name must be lowercase")
+
+	// ErrNameEmpty is returned for empty, invalid repository names.
+	ErrNameEmpty = errors.New("repository name must have at least one component")
+
+	// ErrNameTooLong is returned when a repository name is longer than NameTotalLengthMax.
+	ErrNameTooLong = fmt.Errorf("repository name must not be more than %v characters", NameTotalLengthMax)
+)
+
+// Reference is an opaque object reference identifier that may include
+// modifiers such as a hostname, name, tag, and digest.
+type Reference interface {
+	// String returns the full reference
+	String() string
+}
+
+// Field provides a wrapper type for resolving correct reference types when
+// working with encoding.
+type Field struct {
+	reference Reference
+}
+
+// AsField wraps a reference in a Field for encoding.
+func AsField(reference Reference) Field {
+	return Field{reference}
+}
+
+// Reference unwraps the reference type from the field to
+// return the Reference object. This object should be
+// of the appropriate type to further check for different
+// reference types.
+func (f Field) Reference() Reference {
+	return f.reference
+}
+
+// MarshalText serializes the field to byte text which
+// is the string of the reference.
+func (f Field) MarshalText() (p []byte, err error) {
+	return []byte(f.reference.String()), nil
+}
+
+// UnmarshalText parses text bytes by invoking the
+// reference parser to ensure the appropriately
+// typed reference object is wrapped by field.
+func (f *Field) UnmarshalText(p []byte) error {
+	r, err := Parse(string(p))
+	if err != nil {
+		return err
+	}
+
+	f.reference = r
+	return nil
+}
+
+// Named is an object with a full name
+type Named interface {
+	Reference
+	Name() string
+}
+
+// Tagged is an object which has a tag
+type Tagged interface {
+	Reference
+	Tag() string
+}
+
+// NamedTagged is an object including a name and tag.
+type NamedTagged interface {
+	Named
+	Tag() string
+}
+
+// Digested is an object which has a digest
+// in which it can be referenced by
+type Digested interface {
+	Reference
+	Digest() digest.Digest
+}
+
+// Canonical reference is an object with a fully unique
+// name including a name with hostname and digest
+type Canonical interface {
+	Named
+	Digest() digest.Digest
+}
+
+// SplitHostname splits a named reference into a
+// hostname and name string. If no valid hostname is
+// found, the hostname is empty and the full value
+// is returned as name
+func SplitHostname(named Named) (string, string) {
+	name := named.Name()
+	match := anchoredNameRegexp.FindStringSubmatch(name)
+	if len(match) != 3 {
+		return "", name
+	}
+	return match[1], match[2]
+}
+
+// Parse parses s and returns a syntactically valid Reference.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: Parse will not handle short digests.
+func Parse(s string) (Reference, error) {
+	matches := ReferenceRegexp.FindStringSubmatch(s)
+	if matches == nil {
+		if s == "" {
+			return nil, ErrNameEmpty
+		}
+		if ReferenceRegexp.FindStringSubmatch(strings.ToLower(s)) != nil {
+			return nil, ErrNameContainsUppercase
+		}
+		return nil, ErrReferenceInvalidFormat
+	}
+
+	if len(matches[1]) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+
+	ref := reference{
+		name: matches[1],
+		tag:  matches[2],
+	}
+	if matches[3] != "" {
+		var err error
+		ref.digest, err = digest.ParseDigest(matches[3])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	r := getBestReferenceType(ref)
+	if r == nil {
+		return nil, ErrNameEmpty
+	}
+
+	return r, nil
+}
+
+// ParseNamed parses s and returns a syntactically valid reference implementing
+// the Named interface. The reference must have a name, otherwise an error is
+// returned.
+// If an error was encountered it is returned, along with a nil Reference.
+// NOTE: ParseNamed will not handle short digests.
+func ParseNamed(s string) (Named, error) {
+	ref, err := Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	named, isNamed := ref.(Named)
+	if !isNamed {
+		return nil, fmt.Errorf("reference %s has no name", ref.String())
+	}
+	return named, nil
+}
+
+// WithName returns a named object representing the given string. If the input
+// is invalid ErrReferenceInvalidFormat will be returned.
+func WithName(name string) (Named, error) {
+	if len(name) > NameTotalLengthMax {
+		return nil, ErrNameTooLong
+	}
+	if !anchoredNameRegexp.MatchString(name) {
+		return nil, ErrReferenceInvalidFormat
+	}
+	return repository(name), nil
+}
+
+// WithTag combines the name from "name" and the tag from "tag" to form a
+// reference incorporating both the name and the tag.
+func WithTag(name Named, tag string) (NamedTagged, error) {
+	if !anchoredTagRegexp.MatchString(tag) {
+		return nil, ErrTagInvalidFormat
+	}
+	if canonical, ok := name.(Canonical); ok {
+		return reference{
+			name:   name.Name(),
+			tag:    tag,
+			digest: canonical.Digest(),
+		}, nil
+	}
+	return taggedReference{
+		name: name.Name(),
+		tag:  tag,
+	}, nil
+}
+
+// WithDigest combines the name from "name" and the digest from "digest" to form
+// a reference incorporating both the name and the digest.
+func WithDigest(name Named, digest digest.Digest) (Canonical, error) {
+	if !anchoredDigestRegexp.MatchString(digest.String()) {
+		return nil, ErrDigestInvalidFormat
+	}
+	if tagged, ok := name.(Tagged); ok {
+		return reference{
+			name:   name.Name(),
+			tag:    tagged.Tag(),
+			digest: digest,
+		}, nil
+	}
+	return canonicalReference{
+		name:   name.Name(),
+		digest: digest,
+	}, nil
+}
+
+// Match reports whether ref matches the specified pattern.
+// See https://godoc.org/path#Match for supported patterns.
+func Match(pattern string, ref Reference) (bool, error) {
+	matched, err := path.Match(pattern, ref.String())
+	if namedRef, isNamed := ref.(Named); isNamed && !matched {
+		matched, _ = path.Match(pattern, namedRef.Name())
+	}
+	return matched, err
+}
+
+// TrimNamed removes any tag or digest from the named reference.
+func TrimNamed(ref Named) Named {
+	return repository(ref.Name())
+}
+
+func getBestReferenceType(ref reference) Reference {
+	if ref.name == "" {
+		// Allow digest only references
+		if ref.digest != "" {
+			return digestReference(ref.digest)
+		}
+		return nil
+	}
+	if ref.tag == "" {
+		if ref.digest != "" {
+			return canonicalReference{
+				name:   ref.name,
+				digest: ref.digest,
+			}
+		}
+		return repository(ref.name)
+	}
+	if ref.digest == "" {
+		return taggedReference{
+			name: ref.name,
+			tag:  ref.tag,
+		}
+	}
+
+	return ref
+}
+
+type reference struct {
+	name   string
+	tag    string
+	digest digest.Digest
+}
+
+func (r reference) String() string {
+	return r.name + ":" + r.tag + "@" + r.digest.String()
+}
+
+func (r reference) Name() string {
+	return r.name
+}
+
+func (r reference) Tag() string {
+	return r.tag
+}
+
+func (r reference) Digest() digest.Digest {
+	return r.digest
+}
+
+type repository string
+
+func (r repository) String() string {
+	return string(r)
+}
+
+func (r repository) Name() string {
+	return string(r)
+}
+
+type digestReference digest.Digest
+
+func (d digestReference) String() string {
+	return string(d)
+}
+
+func (d digestReference) Digest() digest.Digest {
+	return digest.Digest(d)
+}
+
+type taggedReference struct {
+	name string
+	tag  string
+}
+
+func (t taggedReference) String() string {
+	return t.name + ":" + t.tag
+}
+
+func (t taggedReference) Name() string {
+	return t.name
+}
+
+func (t taggedReference) Tag() string {
+	return t.tag
+}
+
+type canonicalReference struct {
+	name   string
+	digest digest.Digest
+}
+
+func (c canonicalReference) String() string {
+	return c.name + "@" + c.digest.String()
+}
+
+func (c canonicalReference) Name() string {
+	return c.name
+}
+
+func (c canonicalReference) Digest() digest.Digest {
+	return c.digest
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/internal/reference/regexp.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/internal/reference/regexp.go
@@ -1,0 +1,124 @@
+package reference
+
+import "regexp"
+
+var (
+	// alphaNumericRegexp defines the alpha numeric atom, typically a
+	// component of names. This only allows lower case characters and digits.
+	alphaNumericRegexp = match(`[a-z0-9]+`)
+
+	// separatorRegexp defines the separators allowed to be embedded in name
+	// components. This allow one period, one or two underscore and multiple
+	// dashes.
+	separatorRegexp = match(`(?:[._]|__|[-]*)`)
+
+	// nameComponentRegexp restricts registry path component names to start
+	// with at least one letter or number, with following parts able to be
+	// separated by one period, one or two underscore and multiple dashes.
+	nameComponentRegexp = expression(
+		alphaNumericRegexp,
+		optional(repeated(separatorRegexp, alphaNumericRegexp)))
+
+	// hostnameComponentRegexp restricts the registry hostname component of a
+	// repository name to start with a component as defined by hostnameRegexp
+	// and followed by an optional port.
+	hostnameComponentRegexp = match(`(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`)
+
+	// hostnameRegexp defines the structure of potential hostname components
+	// that may be part of image names. This is purposely a subset of what is
+	// allowed by DNS to ensure backwards compatibility with Docker image
+	// names.
+	hostnameRegexp = expression(
+		hostnameComponentRegexp,
+		optional(repeated(literal(`.`), hostnameComponentRegexp)),
+		optional(literal(`:`), match(`[0-9]+`)))
+
+	// TagRegexp matches valid tag names. From docker/docker:graph/tags.go.
+	TagRegexp = match(`[\w][\w.-]{0,127}`)
+
+	// anchoredTagRegexp matches valid tag names, anchored at the start and
+	// end of the matched string.
+	anchoredTagRegexp = anchored(TagRegexp)
+
+	// DigestRegexp matches valid digests.
+	DigestRegexp = match(`[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}`)
+
+	// anchoredDigestRegexp matches valid digests, anchored at the start and
+	// end of the matched string.
+	anchoredDigestRegexp = anchored(DigestRegexp)
+
+	// NameRegexp is the format for the name component of references. The
+	// regexp has capturing groups for the hostname and name part omitting
+	// the separating forward slash from either.
+	NameRegexp = expression(
+		optional(hostnameRegexp, literal(`/`)),
+		nameComponentRegexp,
+		optional(repeated(literal(`/`), nameComponentRegexp)))
+
+	// anchoredNameRegexp is used to parse a name value, capturing the
+	// hostname and trailing components.
+	anchoredNameRegexp = anchored(
+		optional(capture(hostnameRegexp), literal(`/`)),
+		capture(nameComponentRegexp,
+			optional(repeated(literal(`/`), nameComponentRegexp))))
+
+	// ReferenceRegexp is the full supported format of a reference. The regexp
+	// is anchored and has capturing groups for name, tag, and digest
+	// components.
+	ReferenceRegexp = anchored(capture(NameRegexp),
+		optional(literal(":"), capture(TagRegexp)),
+		optional(literal("@"), capture(DigestRegexp)))
+)
+
+// match compiles the string to a regular expression.
+var match = regexp.MustCompile
+
+// literal compiles s into a literal regular expression, escaping any regexp
+// reserved characters.
+func literal(s string) *regexp.Regexp {
+	re := match(regexp.QuoteMeta(s))
+
+	if _, complete := re.LiteralPrefix(); !complete {
+		panic("must be a literal")
+	}
+
+	return re
+}
+
+// expression defines a full expression, where each regular expression must
+// follow the previous.
+func expression(res ...*regexp.Regexp) *regexp.Regexp {
+	var s string
+	for _, re := range res {
+		s += re.String()
+	}
+
+	return match(s)
+}
+
+// optional wraps the expression in a non-capturing group and makes the
+// production optional.
+func optional(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `?`)
+}
+
+// repeated wraps the regexp in a non-capturing group to get one or more
+// matches.
+func repeated(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(group(expression(res...)).String() + `+`)
+}
+
+// group wraps the regexp in a non-capturing group.
+func group(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(?:` + expression(res...).String() + `)`)
+}
+
+// capture wraps the expression in a capturing group.
+func capture(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`(` + expression(res...).String() + `)`)
+}
+
+// anchored anchors the regular expression by adding start and end delimiters.
+func anchored(res ...*regexp.Regexp) *regexp.Regexp {
+	return match(`^` + expression(res...).String() + `$`)
+}

--- a/vendor/github.com/openshift/library-go/pkg/image/reference/reference.go
+++ b/vendor/github.com/openshift/library-go/pkg/image/reference/reference.go
@@ -1,0 +1,245 @@
+package reference
+
+import (
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/openshift/library-go/pkg/image/internal/digest"
+	"github.com/openshift/library-go/pkg/image/internal/reference"
+)
+
+// DockerImageReference points to a Docker image.
+type DockerImageReference struct {
+	Registry  string
+	Namespace string
+	Name      string
+	Tag       string
+	ID        string
+}
+
+const (
+	// DockerDefaultRegistry is the value for the registry when none was provided.
+	DockerDefaultRegistry = "docker.io"
+	// DockerDefaultV1Registry is the host name of the default v1 registry
+	DockerDefaultV1Registry = "index." + DockerDefaultRegistry
+	// DockerDefaultV2Registry is the host name of the default v2 registry
+	DockerDefaultV2Registry = "registry-1." + DockerDefaultRegistry
+)
+
+// Parse parses a Docker pull spec string into a
+// DockerImageReference.
+func Parse(spec string) (DockerImageReference, error) {
+	var ref DockerImageReference
+
+	namedRef, err := reference.ParseNamed(spec)
+	if err != nil {
+		return ref, err
+	}
+
+	name := namedRef.Name()
+	i := strings.IndexRune(name, '/')
+	if i == -1 || (!strings.ContainsAny(name[:i], ":.") && name[:i] != "localhost") {
+		ref.Name = name
+	} else {
+		ref.Registry, ref.Name = name[:i], name[i+1:]
+	}
+
+	if named, ok := namedRef.(reference.NamedTagged); ok {
+		ref.Tag = named.Tag()
+	}
+
+	if named, ok := namedRef.(reference.Canonical); ok {
+		ref.ID = named.Digest().String()
+	}
+
+	// It's not enough just to use the reference.ParseNamed(). We have to fill
+	// ref.Namespace from ref.Name
+	if i := strings.IndexRune(ref.Name, '/'); i != -1 {
+		ref.Namespace, ref.Name = ref.Name[:i], ref.Name[i+1:]
+	}
+
+	return ref, nil
+}
+
+// Equal returns true if the other DockerImageReference is equivalent to the
+// reference r. The comparison applies defaults to the Docker image reference,
+// so that e.g., "foobar" equals "docker.io/library/foobar:latest".
+func (r DockerImageReference) Equal(other DockerImageReference) bool {
+	defaultedRef := r.DockerClientDefaults()
+	otherDefaultedRef := other.DockerClientDefaults()
+	return defaultedRef == otherDefaultedRef
+}
+
+// DockerClientDefaults sets the default values used by the Docker client.
+func (r DockerImageReference) DockerClientDefaults() DockerImageReference {
+	if len(r.Registry) == 0 {
+		r.Registry = DockerDefaultRegistry
+	}
+	if len(r.Namespace) == 0 && IsRegistryDockerHub(r.Registry) {
+		r.Namespace = "library"
+	}
+	if len(r.Tag) == 0 {
+		r.Tag = "latest"
+	}
+	return r
+}
+
+// Minimal reduces a DockerImageReference to its minimalist form.
+func (r DockerImageReference) Minimal() DockerImageReference {
+	if r.Tag == "latest" {
+		r.Tag = ""
+	}
+	return r
+}
+
+// AsRepository returns the reference without tags or IDs.
+func (r DockerImageReference) AsRepository() DockerImageReference {
+	r.Tag = ""
+	r.ID = ""
+	return r
+}
+
+// RepositoryName returns the registry relative name
+func (r DockerImageReference) RepositoryName() string {
+	r.Tag = ""
+	r.ID = ""
+	r.Registry = ""
+	return r.Exact()
+}
+
+// RegistryHostPort returns the registry hostname and the port.
+// If the port is not specified in the registry hostname we default to 443.
+// This will also default to Docker client defaults if the registry hostname is empty.
+func (r DockerImageReference) RegistryHostPort(insecure bool) (string, string) {
+	registryHost := r.AsV2().DockerClientDefaults().Registry
+	if strings.Contains(registryHost, ":") {
+		hostname, port, _ := net.SplitHostPort(registryHost)
+		return hostname, port
+	}
+	if insecure {
+		return registryHost, "80"
+	}
+	return registryHost, "443"
+}
+
+// RepositoryName returns the registry relative name
+func (r DockerImageReference) RegistryURL() *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   r.AsV2().Registry,
+	}
+}
+
+// DaemonMinimal clears defaults that Docker assumes.
+func (r DockerImageReference) DaemonMinimal() DockerImageReference {
+	switch r.Registry {
+	case DockerDefaultV1Registry, DockerDefaultV2Registry:
+		r.Registry = DockerDefaultRegistry
+	}
+	if IsRegistryDockerHub(r.Registry) && r.Namespace == "library" {
+		r.Namespace = ""
+	}
+	return r.Minimal()
+}
+
+func (r DockerImageReference) AsV2() DockerImageReference {
+	switch r.Registry {
+	case DockerDefaultV1Registry, DockerDefaultRegistry:
+		r.Registry = DockerDefaultV2Registry
+	}
+	return r
+}
+
+// MostSpecific returns the most specific image reference that can be constructed from the
+// current ref, preferring an ID over a Tag. Allows client code dealing with both tags and IDs
+// to get the most specific reference easily.
+func (r DockerImageReference) MostSpecific() DockerImageReference {
+	if len(r.ID) == 0 {
+		return r
+	}
+	if _, err := digest.ParseDigest(r.ID); err == nil {
+		r.Tag = ""
+		return r
+	}
+	if len(r.Tag) == 0 {
+		r.Tag, r.ID = r.ID, ""
+		return r
+	}
+	return r
+}
+
+// NameString returns the name of the reference with its tag or ID.
+func (r DockerImageReference) NameString() string {
+	switch {
+	case len(r.Name) == 0:
+		return ""
+	case len(r.ID) > 0:
+		var ref string
+		if _, err := digest.ParseDigest(r.ID); err == nil {
+			// if it parses as a digest, its v2 pull by id
+			ref = "@" + r.ID
+		} else {
+			// if it doesn't parse as a digest, it's presumably a v1 registry by-id tag
+			ref = ":" + r.ID
+		}
+		return r.Name + ref
+	case len(r.Tag) > 0:
+		return r.Name + ":" + r.Tag
+	default:
+		return r.Name
+	}
+}
+
+// Exact returns a string representation of the set fields on the DockerImageReference
+func (r DockerImageReference) Exact() string {
+	name := r.NameString()
+	if len(name) == 0 {
+		return name
+	}
+	s := r.Registry
+	if len(s) > 0 {
+		s += "/"
+	}
+
+	if len(r.Namespace) != 0 {
+		s += r.Namespace + "/"
+	}
+	return s + name
+}
+
+// String converts a DockerImageReference to a Docker pull spec (which implies a default namespace
+// according to V1 Docker registry rules). Use Exact() if you want no defaulting.
+func (r DockerImageReference) String() string {
+	if len(r.Namespace) == 0 && IsRegistryDockerHub(r.Registry) {
+		r.Namespace = "library"
+	}
+	return r.Exact()
+}
+
+// IsRegistryDockerHub returns true if the given registry name belongs to
+// Docker hub.
+func IsRegistryDockerHub(registry string) bool {
+	switch registry {
+	case DockerDefaultRegistry, DockerDefaultV1Registry, DockerDefaultV2Registry:
+		return true
+	default:
+		return false
+	}
+}
+
+// DeepCopyInto writing into out. in must be non-nil.
+func (in *DockerImageReference) DeepCopyInto(out *DockerImageReference) {
+	*out = *in
+	return
+}
+
+// DeepCopy copies the receiver, creating a new DockerImageReference.
+func (in *DockerImageReference) DeepCopy() *DockerImageReference {
+	if in == nil {
+		return nil
+	}
+	out := new(DockerImageReference)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,6 +129,9 @@ github.com/openshift/library-go/pkg/controller/controllercmd
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/controller/metrics
 github.com/openshift/library-go/pkg/crypto
+github.com/openshift/library-go/pkg/image/internal/digest
+github.com/openshift/library-go/pkg/image/internal/reference
+github.com/openshift/library-go/pkg/image/reference
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/serviceability
 # github.com/pkg/errors v0.8.1


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
The old container image collection code is already in `release-4.6`, but the improvements are not yet. So this PR backports only the improvements into the 4.6 branch.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [x] Enhancement
- [x] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/running_containers.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

Short description in the `docs/gathered-data.md` file, as per usual.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gather/clusterconfig/clusterconfig_test.go` - `TestGatherContainerImages` (together with all the other tests before refactor)

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

No sensitive data is collected by this enhancement.

## Changelog
<!-- Was changelog updated? -->

N/A

## References
<!-- What are related references for this PR? -->

### Base Implementation

PR: #133
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1860032

### Improvements

PR: #174 
Task: https://issues.redhat.com/browse/CCXDEV-2750

### Backporting

Task: https://issues.redhat.com/browse/CCXDEV-2674
