### PR TITLE
Bug 1922267: collect invalid resource name error from logs 

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -316,7 +316,18 @@ collects logs from openshift-apiserver-operator with following substrings:
 The Kubernetes API https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
 Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 
-Location in archive: config/pod/openshift-apiserver-operator/logs/{pod-name}/errors.log
+Location in archive: config/pod/{namespace-name}/logs/{pod-name}/errors.log
+
+
+## OpenshiftAuthenticationLogs
+
+collects logs from pods in openshift-authentication namespace with following substring:
+  - "AuthenticationError: invalid resource name"
+
+The Kubernetes API https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+
+Location in archive: config/pod/openshift-authentication/logs/{pod-name}/errors.log
 
 
 ## OpenshiftSDNControllerLogs

--- a/docs/insights-archive-sample/config/pod/openshift-authentication/logs/oauth-openshift-6c98668d5b-ftt5n/errors.log
+++ b/docs/insights-archive-sample/config/pod/openshift-authentication/logs/oauth-openshift-6c98668d5b-ftt5n/errors.log
@@ -1,0 +1,1 @@
+E0201 16:15:39.833795       1 errorpage.go:26] AuthenticationError: invalid resource name "openid-keycloak:test/test": [may not contain '/']

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -84,6 +84,7 @@ var gatherFunctions = map[string]gathering{
 	"openshift_apiserver_operator_logs": important(GatherOpenShiftAPIServerOperatorLogs),
 	"openshift_sdn_logs":                important(GatherOpenshiftSDNLogs),
 	"openshift_sdn_controller_logs":     important(GatherOpenshiftSDNControllerLogs),
+	"openshift_authentication_logs":     important(GatherOpenshiftAuthenticationLogs),
 	"sap_config":                        failable(GatherSAPConfig),
 }
 

--- a/pkg/gather/clusterconfig/openshift_authentication_logs.go
+++ b/pkg/gather/clusterconfig/openshift_authentication_logs.go
@@ -1,0 +1,45 @@
+package clusterconfig
+
+import (
+	"k8s.io/client-go/kubernetes"
+)
+
+// GatherOpenshiftAuthenticationLogs collects logs from pods in openshift-authentication namespace with following substring:
+//   - "AuthenticationError: invalid resource name"
+//
+// The Kubernetes API https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+// Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+//
+// Location in archive: config/pod/openshift-authentication/logs/{pod-name}/errors.log
+func GatherOpenshiftAuthenticationLogs(g *Gatherer, c chan<- gatherResult) {
+	messagesToSearch := []string{
+		"AuthenticationError: invalid resource name",
+	}
+
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		c <- gatherResult{nil, []error{err}}
+		return
+	}
+
+	coreClient := gatherKubeClient.CoreV1()
+
+	records, err := gatherLogsFromPodsInNamespace(
+		g.ctx,
+		coreClient,
+		"openshift-authentication",
+		messagesToSearch,
+		86400,   // last day
+		1024*64, // maximum 64 kb of logs
+		"errors",
+		"",
+		false,
+	)
+	if err != nil {
+		c <- gatherResult{nil, []error{err}}
+		return
+	}
+
+	c <- gatherResult{records, nil}
+	return
+}


### PR DESCRIPTION
collect invalid resource name error from logs of openshift-authentication namespace

## Categories

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Documentation

- `docs/gathered-data.md`

## Privacy

Yes. There are no sensitive data in the newly collected information.

## References

https://issues.redhat.com/browse/CCXDEV-3900
https://bugzilla.redhat.com/show_bug.cgi?id=1922267
https://access.redhat.com/solutions/???
