### PR TITLE
[release-4.6] Bug 1921554: Gather OpenShift SDN error messages from logs

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -251,6 +251,20 @@ Output raw size: 491
 #### Nodes
 [{"Name":"config/node/","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":{"metadata":{"creationTimestamp":null},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False","lastHeartbeatTime":null,"lastTransitionTime":null}],"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}}]
 
+## OpenshiftSDNLogs
+
+collects logs from pods in openshift-sdn namespace with following substrings:
+  - "Got OnEndpointsUpdate for unknown Endpoints",
+  - "Got OnEndpointsDelete for unknown Endpoints",
+  - "Unable to update proxy firewall for policy",
+  - "Failed to update proxy firewall for policy",
+
+The Kubernetes API https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+
+Location in archive: config/pod/openshift-sdn/logs/{pod-name}/errors.log
+
+
 ## PodDisruptionBudgets
 
 gathers the cluster's PodDisruptionBudgets.


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This adds new gatherer which gathers important messages from SDN pod logs. 

OCP Networking is one of biggest support case volumes areas
These data enhancements were requested by Support SMEs and will enable them to
- shorten time to resolve. Data that we normally request form customers will be gathered automatically
- there are several Insights rules attached to these new data enhancement which have potential to deflect dozens OCP support cases each month

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->
- no data available for the sample archive because we haven't been able to reproduce the errors yet

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md `

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Unfortunately no unit test because the fake pod expansion returns only empty request (see https://github.com/kubernetes/client-go/blob/v0.18.9/kubernetes/typed/core/v1/fake/fake_pod_expansion.go#L60) in our current version. So there's not much to test. 

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->
So far, we only have changelog in the master branch 

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-3957
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
