### PR TITLE
Bug 1926082: Relax the recent log gatherers to avoid degrading during…

### DIFF
--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -16,10 +16,10 @@ import (
 )
 
 type gatherStatusReport struct {
-	Name     		string        `json:"name"`
-	Duration 		time.Duration `json:"duration_in_ms"`
-	RecordsCount  	int           `json:"records_count"`
-	Errors   		[]string      `json:"errors"`
+	Name         string        `json:"name"`
+	Duration     time.Duration `json:"duration_in_ms"`
+	RecordsCount int           `json:"records_count"`
+	Errors       []string      `json:"errors"`
 }
 
 // Gatherer is a driving instance invoking collection of data
@@ -78,10 +78,10 @@ var gatherFunctions = map[string]gathering{
 	"machine_config_pools":              important(GatherMachineConfigPool),
 	"container_runtime_configs":         important(GatherContainerRuntimeConfig),
 	"netnamespaces":                     important(GatherNetNamespace),
-	"openshift_apiserver_operator_logs": important(GatherOpenShiftAPIServerOperatorLogs),
-	"openshift_sdn_logs":                important(GatherOpenshiftSDNLogs),
-	"openshift_sdn_controller_logs":     important(GatherOpenshiftSDNControllerLogs),
-	"openshift_authentication_logs":     important(GatherOpenshiftAuthenticationLogs),
+	"openshift_apiserver_operator_logs": failable(GatherOpenShiftAPIServerOperatorLogs),
+	"openshift_sdn_logs":                failable(GatherOpenshiftSDNLogs),
+	"openshift_sdn_controller_logs":     failable(GatherOpenshiftSDNControllerLogs),
+	"openshift_authentication_logs":     failable(GatherOpenshiftAuthenticationLogs),
 	"sap_config":                        failable(GatherSAPConfig),
 	"olm_operators":                     failable(GatherOLMOperators),
 }


### PR DESCRIPTION
… the upgrade

<!-- Short description of the PR. What does it do? -->
Gathering pod logs after/during upgrade may fail, because the respective containers may not be ready yet. We shouldn't cause degraded state o the IO in this case.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No new data added.

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new unit test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=1926082
https://access.redhat.com/solutions/???
