### PR TITLE
[release-4.6] Bug 1885941: Gather ServiceAccounts stats from cluster namespaces

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -297,6 +297,7 @@ Response see https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-
 
 Location in archive: config/machineconfigpools/
 See: docs/insights-archive-sample/config/machineconfigpools/
+
 ## ContainerRuntimeConfig
 
 collects ContainerRuntimeConfig information
@@ -306,4 +307,16 @@ Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeco
 
 Location in archive: config/containerruntimeconfigs/
 See: docs/insights-archive-sample/config/containerruntimeconfigs
+
+## ServiceAccounts
+
+collects ServiceAccount stats
+from kubernetes default and namespaces starting with openshift.
+
+The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/serviceaccount.go#L83
+Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#serviceaccount-v1-core
+
+Location of serviceaccounts in archive: config/serviceaccounts
+See: docs/insights-archive-sample/config/serviceaccounts
+
 

--- a/docs/insights-archive-sample/config/serviceaccounts.json
+++ b/docs/insights-archive-sample/config/serviceaccounts.json
@@ -1,0 +1,175 @@
+{
+    "serviceAccounts": {
+        "TOTAL_COUNT": 211,
+        "namespaces": {
+            "default": {
+                "name": "local-storage-operator",
+                "secrets": 2
+            },
+            "kube-public": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "kube-system": {
+                "name": "statefulset-controller",
+                "secrets": 2
+            },
+            "openshift": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-apiserver": {
+                "name": "openshift-apiserver-sa",
+                "secrets": 2
+            },
+            "openshift-apiserver-operator": {
+                "name": "openshift-apiserver-operator",
+                "secrets": 2
+            },
+            "openshift-authentication": {
+                "name": "oauth-openshift",
+                "secrets": 2
+            },
+            "openshift-authentication-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-cloud-credential-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-cluster-node-tuning-operator": {
+                "name": "tuned",
+                "secrets": 2
+            },
+            "openshift-cluster-samples-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-cluster-storage-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-config": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-config-managed": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-console": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-console-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-controller-manager": {
+                "name": "openshift-controller-manager-sa",
+                "secrets": 2
+            },
+            "openshift-controller-manager-operator": {
+                "name": "openshift-controller-manager-operator",
+                "secrets": 2
+            },
+            "openshift-dns": {
+                "name": "dns",
+                "secrets": 2
+            },
+            "openshift-dns-operator": {
+                "name": "dns-operator",
+                "secrets": 2
+            },
+            "openshift-image-registry": {
+                "name": "registry",
+                "secrets": 2
+            },
+            "openshift-ingress": {
+                "name": "router",
+                "secrets": 2
+            },
+            "openshift-ingress-operator": {
+                "name": "ingress-operator",
+                "secrets": 2
+            },
+            "openshift-insights": {
+                "name": "operator",
+                "secrets": 2
+            },
+            "openshift-kube-apiserver": {
+                "name": "installer-sa",
+                "secrets": 2
+            },
+            "openshift-kube-apiserver-operator": {
+                "name": "kube-apiserver-operator",
+                "secrets": 2
+            },
+            "openshift-kube-controller-manager": {
+                "name": "kube-controller-manager-sa",
+                "secrets": 2
+            },
+            "openshift-kube-controller-manager-operator": {
+                "name": "kube-controller-manager-operator",
+                "secrets": 2
+            },
+            "openshift-kube-scheduler": {
+                "name": "openshift-kube-scheduler-sa",
+                "secrets": 2
+            },
+            "openshift-kube-scheduler-operator": {
+                "name": "openshift-kube-scheduler-operator",
+                "secrets": 2
+            },
+            "openshift-machine-api": {
+                "name": "machine-api-operator",
+                "secrets": 2
+            },
+            "openshift-machine-config-operator": {
+                "name": "node-bootstrapper",
+                "secrets": 2
+            },
+            "openshift-marketplace": {
+                "name": "marketplace-operator",
+                "secrets": 2
+            },
+            "openshift-monitoring": {
+                "name": "thanos-querier",
+                "secrets": 2
+            },
+            "openshift-multus": {
+                "name": "multus",
+                "secrets": 2
+            },
+            "openshift-network-operator": {
+                "name": "deployer",
+                "secrets": 2
+            },
+            "openshift-operator-lifecycle-manager": {
+                "name": "olm-operator-serviceaccount",
+                "secrets": 2
+            },
+            "openshift-sdn": {
+                "name": "sdn-controller",
+                "secrets": 2
+            },
+            "openshift-service-ca": {
+                "name": "service-serving-cert-signer-sa",
+                "secrets": 2
+            },
+            "openshift-service-ca-operator": {
+                "name": "service-ca-operator",
+                "secrets": 2
+            },
+            "openshift-service-catalog-apiserver-operator": {
+                "name": "openshift-service-catalog-apiserver-operator",
+                "secrets": 2
+            },
+            "openshift-service-catalog-controller-manager-operator": {
+                "name": "openshift-service-catalog-controller-manager-operator",
+                "secrets": 2
+            }
+        }
+    }
+}

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -41,6 +41,7 @@ type Support struct {
 	config.Controller
 }
 
