### PR TITLE
[release-4.6] Bug 1921743: collect logs from openshift-sdn-controller…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -264,6 +264,26 @@ Output raw size: 491
 #### Nodes
 [{"Name":"config/node/","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":{"metadata":{"creationTimestamp":null},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False","lastHeartbeatTime":null,"lastTransitionTime":null}],"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}}]
 
+## OpenshiftSDNControllerLogs
+
+collects logs from sdn-controller pod in openshift-sdn namespace with following substrings:
+  - "Node %s is not Ready": A node has been set offline for egress IPs because it is reported not ready at API
+  - "Node %s may be offline... retrying": An egress node has failed the egress IP health check once,
+      so it has big chances to be marked as offline soon or, at the very least, there has been a connectivity glitch.
+  - "Node %s is offline": An egress node has failed enough probes to have been marked offline for egress IPs.
+      If it has egress CIDRs assigned, its egress IPs have been moved to other nodes.
+      Indicates issues at either the node or the network between the master and the node.
+  - "Node %s is back online": This indicates that a node has recovered from the condition described
+      at the previous message, by starting succeeding the egress IP health checks.
+      Useful just in case that previous “Node %s is offline” messages are lost,
+      so that we have a clue that there was failure previously.
+
+The Kubernetes API https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+
+Location in archive: config/pod/openshift-sdn/logs/{pod-name}/errors.log
+
+
 ## OpenshiftSDNLogs
 
 collects logs from pods in openshift-sdn namespace with following substrings:

--- a/docs/insights-archive-sample/config/pod/openshift-sdn/logs/sdn-controller-l8gq9/errors.log
+++ b/docs/insights-archive-sample/config/pod/openshift-sdn/logs/sdn-controller-l8gq9/errors.log
@@ -1,0 +1,7 @@
+W0120 20:07:54.645321       1 egressip.go:199] Node ci-ln-0d402jb-f76d1-hts4b-worker-c-2nwdl is not Ready
+W0120 20:08:29.646400       1 egressip.go:199] Node ci-ln-0d402jb-f76d1-hts4b-worker-c-2nwdl is not Ready
+I0120 20:08:59.649184       1 egressip.go:208] Node 10.0.32.3 is back online
+I0120 20:13:49.656538       1 egressip.go:219] Node 10.0.32.3 may be offline... retrying
+I0120 20:13:57.710028       1 egressip.go:219] Node 10.0.32.3 may be offline... retrying
+W0120 20:14:12.749977       1 egressip.go:214] Node 10.0.32.3 is offline
+I0120 20:15:29.663808       1 egressip.go:208] Node 10.0.32.3 is back online

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -205,6 +205,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherNetNamespace(i),
 		GatherServiceAccounts(i),
 		GatherSAPConfig(i),
+		GatherOpenshiftSDNControllerLogs(i),
 	)
 }
 
@@ -1309,6 +1310,50 @@ func GatherOpenshiftSDNLogs(g *Gatherer) func() ([]record.Record, []error) {
 			"errors",
 			"app=sdn",
 			false,
+		)
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		return records, nil
+	}
+}
+
+// GatherOpenshiftSDNControllerLogs collects logs from sdn-controller pod in openshift-sdn namespace with following substrings:
+//   - "Node %s is not Ready": A node has been set offline for egress IPs because it is reported not ready at API
+//   - "Node %s may be offline... retrying": An egress node has failed the egress IP health check once,
+//       so it has big chances to be marked as offline soon or, at the very least, there has been a connectivity glitch.
+//   - "Node %s is offline": An egress node has failed enough probes to have been marked offline for egress IPs.
+//       If it has egress CIDRs assigned, its egress IPs have been moved to other nodes.
+//       Indicates issues at either the node or the network between the master and the node.
+//   - "Node %s is back online": This indicates that a node has recovered from the condition described
+//       at the previous message, by starting succeeding the egress IP health checks.
+//       Useful just in case that previous “Node %s is offline” messages are lost,
+//       so that we have a clue that there was failure previously.
+//
+// The Kubernetes API https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+// Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+//
+// Location in archive: config/pod/openshift-sdn/logs/{pod-name}/errors.log
+func GatherOpenshiftSDNControllerLogs(g *Gatherer) func() ([]record.Record, []error) {
+	return func() ([]record.Record, []error) {
+		messagesToSearch := []string{
+			"Node.+is not Ready",
+			"Node.+may be offline\\.\\.\\. retrying",
+			"Node.+is offline",
+			"Node.+is back online",
+		}
+
+		records, err := gatherLogsFromPodsInNamespace(
+			g.ctx,
+			g.coreClient,
+			"openshift-sdn",
+			messagesToSearch,
+			86400,   // last day
+			1024*64, // maximum 64 kb of logs
+			"errors",
+			"app=sdn-controller",
+			true,
 		)
 		if err != nil {
 			return nil, []error{err}


### PR DESCRIPTION
… pod

<!-- Short description of the PR. What does it do? -->
This adds new gatherer which gathers important messages from SDN controller pod logs.

OCP Networking is one of biggest support case volumes areas
These data enhancements were requested by Support SMEs and will enable them to:

- shorten time to resolve. Data that we normally request form customers will be gathered automatically
-  there are several Insights rules attached to these new data enhancement which have potential to deflect dozens OCP support cases each month


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/pod/openshift-sdn/logs/sdn-controller-l8gq9/errors.log `

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
Unfortunately no unit test because the fake pod expansion returns only empty request (see https://github.com/kubernetes/client-go/blob/v0.18.9/kubernetes/typed/core/v1/fake/fake_pod_expansion.go#L60) in our current version. So there's not much to test.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->
So far, we only have changelog in the master branch

## References
<!-- What are related references for this PR? -->
https://issues.redhat.com/browse/CCXDEV-3607
https://bugzilla.redhat.com/show_bug.cgi?id=1921743
