### PR TITLE
[release-4.5] Bug 1928122: Gather PersistentVolume definition (if any…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -54,6 +54,8 @@ Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/
 ## ClusterImageRegistry
 
 fetches the cluster Image Registry configuration
+If the Image Registry configuration uses some PersistentVolumeClaim for the storage then the corresponding
+PersistentVolume definition is gathered
 
 Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 

--- a/docs/insights-archive-sample/config/persistentvolumes/task-pv-volume.json
+++ b/docs/insights-archive-sample/config/persistentvolumes/task-pv-volume.json
@@ -1,0 +1,107 @@
+{
+    "kind": "PersistentVolume",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "task-pv-volume",
+        "selfLink": "/api/v1/persistentvolumes/task-pv-volume",
+        "uid": "acb1c20e-9bec-4fbf-807a-84f694e00865",
+        "resourceVersion": "1356638",
+        "creationTimestamp": "2021-02-12T12:03:26Z",
+        "labels": {
+            "type": "local"
+        },
+        "annotations": {
+            "pv.kubernetes.io/bound-by-controller": "yes"
+        },
+        "finalizers": [
+            "kubernetes.io/pv-protection"
+        ],
+        "managedFields": [
+            {
+                "manager": "oc",
+                "operation": "Update",
+                "apiVersion": "v1",
+                "time": "2021-02-12T12:03:26Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:labels": {
+                            ".": {},
+                            "f:type": {}
+                        }
+                    },
+                    "f:spec": {
+                        "f:accessModes": {},
+                        "f:capacity": {
+                            ".": {},
+                            "f:storage": {}
+                        },
+                        "f:hostPath": {
+                            ".": {},
+                            "f:path": {},
+                            "f:type": {}
+                        },
+                        "f:persistentVolumeReclaimPolicy": {},
+                        "f:storageClassName": {},
+                        "f:volumeMode": {}
+                    }
+                }
+            },
+            {
+                "manager": "kube-controller-manager",
+                "operation": "Update",
+                "apiVersion": "v1",
+                "time": "2021-02-12T12:03:40Z",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                    "f:metadata": {
+                        "f:annotations": {
+                            ".": {},
+                            "f:pv.kubernetes.io/bound-by-controller": {}
+                        }
+                    },
+                    "f:spec": {
+                        "f:claimRef": {
+                            ".": {},
+                            "f:apiVersion": {},
+                            "f:kind": {},
+                            "f:name": {},
+                            "f:namespace": {},
+                            "f:resourceVersion": {},
+                            "f:uid": {}
+                        }
+                    },
+                    "f:status": {
+                        "f:phase": {}
+                    }
+                }
+            }
+        ]
+    },
+    "spec": {
+        "capacity": {
+            "storage": "50Mi"
+        },
+        "hostPath": {
+            "path": "/tmp/data",
+            "type": ""
+        },
+        "accessModes": [
+            "ReadWriteOnce"
+        ],
+        "claimRef": {
+            "kind": "PersistentVolumeClaim",
+            "namespace": "openshift-insights",
+            "name": "task-pvc-volume",
+            "uid": "b9edf0d4-4785-4f44-8f23-152250daafa3",
+            "apiVersion": "v1",
+            "resourceVersion": "1356636"
+        },
+        "persistentVolumeReclaimPolicy": "Retain",
+        "storageClassName": "manual",
+        "volumeMode": "Filesystem"
+    },
+    "status": {
+        "phase": "Bound"
+    }
+}

--- a/pkg/gather/clusterconfig/clusterconfig.go
+++ b/pkg/gather/clusterconfig/clusterconfig.go
@@ -766,6 +766,8 @@ func GatherClusterImagePruner(i *Gatherer) func() ([]record.Record, []error) {
 }
 
 // GatherClusterImageRegistry fetches the cluster Image Registry configuration