+// LoadConfig unmarshalls config from obj and loads it to this Support struct
 func (s *Support) LoadConfig(obj map[string]interface{}) error {
 	var cfg config.Serialized
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj, &cfg); err != nil {

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -82,8 +82,9 @@ const (
 	InstallPlansTopX = 100
 
 	// Maximal total number of service accounts
-	maxServiceAccountsLimit = 1000
-	maxNamespacesLimit      = 1000
+	maxServiceAccountsLimit          = 1000
+	maxNamespacesLimit               = 1000
+	maxServiceAccountNamespacesLimit = 1000
 )
 
 var (
@@ -106,6 +107,8 @@ var (
 
 	// lineSep is the line separator used by the alerts metric
 	lineSep = []byte{'\n'}
+
+	defaultNamespaces = []string{"default", "kube-system", "kube-public"}
 )
 
 func init() {
@@ -194,6 +197,7 @@ func (i *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherContainerRuntimeConfig(i),
 		GatherOpenshiftSDNLogs(i),
 		GatherNetNamespace(i),
+		GatherServiceAccounts(i),
 	)
 }
 
@@ -1443,6 +1447,60 @@ type contextKey string
 
 const contextKeyAllNamespaces contextKey = "allnamespaces"
 
+// GatherServiceAccounts collects ServiceAccount stats
+// from kubernetes default and namespaces starting with openshift.
+//
+// The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/serviceaccount.go#L83
+// Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#serviceaccount-v1-core
+//
+// Location of serviceaccounts in archive: config/serviceaccounts
+// See: docs/insights-archive-sample/config/serviceaccounts
+func GatherServiceAccounts(i *Gatherer) func() ([]record.Record, []error) {
+	return func() ([]record.Record, []error) {
+		config, err := i.coreClient.Namespaces().List(i.ctx, metav1.ListOptions{Limit: maxServiceAccountNamespacesLimit})
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		if err != nil {
+			return nil, []error{err}
+		}
+		totalServiceAccounts := 0
+		serviceAccounts := []corev1.ServiceAccount{}
+		records := []record.Record{}
+		namespaces := defaultNamespaces
+		namespaceCollected := sets.NewString()
+		// collect from all openshift* namespaces + kubernetes defaults
+		for _, item := range config.Items {
+			if strings.HasPrefix(item.Name, "openshift") {
+				namespaces = append(namespaces, item.Name)
+			}
+		}
+		for _, namespace := range namespaces {
+			// fetching service accounts from namespace
+			if namespaceCollected.Has(namespace) {
+				continue
+			}
+			svca, err := i.coreClient.ServiceAccounts(namespace).List(i.ctx, metav1.ListOptions{Limit: maxServiceAccountsLimit})
+			if err != nil {
+				klog.V(2).Infof("Unable to read ServiceAccounts in namespace %s error %s", namespace, err)
+				continue
+			}
+
+			totalServiceAccounts += len(svca.Items)
+			for _, j := range svca.Items {
+				if len(serviceAccounts) > maxServiceAccountsLimit {
+					break
+				}
+				serviceAccounts = append(serviceAccounts, j)
+			}
+			namespaceCollected.Insert(namespace)
+		}
+
+		records = append(records, record.Record{Name: fmt.Sprintf("config/serviceaccounts"), Item: ServiceAccountsMarshaller{serviceAccounts, totalServiceAccounts}})
+		return records, nil
+	}
+}
+
 // RawByte is skipping Marshalling from byte slice
 type RawByte []byte
 
@@ -2177,5 +2235,40 @@ func (a NetNamespaceAnonymizer) Marshal(_ context.Context) ([]byte, error) {
 
 // GetExtension returns extension for NetNamespace object
 func (a NetNamespaceAnonymizer) GetExtension() string {
+	return "json"
+}
+
+// ServiceAccountsMarshaller implements serialization of Service Accounts
+type ServiceAccountsMarshaller struct {
+	sa                   []corev1.ServiceAccount
+	totalServiceAccounts int
+}
+
+// Marshal implements serialization of ServiceAccount
+func (a ServiceAccountsMarshaller) Marshal(_ context.Context) ([]byte, error) {
+	// Creates map for marshal
+	sr := map[string]interface{}{}
+	st := map[string]interface{}{}
+	st["TOTAL_COUNT"] = a.totalServiceAccounts
+	sr["serviceAccounts"] = st
+	nss := map[string]interface{}{}
+	st["namespaces"] = nss
+	for _, sa := range a.sa {
+		var ns map[string]interface{}
+		var ok bool
+		if _, ok = nss[sa.Namespace]; !ok {
+			ns = map[string]interface{}{}
+			nss[sa.Namespace] = ns
+		} else {
+			ns = nss[sa.Namespace].(map[string]interface{})
+		}
+		ns["name"] = sa.Name
+		ns["secrets"] = len(sa.Secrets)
+	}
+	return json.Marshal(sr)
+}
+
+// GetExtension returns extension for anonymized openshift objects
+func (a ServiceAccountsMarshaller) GetExtension() string {
 	return "json"
 }

--- a/pkg/gather/clusterconfig/clusterconfig_test.go
+++ b/pkg/gather/clusterconfig/clusterconfig_test.go
@@ -616,7 +616,6 @@ metadata:
 	}
 }
 
-
 func TestGatherClusterOperator(t *testing.T) {
 	testOperator := &configv1.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{
@@ -644,6 +643,7 @@ func TestGatherClusterOperator(t *testing.T) {
 		t.Fatalf("unexpected clusteroperator name %s", gatheredCO.Name)
 	}
 }
+
 func TestGatherMachineConfigPool(t *testing.T) {
 	var machineconfigpoolYAML = `
 apiVersion: machineconfiguration.openshift.io/v1
@@ -863,6 +863,75 @@ func TestGatherNetNamespaces(t *testing.T) {
 
 	if !equalNetNamespaceS(*ns2, netNamespaces[1]) {
 		t.Fatalf("unexpected netnamespace %v ", netNamespaces[1])
+	}
+}
+
+func TestGatherServiceAccounts(t *testing.T) {
+	tests := []struct {
+		name string
+		data []*corev1.ServiceAccount
+		exp  string
+	}{
+		{
+			name: "one account",
+			data: []*corev1.ServiceAccount{&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "local-storage-operator",
+					Namespace: "default",
+				},
+				Secrets: []corev1.ObjectReference{corev1.ObjectReference{}},
+			}},
+			exp: `{"serviceAccounts":{"TOTAL_COUNT":1,"namespaces":{"default":{"name":"local-storage-operator","secrets":1}}}}`,
+		},
+		{
+			name: "multiple accounts",
+			data: []*corev1.ServiceAccount{&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployer",
+					Namespace: "openshift",
+				},
+				Secrets: []corev1.ObjectReference{corev1.ObjectReference{}},
+			},
+				&corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "openshift-apiserver-sa",
+						Namespace: "openshift-apiserver",
+					},
+					Secrets: []corev1.ObjectReference{corev1.ObjectReference{}},
+				}},
+			exp: `{"serviceAccounts":{"TOTAL_COUNT":2,"namespaces":{"openshift":{"name":"deployer","secrets":1},"openshift-apiserver":{"name":"openshift-apiserver-sa","secrets":1}}}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			coreClient := kubefake.NewSimpleClientset()
+			for _, d := range test.data {
+				_, err := coreClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: d.Namespace}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("unable to create fake ns %s", err)
+				}
+				_, err = coreClient.CoreV1().ServiceAccounts(d.Namespace).
+					Create(context.Background(), d, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("unable to create fake service account %s", err)
+				}
+			}
+			gatherer := &Gatherer{coreClient: coreClient.CoreV1()}
+			sa, errs := GatherServiceAccounts(gatherer)()
+			if len(errs) > 0 {
+				t.Fatalf("unexpected errors: %#v", errs)
+				return
+			}
+			bts, err := sa[0].Item.Marshal(context.Background())
+			if err != nil {
+				t.Fatalf("error marshalling %s", err)
+			}
+			s := string(bts)
+			if test.exp != s {
+				t.Fatalf("serviceaccount test failed. expected: %s got: %s", test.exp, s)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This data enhancement is linked to the Insights rule that enables all customers on 4.6.z to self solve the following issue:
lib-bucket-provisioner' keeps flapping between "Pending" and "Succeeded" in the process of upgrading from v1.0.0 to 2.0.0.
Backporting to 4.6 will therefore reduce CEE support case volume.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/serviceaccounts.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gather/clusterconfig/clusterconfig_test.go` (line 796)

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. The collected data is being anonymized.

## Changelog
<!-- Was changelog updated? -->
Implements the Service Account Gatherer to the Insights Operator to collect ServiceAccounts statistics from Openshift namespaces.

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-3250
https://bugzilla.redhat.com/show_bug.cgi?id=1885941
https://issues.redhat.com/browse/INSIGHTOCP-75
https://access.redhat.com/solutions/5221881
https://github.com/openshift/insights-operator/pull/206 (old pull request)
