### PR TITLE
Bug 1921013: Gather PersistentVolume definition (if any) used in Image registry st…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.7
 
+- [#319](https://github.com/openshift/insights-operator/pull/319) Gather PersistentVolume definition (if any) used in Image registry storage config
 - [#309](https://github.com/openshift/insights-operator/pull/309) Collect logs from openshift-sdn namespace
 - [#279](https://github.com/openshift/insights-operator/pull/279) Refactoring record and gatherer
 - [#297](https://github.com/openshift/insights-operator/pull/297) Gather netnamespaces network info

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -73,6 +73,8 @@ Id in config: image_pruners
 ## ClusterImageRegistry
 
 fetches the cluster Image Registry configuration
+If the Image Registry configuration uses some PersistentVolumeClaim for the storage then the corresponding
+PersistentVolume definition is gathered
 
 Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 Id in config: image_registries

--- a/pkg/gather/clusterconfig/image_registries.go
+++ b/pkg/gather/clusterconfig/image_registries.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 
 	registryv1 "github.com/openshift/api/imageregistry/v1"
@@ -19,27 +22,50 @@ import (
 )
 
 // GatherClusterImageRegistry fetches the cluster Image Registry configuration
+// If the Image Registry configuration uses some PersistentVolumeClaim for the storage then the corresponding
+// PersistentVolume definition is gathered
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 // Id in config: image_registries
-func GatherClusterImageRegistry(g *Gatherer, c chan<- gatherResult){
+func GatherClusterImageRegistry(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)
 	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
 		c <- gatherResult{nil, []error{err}}
 		return
 	}
-	records, errors := gatherClusterImageRegistry(g.ctx, registryClient.ImageregistryV1())
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		c <- gatherResult{nil, []error{err}}
+		return
+	}
+	records, errors := gatherClusterImageRegistry(g.ctx, registryClient.ImageregistryV1(), gatherKubeClient.CoreV1())
 	c <- gatherResult{records, errors}
 }
 
-func gatherClusterImageRegistry(ctx context.Context, registryClient imageregistryv1.ImageregistryV1Interface) ([]record.Record, []error) {
+func gatherClusterImageRegistry(ctx context.Context, registryClient imageregistryv1.ImageregistryV1Interface, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
 	config, err := registryClient.Configs().Get(ctx, "cluster", metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, []error{err}
+	}
+	records := []record.Record{}
+	// if there is some PVC then try to gather used persistent volume
+	if config.Spec.Storage.PVC != nil {
+
+		pvcName := config.Spec.Storage.PVC.Claim
+		pv, err := findPVByPVCName(ctx, coreClient, pvcName)
+		if err != nil {
+			klog.Errorf("unable to find persistent volume: %s", err)
+		} else {
+			pvRecord := record.Record{
+				Name: fmt.Sprintf("config/persistentvolumes/%s", pv.Name),
+				Item: PersistentVolumeAnonymizer{pv},
+			}
+			records = append(records, pvRecord)
+		}
 	}
 	// TypeMeta is empty - see https://github.com/kubernetes/kubernetes/issues/3030
 	kinds, _, err := registryScheme.ObjectKinds(config)
@@ -50,10 +76,12 @@ func gatherClusterImageRegistry(ctx context.Context, registryClient imageregistr
 		klog.Warningf("More kinds for image registry config operator resource %s", kinds)
 	}
 	objKind := kinds[0]
-	return []record.Record{{
+	coRecord := record.Record{
 		Name: fmt.Sprintf("config/clusteroperator/%s/%s/%s", objKind.Group, strings.ToLower(objKind.Kind), config.Name),
 		Item: ImageRegistryAnonymizer{config},
-	}}, nil
+	}
+	records = append(records, coRecord)
+	return records, nil
 }
 
 // ImageRegistryAnonymizer implements serialization with marshalling
@@ -93,5 +121,45 @@ func (a ImageRegistryAnonymizer) Marshal(_ context.Context) ([]byte, error) {
 
 // GetExtension returns extension for anonymized image registry objects
 func (a ImageRegistryAnonymizer) GetExtension() string {
+	return "json"
+}
+
+// findPVByPVCName tries to find *corev1.PersistentVolume used in PersistentVolumeClaim with provided name
+func findPVByPVCName(ctx context.Context, coreClient corev1client.CoreV1Interface, name string) (*corev1.PersistentVolume, error) {
+	// unfortunately we can't do "coreClient.PersistentVolumeClaims("").Get(ctx, name, ... )"
+	pvcs, err := coreClient.PersistentVolumeClaims("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var pvc *corev1.PersistentVolumeClaim
+	for _, p := range pvcs.Items {
+		if p.Name == name {
+			pvc = &p
+			break
+		}
+	}
+	if pvc == nil {
+		return nil, fmt.Errorf("can't find any %s persistentvolumeclaim", name)
+	}
+	pvName := pvc.Spec.VolumeName
+	pv, err := coreClient.PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return pv, nil
+}
+
+// PersistentVolumeAnonymizer implements serialization with marshalling
+type PersistentVolumeAnonymizer struct {
+	*corev1.PersistentVolume
+}
+
+// Marshal implements serialization of corev1.PersistentVolume without anonymization
+func (p PersistentVolumeAnonymizer) Marshal(_ context.Context) ([]byte, error) {
+	return runtime.Encode(kubeSerializer, p.PersistentVolume)
+}
+
+// GetExtension returns extension for PersistentVolume objects
+func (p PersistentVolumeAnonymizer) GetExtension() string {
 	return "json"
 }

--- a/pkg/gather/clusterconfig/image_registries_test.go
+++ b/pkg/gather/clusterconfig/image_registries_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	imageregistryfake "github.com/openshift/client-go/imageregistry/clientset/versioned/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestGatherClusterImageRegistry(t *testing.T) {
@@ -121,8 +122,9 @@ func TestGatherClusterImageRegistry(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := imageregistryfake.NewSimpleClientset(test.inputObj)
+			coreClient := kubefake.NewSimpleClientset()
 			ctx := context.Background()
-			records, errs := gatherClusterImageRegistry(ctx, client.ImageregistryV1())
+			records, errs := gatherClusterImageRegistry(ctx, client.ImageregistryV1(), coreClient.CoreV1())
 			if len(errs) > 0 {
 				t.Errorf("unexpected errors: %#v", errs)
 				return


### PR DESCRIPTION
…orage config

<!-- Short description of the PR. What does it do? -->
This gathers PV (if there's any) used in image registry config as storage. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->
I didn't add the corresponding PV to the sample archive, because it could look like we gather all the persistent volumes by default. 

## Documentation
<!-- Are these changes reflected in documentation? -->

- Doc updated in `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- No update. No way to use "real" PV in the unit tests AFAIK. 

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->
Not yet

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/INSIGHTOCP-54