+// If the Image Registry configuration uses some PersistentVolumeClaim for the storage then the corresponding
+// PersistentVolume definition is gathered
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 func GatherClusterImageRegistry(i *Gatherer) func() ([]record.Record, []error) {
@@ -777,6 +779,22 @@ func GatherClusterImageRegistry(i *Gatherer) func() ([]record.Record, []error) {
 		if err != nil {
 			return nil, []error{err}
 		}
+		records := []record.Record{}
+		// if there is some PVC then try to gather used persistent volume
+		if config.Spec.Storage.PVC != nil {
+
+			pvcName := config.Spec.Storage.PVC.Claim
+			pv, err := findPVByPVCName(i.ctx, i.coreClient, pvcName)
+			if err != nil {
+				klog.Errorf("unable to find persistent volume: %s", err)
+			} else {
+				pvRecord := record.Record{
+					Name: fmt.Sprintf("config/persistentvolumes/%s", pv.Name),
+					Item: PersistentVolumeAnonymizer{pv},
+				}
+				records = append(records, pvRecord)
+			}
+		}
 		// TypeMeta is empty - see https://github.com/kubernetes/kubernetes/issues/3030
 		kinds, _, err := registryScheme.ObjectKinds(config)
 		if err != nil {
@@ -786,10 +804,13 @@ func GatherClusterImageRegistry(i *Gatherer) func() ([]record.Record, []error) {
 			klog.Warningf("More kinds for image registry config operator resource %s", kinds)
 		}
 		objKind := kinds[0]
-		return []record.Record{{
+		coRecord := record.Record{
 			Name: fmt.Sprintf("config/clusteroperator/%s/%s/%s", objKind.Group, strings.ToLower(objKind.Kind), config.Name),
 			Item: ImageRegistryAnonymizer{config},
-		}}, nil
+		}
+
+		records = append(records, coRecord)
+		return records, nil
 	}
 }
 
@@ -986,6 +1007,7 @@ func GatherContainerRuntimeConfig(i *Gatherer) func() ([]record.Record, []error)
 		return records, nil
 	}
 }
+
 // GatherInstallPlans collects Top x InstallPlans from all openshift namespaces.
 // Because InstallPlans have unique generated names, it groups them by namespace and the "template"
 // for name generation from field generateName.
@@ -1883,5 +1905,45 @@ func (a InstallPlanAnonymizer) Marshal(_ context.Context) ([]byte, error) {
 
 // GetExtension returns extension for anonymized openshift objects
 func (a InstallPlanAnonymizer) GetExtension() string {
+	return "json"
+}
+
+// findPVByPVCName tries to find *corev1.PersistentVolume used in PersistentVolumeClaim with provided name
+func findPVByPVCName(ctx context.Context, coreClient corev1client.CoreV1Interface, name string) (*corev1.PersistentVolume, error) {
+	// unfortunately we can't do "coreClient.PersistentVolumeClaims("").Get(ctx, name, ... )"
+	pvcs, err := coreClient.PersistentVolumeClaims("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var pvc *corev1.PersistentVolumeClaim
+	for _, p := range pvcs.Items {
+		if p.Name == name {
+			pvc = &p
+			break
+		}
+	}
+	if pvc == nil {
+		return nil, fmt.Errorf("can't find any %s persistentvolumeclaim", name)
+	}
+	pvName := pvc.Spec.VolumeName
+	pv, err := coreClient.PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return pv, nil
+}
+
+// PersistentVolumeAnonymizer implements serialization with marshalling
+type PersistentVolumeAnonymizer struct {
+	*corev1.PersistentVolume
+}
+
+// Marshal implements serialization of corev1.PersistentVolume without anonymization
+func (p PersistentVolumeAnonymizer) Marshal(_ context.Context) ([]byte, error) {
+	return runtime.Encode(kubeSerializer, p.PersistentVolume)
+}
+
+// GetExtension returns extension for PersistentVolume objects
+func (p PersistentVolumeAnonymizer) GetExtension() string {
 	return "json"
 }


### PR DESCRIPTION
…) used in Image registry storage config

<!-- Short description of the PR. What does it do? -->
This gathers PV (if there's any) used in image registry config as storage.

Testing shows issues with using the NFS server as a storage backend for core services. This gathering is to help to check this configuration and to help analyze possible issues related to this.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->
Added
- `docs/insights-archive-sample/config/persistentvolumes/task-pv-volume.json`

## Documentation
<!-- Are these changes reflected in documentation? -->
Doc updated in 
- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No update. No way to use "real" PV in the unit tests AFAIK.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/INSIGHTOCP-54
https://bugzilla.redhat.com/show_bug.cgi?id=1928122
https://access.redhat.com/solutions/???
