### PR TITLE
Do not create the metrics file in case of any error

### DIFF
--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -53,7 +53,7 @@ const gatherAll = "ALL"
 
 var gatherFunctions = map[string]gathering{
 	"pdbs":                              important(GatherPodDisruptionBudgets),
-	"metrics":                           important(GatherMostRecentMetrics),
+	"metrics":                           failable(GatherMostRecentMetrics),
 	"operators":                         important(GatherClusterOperators),
 	"container_images":                  important(GatherContainerImages),
 	"nodes":                             important(GatherNodes),

--- a/pkg/gather/clusterconfig/recent_metrics.go
+++ b/pkg/gather/clusterconfig/recent_metrics.go
@@ -57,18 +57,16 @@ func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) 
 		Param("match[]", "namespace:container_memory_usage_bytes:sum").
 		DoRaw(ctx)
 	if err != nil {
-		// write metrics errors to the file format as a comment
 		klog.Errorf("Unable to retrieve most recent metrics: %v", err)
-		return []record.Record{{Name: "config/metrics", Item: RawByte(fmt.Sprintf("# error: %v\n", err))}}, nil
+		return nil, []error{err}
 	}
 
 	rsp, err := metricsClient.Get().AbsPath("federate").
 		Param("match[]", "ALERTS").
 		Stream(ctx)
 	if err != nil {
-		// write metrics errors to the file format as a comment
 		klog.Errorf("Unable to retrieve most recent alerts from metrics: %v", err)
-		return []record.Record{{Name: "config/metrics", Item: RawByte(fmt.Sprintf("# error: %v\n", err))}}, nil
+		return nil, []error{err}
 	}
 	r := NewLineLimitReader(rsp, metricsAlertsLinesLimit)
 	alerts, err := ioutil.ReadAll(r)


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Do not create the metrics file in the IO archive when there is some error when querying the metrics. From processing perspective it doesn't make any sense to have a file (containing some error message) that can't be parsed. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No new data. 

## Documentation
<!-- Are these changes reflected in documentation? -->

No neeed to update.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new unit test.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-3961
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
