### PR TITLE
Bug 1923888: Fixes error metadata gathering

### DIFF
--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -16,10 +16,10 @@ import (
 )
 
 type gatherStatusReport struct {
-	Name    string        `json:"name"`
-	Elapsed time.Duration `json:"elapsed"`
-	Report  int           `json:"report"`
-	Errors  []string      `json:"errors"`
+	Name     string        `json:"name"`
+	Duration time.Duration `json:"duration_in_ms"`
+	Report   int           `json:"report"`
+	Errors   []string      `json:"errors"`
 }
 
 // Gatherer is a driving instance invoking collection of data
@@ -130,7 +130,7 @@ func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder rec
 		gatherCanFail := gatherFunctions[gatherList[chosen]].canFail
 		gatherName := runtime.FuncForPC(reflect.ValueOf(gatherFunc).Pointer()).Name()
 		klog.V(4).Infof("Gather %s took %s to process %d records", gatherName, elapsed, len(gatherResults.records))
-		gatherReport = append(gatherReport, gatherStatusReport{gatherName, elapsed, len(gatherResults.records), extractErrors(gatherResults.errors)})
+		gatherReport = append(gatherReport, gatherStatusReport{gatherName, time.Duration(elapsed.Milliseconds()), len(gatherResults.records), extractErrors(gatherResults.errors)})
 
 		if gatherCanFail {
 			for _, err := range gatherResults.errors {

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -16,10 +16,10 @@ import (
 )
 
 type gatherStatusReport struct {
-	Name     string        `json:"name"`
-	Duration time.Duration `json:"duration_in_ms"`
-	Report   int           `json:"report"`
-	Errors   []string      `json:"errors"`
+	Name     		string        `json:"name"`
+	Duration 		time.Duration `json:"duration_in_ms"`
+	RecordsCount  	int           `json:"records_count"`
+	Errors   		[]string      `json:"errors"`
 }
 
 // Gatherer is a driving instance invoking collection of data
@@ -99,7 +99,7 @@ func New(gatherKubeConfig *rest.Config, gatherProtoKubeConfig *rest.Config, metr
 func (g *Gatherer) Gather(ctx context.Context, gatherList []string, recorder record.Interface) error {
 	g.ctx = ctx
 	var errors []string
-	var gatherReport []interface{}
+	var gatherReport []gatherStatusReport
 
 	if len(gatherList) == 0 {
 		errors = append(errors, "no gather functions are specified to run")
@@ -189,7 +189,7 @@ func (g *Gatherer) startGathering(gatherList []string, errors *[]string) ([]refl
 	return cases, starts, nil
 }
 
-func recordGatherReport(recorder record.Interface, report []interface{}) error {
+func recordGatherReport(recorder record.Interface, report []gatherStatusReport) error {
 	r := record.Record{Name: "insights-operator/gathers", Item: record.JSONMarshaller{Object: report}}
 	return recorder.Record(r)
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Errors produced by the gather-functions are supposed to be stored in the metadata, but because it was left up to go on how to parse/store the errors, so they either showed up correctly or just an empty object, which is not really helpful.

This PR fixes that by just storing the error string (ie.: `error.Error()`).

## Categories
<!-- Select the categories that your PR better fits on -->

- [x] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- not necessary

## Documentation
<!-- Are these changes reflected in documentation? -->

- not necessary

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- not necessary

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->
not necessary

## References
<!-- What are related references for this PR? -->
-