### PR TITLE
[release-4.7] Bug 1925659: Relax the recent log gatherers to avoid degrading during…

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -158,11 +158,13 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 				disabledMessage = summary.Message
 			}
 		} else if summary.Operation == controllerstatus.GatheringReport {
+			degradingFailure = false
 			if summary.Count < GatherFailuresCountThreshold {
-				klog.V(4).Infof("Number of last gather failures %d lower than threshold %d. Not marking as degraded.", summary.Count, GatherFailuresCountThreshold)
-				degradingFailure = false
+				klog.V(5).Infof("Number of last gather failures %d lower than threshold %d. Not marking as disabled.", summary.Count, GatherFailuresCountThreshold)
 			} else {
-				klog.V(3).Infof("Number of last gather failures %d exceeded the threshold %d. Marking as degraded.", summary.Count, GatherFailuresCountThreshold)
+				klog.V(3).Infof("Number of last gather failures %d exceeded the threshold %d. Marking as disabled.", summary.Count, GatherFailuresCountThreshold)
+				disabledReason = summary.Reason
+				disabledMessage = summary.Message
 			}
 		}
 

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -16,10 +16,10 @@ import (
 )
 
 type gatherStatusReport struct {
-	Name     		string        `json:"name"`
-	Duration 		time.Duration `json:"duration_in_ms"`
-	RecordsCount  	int           `json:"records_count"`
-	Errors   		[]string      `json:"errors"`
+	Name         string        `json:"name"`
+	Duration     time.Duration `json:"duration_in_ms"`
+	RecordsCount int           `json:"records_count"`
+	Errors       []string      `json:"errors"`
 }
 
 // Gatherer is a driving instance invoking collection of data
@@ -78,10 +78,10 @@ var gatherFunctions = map[string]gathering{
 	"machine_config_pools":              important(GatherMachineConfigPool),
 	"container_runtime_configs":         important(GatherContainerRuntimeConfig),
 	"netnamespaces":                     important(GatherNetNamespace),
-	"openshift_apiserver_operator_logs": important(GatherOpenShiftAPIServerOperatorLogs),
-	"openshift_sdn_logs":                important(GatherOpenshiftSDNLogs),
-	"openshift_sdn_controller_logs":     important(GatherOpenshiftSDNControllerLogs),
-	"openshift_authentication_logs":     important(GatherOpenshiftAuthenticationLogs),
+	"openshift_apiserver_operator_logs": failable(GatherOpenShiftAPIServerOperatorLogs),
+	"openshift_sdn_logs":                failable(GatherOpenshiftSDNLogs),
+	"openshift_sdn_controller_logs":     failable(GatherOpenshiftSDNControllerLogs),
+	"openshift_authentication_logs":     failable(GatherOpenshiftAuthenticationLogs),
 	"sap_config":                        failable(GatherSAPConfig),
 	"olm_operators":                     failable(GatherOLMOperators),
 }


### PR DESCRIPTION
… the upgrade

<!-- Short description of the PR. What does it do? -->
Gathering pod logs after/during upgrade may fail, because the respective containers may not be ready yet.
Removing the degraded state and marking the IO as disabled in case when the `GatherFailuresCountThreshold` is exceeded.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [] Enhancement
- [] Backporting
- [] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No new data added. 

## Documentation
<!-- Are these changes reflected in documentation? -->
No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new unit test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=1925659
https://access.redhat.com/solutions/???
