### PR TITLE
Bug 1917799: Gather list of OLM operator names and versions & minor clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.7
 
 - [#319](https://github.com/openshift/insights-operator/pull/319) Gather PersistentVolume definition (if any) used in Image registry storage config
+- [#316](https://github.com/openshift/insights-operator/pull/316) Gather list of OLM operator names and versions & minor clean up
 - [#309](https://github.com/openshift/insights-operator/pull/309) Collect logs from openshift-sdn namespace
 - [#279](https://github.com/openshift/insights-operator/pull/279) Refactoring record and gatherer
 - [#297](https://github.com/openshift/insights-operator/pull/297) Gather netnamespaces network info

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -307,6 +307,15 @@ Output raw size: 491
 #### Nodes
 [{"Name":"config/node/","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":{"metadata":{"creationTimestamp":null},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False","lastHeartbeatTime":null,"lastTransitionTime":null}],"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}}]
 
+## OLMOperators
+
+collects list of all names (including version) of installed OLM operators.
+
+See: docs/insights-archive-sample/config/olm_operators
+Location of in archive: config/olm_operators
+Id in config: olm_operators
+
+
 ## OpenShiftAPIServerOperatorLogs
 
 collects logs from openshift-apiserver-operator with following substrings:

--- a/docs/insights-archive-sample/config/olm_operators.json
+++ b/docs/insights-archive-sample/config/olm_operators.json
@@ -1,0 +1,22 @@
+[
+    {
+        "name": "eap.openshift-operators",
+        "version": "v2.0.2"
+    },
+    {
+        "name": "elasticsearch-operator.openshift-operators-redhat",
+        "version": "4.6.0-202011221454.p0"
+    },
+    {
+        "name": "kiali-ossm.openshift-operators",
+        "version": "v1.24.4"
+    },
+    {
+        "name": "postgresql-operator-dev4devs-com.postgresql-operator",
+        "version": "v0.1.1"
+    },
+    {
+        "name": "radanalytics-spark.openshift-operators",
+        "version": "v1.1.0"
+    }
+]

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -180,6 +180,14 @@ rules:
     - get
     - list
     - watch 
+- apiGroups:
+    - operators.coreos.com
+  resources:
+    - "*"
+  verbs:
+    - get
+    - list
+    - watch      
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 )
 

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -85,6 +85,7 @@ var gatherFunctions = map[string]gathering{
 	"openshift_sdn_logs":                important(GatherOpenshiftSDNLogs),
 	"openshift_sdn_controller_logs":     important(GatherOpenshiftSDNControllerLogs),
 	"sap_config":                        failable(GatherSAPConfig),
+	"olm_operators":                     failable(GatherOLMOperators),
 }
 
 // New creates new Gatherer

--- a/pkg/gather/clusterconfig/0_utils.go
+++ b/pkg/gather/clusterconfig/0_utils.go
@@ -24,7 +24,6 @@ import (
 	networkv1 "github.com/openshift/api/network/v1"
 	openshiftscheme "github.com/openshift/client-go/config/clientset/versioned/scheme"
 	appsv1 "k8s.io/api/apps/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 

--- a/pkg/gather/clusterconfig/0_utils.go
+++ b/pkg/gather/clusterconfig/0_utils.go
@@ -3,8 +3,10 @@ package clusterconfig
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/url"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -312,4 +314,41 @@ func countLines(r io.Reader) (int, error) {
 			return lineCount, err
 		}
 	}
+}
+
+func parseJSONQuery(j map[string]interface{}, jq string, o interface{}) error {
+	for _, k := range strings.Split(jq, ".") {
+		// optional field
+		opt := false
+		sz := len(k)
+		if sz > 0 && k[sz-1] == '?' {
+			opt = true
+			k = k[:sz-1]
+		}
+
+		if uv, ok := j[k]; ok {
+			if v, ok := uv.(map[string]interface{}); ok {
+				j = v
+				continue
+			}
+			// ValueOf to enter reflect-land
+			dstPtrValue := reflect.ValueOf(o)
+			dstValue := reflect.Indirect(dstPtrValue)
+			dstValue.Set(reflect.ValueOf(uv))
+
+			return nil
+		}
+		if opt {
+			return nil
+		}
+		// otherwise key was not found
+		// keys are case sensitive, because maps are
+		for ki := range j {
+			if strings.ToLower(k) == strings.ToLower(ki) {
+				return fmt.Errorf("key %s wasn't found, but %s was ", k, ki)
+			}
+		}
+		return fmt.Errorf("key %s wasn't found in %v ", k, j)
+	}
+	return fmt.Errorf("query didn't match the structure")
 }

--- a/pkg/gather/clusterconfig/authentications.go
+++ b/pkg/gather/clusterconfig/authentications.go
@@ -2,11 +2,11 @@ package clusterconfig
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/certificate_signing_requests_test.go
+++ b/pkg/gather/clusterconfig/certificate_signing_requests_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	certificatesv1b1api "k8s.io/api/certificates/v1beta1"
+	certificatesv1api "k8s.io/api/certificates/v1"
 )
 
 func TestCSRs(t *testing.T) {
@@ -24,7 +24,7 @@ func TestCSRs(t *testing.T) {
 	for _, tt := range files {
 		t.Run(tt.dataFile, func(t *testing.T) {
 
-			r := &certificatesv1b1api.CertificateSigningRequest{}
+			r := &certificatesv1api.CertificateSigningRequest{}
 
 			f, err := os.Open(tt.dataFile)
 			if err != nil {

--- a/pkg/gather/clusterconfig/config_maps.go
+++ b/pkg/gather/clusterconfig/config_maps.go
@@ -11,8 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 )
 

--- a/pkg/gather/clusterconfig/container_images.go
+++ b/pkg/gather/clusterconfig/container_images.go
@@ -12,8 +12,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 	"github.com/openshift/library-go/pkg/image/reference"
 )

--- a/pkg/gather/clusterconfig/container_runtime_configs.go
+++ b/pkg/gather/clusterconfig/container_runtime_configs.go
@@ -9,8 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 )
 

--- a/pkg/gather/clusterconfig/custom_resource_definitions.go
+++ b/pkg/gather/clusterconfig/custom_resource_definitions.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	apixv1beta1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	apixv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )
@@ -26,7 +24,7 @@ import (
 // Id in config: crds
 func GatherCRD(g *Gatherer, c chan<- gatherResult){
 	defer close(c)
-	crdClient, err := apixv1beta1client.NewForConfig(g.gatherKubeConfig)
+	crdClient, err := apixv1.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
 		c <- gatherResult{nil, []error{err}}
 		return
@@ -35,7 +33,7 @@ func GatherCRD(g *Gatherer, c chan<- gatherResult){
 	c <- gatherResult{records, errors}
 }
 
-func gatherCRD(ctx context.Context, crdClient apixv1beta1client.ApiextensionsV1beta1Interface) ([]record.Record, []error) {
+func gatherCRD(ctx context.Context, crdClient apixv1.ApiextensionsV1Interface) ([]record.Record, []error) {
 	toBeCollected := []string{
 		"volumesnapshots.snapshot.storage.k8s.io",
 		"volumesnapshotcontents.snapshot.storage.k8s.io",

--- a/pkg/gather/clusterconfig/custom_resource_definitions_test.go
+++ b/pkg/gather/clusterconfig/custom_resource_definitions_test.go
@@ -5,13 +5,13 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apixv1beta1clientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apixv1clientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCollectVolumeSnapshotCRD(t *testing.T) {
-	expectedRecords := map[string]v1beta1.CustomResourceDefinition{
+	expectedRecords := map[string]v1.CustomResourceDefinition{
 		"config/crd/volumesnapshots.snapshot.storage.k8s.io":        {ObjectMeta: metav1.ObjectMeta{Name: "volumesnapshots.snapshot.storage.k8s.io"}},
 		"config/crd/volumesnapshotcontents.snapshot.storage.k8s.io": {ObjectMeta: metav1.ObjectMeta{Name: "volumesnapshotcontents.snapshot.storage.k8s.io"}},
 	}
@@ -24,16 +24,16 @@ func TestCollectVolumeSnapshotCRD(t *testing.T) {
 		"this.should.not.be.gathered.k8s.io",
 	}
 
-	crdClientset := apixv1beta1clientfake.NewSimpleClientset()
+	crdClientset := apixv1clientfake.NewSimpleClientset()
 
 	for _, name := range crdNames {
-		crdClientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.Background(), &v1beta1.CustomResourceDefinition{
+		crdClientset.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), &v1.CustomResourceDefinition{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 		}, metav1.CreateOptions{})
 	}
 
 	ctx := context.Background()
-	records, errs := gatherCRD(ctx, crdClientset.ApiextensionsV1beta1())
+	records, errs := gatherCRD(ctx, crdClientset.ApiextensionsV1())
 	if len(errs) != 0 {
 		t.Fatalf("gather CRDs resulted in error: %#v", errs)
 	}

--- a/pkg/gather/clusterconfig/feature_gates.go
+++ b/pkg/gather/clusterconfig/feature_gates.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/host_subnets.go
+++ b/pkg/gather/clusterconfig/host_subnets.go
@@ -10,7 +10,6 @@ import (
 
 	networkv1 "github.com/openshift/api/network/v1"
 	networkv1client "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/image_pruners.go
+++ b/pkg/gather/clusterconfig/image_pruners.go
@@ -13,7 +13,6 @@ import (
 	registryv1 "github.com/openshift/api/imageregistry/v1"
 	imageregistryv1client "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	imageregistryv1 "github.com/openshift/client-go/imageregistry/clientset/versioned/typed/imageregistry/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/image_registries.go
+++ b/pkg/gather/clusterconfig/image_registries.go
@@ -16,7 +16,6 @@ import (
 	registryv1 "github.com/openshift/api/imageregistry/v1"
 	imageregistryv1client "github.com/openshift/client-go/imageregistry/clientset/versioned"
 	imageregistryv1 "github.com/openshift/client-go/imageregistry/clientset/versioned/typed/imageregistry/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/infrastructures.go
+++ b/pkg/gather/clusterconfig/infrastructures.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/ingresses.go
+++ b/pkg/gather/clusterconfig/ingresses.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/install_plans.go
+++ b/pkg/gather/clusterconfig/install_plans.go
@@ -14,8 +14,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 )
 

--- a/pkg/gather/clusterconfig/install_plans.go
+++ b/pkg/gather/clusterconfig/install_plans.go
@@ -3,7 +3,6 @@ package clusterconfig
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -145,43 +144,6 @@ func failEarly(fns ...func() error) error {
 		}
 	}
 	return nil
-}
-
-func parseJSONQuery(j map[string]interface{}, jq string, o interface{}) error {
-	for _, k := range strings.Split(jq, ".") {
-		// optional field
-		opt := false
-		sz := len(k)
-		if sz > 0 && k[sz-1] == '?' {
-			opt = true
-			k = k[:sz-1]
-		}
-
-		if uv, ok := j[k]; ok {
-			if v, ok := uv.(map[string]interface{}); ok {
-				j = v
-				continue
-			}
-			// ValueOf to enter reflect-land
-			dstPtrValue := reflect.ValueOf(o)
-			dstValue := reflect.Indirect(dstPtrValue)
-			dstValue.Set(reflect.ValueOf(uv))
-
-			return nil
-		}
-		if opt {
-			return nil
-		}
-		// otherwise key was not found
-		// keys are case sensitive, because maps are
-		for ki := range j {
-			if strings.ToLower(k) == strings.ToLower(ki) {
-				return fmt.Errorf("key %s wasn't found, but %s was ", k, ki)
-			}
-		}
-		return fmt.Errorf("key %s wasn't found in %v ", k, j)
-	}
-	return fmt.Errorf("query didn't match the structure")
 }
 
 type collectedPlan struct {

--- a/pkg/gather/clusterconfig/machine_config_pools.go
+++ b/pkg/gather/clusterconfig/machine_config_pools.go
@@ -9,8 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 )
 

--- a/pkg/gather/clusterconfig/machine_sets.go
+++ b/pkg/gather/clusterconfig/machine_sets.go
@@ -9,8 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 )
 

--- a/pkg/gather/clusterconfig/netnamespaces.go
+++ b/pkg/gather/clusterconfig/netnamespaces.go
@@ -9,7 +9,6 @@ import (
 
 	networkv1 "github.com/openshift/api/network/v1"
 	networkv1client "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/networks.go
+++ b/pkg/gather/clusterconfig/networks.go
@@ -7,7 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/nodes.go
+++ b/pkg/gather/clusterconfig/nodes.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 

--- a/pkg/gather/clusterconfig/oauths.go
+++ b/pkg/gather/clusterconfig/oauths.go
@@ -7,7 +7,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/olm_operators.go
+++ b/pkg/gather/clusterconfig/olm_operators.go
@@ -25,12 +25,15 @@ type olmOperator struct {
 // See: docs/insights-archive-sample/config/olm_operators
 // Location of in archive: config/olm_operators
 // Id in config: olm_operators
-func GatherOLMOperators(g *Gatherer) ([]record.Record, []error) {
+func GatherOLMOperators(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
 	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{nil, []error{err}}
+		return
 	}
-	return gatherOLMOperators(g.ctx, dynamicClient)
+	records, errors := gatherOLMOperators(g.ctx, dynamicClient)
+	c <- gatherResult{records, errors}
 }
 
 func gatherOLMOperators(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/olm_operators.go
+++ b/pkg/gather/clusterconfig/olm_operators.go
@@ -1,0 +1,113 @@
+package clusterconfig
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+type olmOperator struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// GatherOLMOperators collects list of all names (including version) of installed OLM operators.
+//
+// See: docs/insights-archive-sample/config/olm_operators
+// Location of in archive: config/olm_operators
+// Id in config: olm_operators
+func GatherOLMOperators(g *Gatherer) ([]record.Record, []error) {
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherOLMOperators(g.ctx, dynamicClient)
+}
+
+func gatherOLMOperators(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	gvr := schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1", Resource: "operators"}
+	olmOperators, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	var refs []interface{}
+	olms := []olmOperator{}
+	for _, i := range olmOperators.Items {
+		err := parseJSONQuery(i.Object, "status.components.refs", &refs)
+		if err != nil {
+			klog.Errorf("Cannot find \"status.components.refs\" in %s definition: %v", i.GetName(), err)
+			continue
+		}
+		for _, r := range refs {
+			ver := readVersionFromRefs(r)
+			if ver == "" {
+				continue
+			}
+			olmO := olmOperator{
+				Name:    i.GetName(),
+				Version: ver,
+			}
+			if isInArray(olmO, olms) {
+				continue
+			}
+			olms = append(olms, olmO)
+		}
+	}
+	if len(olms) == 0 {
+		return nil, nil
+	}
+	r := record.Record{
+		Name: "config/olm_operators",
+		Item: OlmOperatorAnonymizer{operators: olms},
+	}
+	return []record.Record{r}, nil
+}
+
+func isInArray(o olmOperator, a []olmOperator) bool {
+	for _, op := range a {
+		if o == op {
+			return true
+		}
+	}
+	return false
+}
+
+func readVersionFromRefs(r interface{}) string {
+	refMap, ok := r.(map[string]interface{})
+	if !ok {
+		klog.Errorf("Cannot convert %s to map[string]interface{}", r)
+		return ""
+	}
+	// version is part of the name of ClusterServiceVersion
+	if refMap["kind"] == "ClusterServiceVersion" {
+		name := refMap["name"].(string)
+		nameVer := strings.SplitN(name, ".", 2)
+		return nameVer[1]
+	}
+	return ""
+}
+
+// OlmOperatorAnonymizer implements HostSubnet serialization
+type OlmOperatorAnonymizer struct{ operators []olmOperator }
+
+// Marshal implements OlmOperator serialization
+func (a OlmOperatorAnonymizer) Marshal(_ context.Context) ([]byte, error) {
+	return json.Marshal(a.operators)
+}
+
+// GetExtension returns extension for OlmOperator object
+func (a OlmOperatorAnonymizer) GetExtension() string {
+	return "json"
+}

--- a/pkg/gather/clusterconfig/olm_operators_test.go
+++ b/pkg/gather/clusterconfig/olm_operators_test.go
@@ -1,0 +1,62 @@
+package clusterconfig
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestOLMOperatorsGather(t *testing.T) {
+	f, err := os.Open("testdata/olm_operator_1.yaml")
+	if err != nil {
+		t.Fatal("test failed to read OLM operator data", err)
+	}
+	olmOpContent, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatal("error reading test data file", err)
+	}
+	gvr := schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1", Resource: "operators"}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		gvr: "OperatorsList",
+	})
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+
+	testOLMOperator := &unstructured.Unstructured{}
+
+	_, _, err = decUnstructured.Decode(olmOpContent, nil, testOLMOperator)
+	if err != nil {
+		t.Fatal("unable to decode OLM operator ", err)
+	}
+	_, err = client.Resource(gvr).Create(context.Background(), testOLMOperator, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("unable to create fake OLM operator ", err)
+	}
+
+	ctx := context.Background()
+	records, errs := gatherOLMOperators(ctx, client)
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %#v", errs)
+		return
+	}
+	if len(records) != 1 {
+		t.Fatalf("unexpected number or records %d", len(records))
+	}
+	ooa, ok := records[0].Item.(OlmOperatorAnonymizer)
+	if !ok {
+		t.Fatalf("returned item is not of type OlmOperatorAnonymizer")
+	}
+	if ooa.operators[0].Name != "test-olm-operator" {
+		t.Fatalf("unexpected name of gathered OLM operator %s", ooa.operators[0])
+	}
+	if ooa.operators[0].Version != "v6.6.6" {
+		t.Fatalf("unexpected version of gathered OLM operator %s", ooa.operators[0])
+	}
+}

--- a/pkg/gather/clusterconfig/olm_operators_test.go
+++ b/pkg/gather/clusterconfig/olm_operators_test.go
@@ -56,7 +56,7 @@ func TestOLMOperatorsGather(t *testing.T) {
 	if ooa.operators[0].Name != "test-olm-operator" {
 		t.Fatalf("unexpected name of gathered OLM operator %s", ooa.operators[0])
 	}
-	if ooa.operators[0].Version != "v6.6.6" {
+	if ooa.operators[0].Version != "v1.2.3" {
 		t.Fatalf("unexpected version of gathered OLM operator %s", ooa.operators[0])
 	}
 }

--- a/pkg/gather/clusterconfig/operators.go
+++ b/pkg/gather/clusterconfig/operators.go
@@ -21,7 +21,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/gather/clusterconfig/pod_disruption_budgets.go
+++ b/pkg/gather/clusterconfig/pod_disruption_budgets.go
@@ -11,8 +11,6 @@ import (
 
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 )
 

--- a/pkg/gather/clusterconfig/proxies.go
+++ b/pkg/gather/clusterconfig/proxies.go
@@ -9,7 +9,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/service_accounts.go
+++ b/pkg/gather/clusterconfig/service_accounts.go
@@ -13,8 +13,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-
 	"github.com/openshift/insights-operator/pkg/record"
 )
 

--- a/pkg/gather/clusterconfig/stateful_sets.go
+++ b/pkg/gather/clusterconfig/stateful_sets.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/klog/v2"
 
 	appsv1 "k8s.io/api/apps/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )

--- a/pkg/gather/clusterconfig/testdata/olm_operator_1.yaml
+++ b/pkg/gather/clusterconfig/testdata/olm_operator_1.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+    name: test-olm-operator
+status:
+    components:
+        refs:
+            - apiVersion: operators.coreos.com/v1alpha1
+              kind: ClusterServiceVersion
+              name: test-olm-operator.v1.2.3
+              namespace: test-olm-operator

--- a/pkg/gather/clusterconfig/version.go
+++ b/pkg/gather/clusterconfig/version.go
@@ -10,7 +10,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	_ "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR gathers all the names & versions of the installed OLM operators using dynamic client & some clean up.

I am still wondering what the relation between `ClusterServiceVersion` and `Operator` kind is and why the versions (`v1alpha1` and `v1`) are different when both are from `operators.coreos.com`. The sets of these kinds are not equal that's why I implemented with using `Operator`, but it would be much more straightforward using `ClusterServiceVersion`. 


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/olm_operators.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

-  `pkg/gather/clusterconfig/olm_operators_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->
Not yet

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
