### PR TITLE
Disable instead of Degrade in case of gather fails

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -158,11 +158,13 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 				disabledMessage = summary.Message
 			}
 		} else if summary.Operation == controllerstatus.GatheringReport {
+			degradingFailure = false
 			if summary.Count < GatherFailuresCountThreshold {
-				klog.V(4).Infof("Number of last gather failures %d lower than threshold %d. Not marking as degraded.", summary.Count, GatherFailuresCountThreshold)
-				degradingFailure = false
+				klog.V(5).Infof("Number of last gather failures %d lower than threshold %d. Not marking as disabled.", summary.Count, GatherFailuresCountThreshold)
 			} else {
-				klog.V(3).Infof("Number of last gather failures %d exceeded the threshold %d. Marking as degraded.", summary.Count, GatherFailuresCountThreshold)
+				klog.V(3).Infof("Number of last gather failures %d exceeded the threshold %d. Marking as disabled.", summary.Count, GatherFailuresCountThreshold)
+				disabledReason = summary.Reason
+				disabledMessage = summary.Message
 			}
 		}
 


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Sets the status of the operator to disabled on repeated gather failures instead of degraded.  

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- not needed

## Documentation
<!-- Are these changes reflected in documentation? -->

- not needed

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- not needed

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->
not needed

## References
<!-- What are related references for this PR? -->

https://bugzilla.redhat.com/show_bug.cgi?id=1925659
