### PR TITLE
Do not use context in the recorder

### DIFF
--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -124,7 +124,7 @@ func (c *Controller) runGatherer(name string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), c.configurator.Config().Interval/2)
 	defer cancel()
 	defer func() {
-		if err := c.recorder.Flush(ctx); err != nil {
+		if err := c.recorder.Flush(); err != nil {
 			klog.Errorf("Unable to flush recorder: %v", err)
 		}
 	}()

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -26,7 +26,7 @@ func New(path string) *DiskRecorder {
 }
 
 // Save the records into the archive
-func (d *DiskRecorder) Save(ctx context.Context, records record.MemoryRecords) (record.MemoryRecords, error) {
+func (d *DiskRecorder) Save(records record.MemoryRecords) (record.MemoryRecords, error) {
 	wrote := 0
 	start := time.Now()
 	defer func() {
@@ -59,14 +59,7 @@ func (d *DiskRecorder) Save(ctx context.Context, records record.MemoryRecords) (
 	gw := gzip.NewWriter(f)
 	tw := tar.NewWriter(gw)
 
-	done := ctx.Done()
 	for _, record := range records {
-		select {
-		case <-done:
-			return nil, fmt.Errorf("cancelled before all results could be written to disk")
-		default:
-		}
-
 		if err := tw.WriteHeader(&tar.Header{
 			Name:     record.Name,
 			ModTime:  record.At,
@@ -95,7 +88,7 @@ func (d *DiskRecorder) Save(ctx context.Context, records record.MemoryRecords) (
 }
 
 // Prune the archives older than given time
-func (d *DiskRecorder) Prune(ctx context.Context, olderThan time.Time) error {
+func (d *DiskRecorder) Prune(olderThan time.Time) error {
 	files, err := ioutil.ReadDir(d.basePath)
 	if err != nil {
 		return err

--- a/pkg/recorder/diskrecorder/diskrecorder_test.go
+++ b/pkg/recorder/diskrecorder/diskrecorder_test.go
@@ -31,7 +31,7 @@ func newDiskRecorder() DiskRecorder {
 func TestSave(t *testing.T) {
 	dr := newDiskRecorder()
 	records := getMemoryRecords()
-	saved, err := dr.Save(context.TODO(), records)
+	saved, err := dr.Save(records)
 	assert.Nil(t, err)
 	assert.Len(t, saved, len(records))
 }
@@ -39,7 +39,7 @@ func TestSave(t *testing.T) {
 func TestSaveInvalidPath(t *testing.T) {
 	dr := DiskRecorder{basePath: "/tmp/this-path-not-exists"}
 	records := getMemoryRecords()
-	saved, err := dr.Save(context.TODO(), records)
+	saved, err := dr.Save(records)
 	assert.Error(t, err)
 	assert.Nil(t, saved)
 }
@@ -56,8 +56,8 @@ func TestSaveFailsIfDuplicatedReport(t *testing.T) {
 			Data: []byte("data"),
 		},
 	}
-	_, _ = dr.Save(context.TODO(), records)
-	saved, err := dr.Save(context.TODO(), records)
+	_, _ = dr.Save(records)
+	saved, err := dr.Save(records)
 	assert.Error(t, err)
 	assert.Nil(t, saved)
 }
@@ -75,6 +75,6 @@ func TestSummary(t *testing.T) {
 func TestPrune(t *testing.T) {
 	olderThan := time.Now().Add(time.Duration(5) * time.Minute)
 	dr := newDiskRecorder()
-	err := dr.Prune(context.TODO(), olderThan)
+	err := dr.Prune(olderThan)
 	assert.Nil(t, err)
 }

--- a/pkg/recorder/interface.go
+++ b/pkg/recorder/interface.go
@@ -1,7 +1,6 @@
 package recorder
 
 import (
-	"context"
 	"time"
 
 	"github.com/openshift/insights-operator/pkg/record"
@@ -15,11 +14,11 @@ type Interface interface {
 // FlushInterface extends Recorder by requiring flush
 type FlushInterface interface {
 	Interface
-	Flush(context.Context) error
+	Flush() error
 }
 
 // Driver for the recorder
 type Driver interface {
-	Save(context.Context, record.MemoryRecords) (record.MemoryRecords, error)
-	Prune(context.Context, time.Time) error
+	Save(record.MemoryRecords) (record.MemoryRecords, error)
+	Prune(time.Time) error
 }

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -85,7 +85,7 @@ func (r *Recorder) Record(rec record.Record) error {
 }
 
 // Flush and save the reports using recorder driver
-func (r *Recorder) Flush(ctx context.Context) error {
+func (r *Recorder) Flush() error {
 	records := r.copy()
 	if len(records) == 0 {
 		return nil
@@ -93,7 +93,7 @@ func (r *Recorder) Flush(ctx context.Context) error {
 
 	sort.Sort(records)
 
-	saved, err := r.driver.Save(ctx, records)
+	saved, err := r.driver.Save(records)
 	defer func() {
 		r.clear(saved)
 	}()
@@ -124,7 +124,7 @@ func (r *Recorder) PeriodicallyPrune(ctx context.Context, reported alreadyReport
 					lastReported = oldestAllowed
 				}
 
-				if err := r.driver.Prune(ctx, lastReported); err != nil {
+				if err := r.driver.Prune(lastReported); err != nil {
 					klog.Errorf("Failed to prune older records: %v", err)
 					return false, nil
 				}

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -1,7 +1,6 @@
 package recorder
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -16,12 +15,12 @@ type driverMock struct {
 	mock.Mock
 }
 
-func (d *driverMock) Save(ctx context.Context, records record.MemoryRecords) (record.MemoryRecords, error) {
+func (d *driverMock) Save(records record.MemoryRecords) (record.MemoryRecords, error) {
 	args := d.Called()
 	return records, args.Error(1)
 }
 
-func (d *driverMock) Prune(ctx context.Context, olderThan time.Time) error {
+func (d *driverMock) Prune(olderThan time.Time) error {
 	args := d.Called()
 	return args.Error(1)
 }
@@ -84,13 +83,13 @@ func TestFlush(t *testing.T) {
 			Item: tests.RawReport{Data: "mockdata"},
 		})
 	}
-	err := rec.Flush(context.TODO())
+	err := rec.Flush()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), rec.size)
 }
 
 func TestFlushEmptyRecorder(t *testing.T) {
 	rec := newRecorder()
-	err := rec.Flush(context.TODO())
+	err := rec.Flush()
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Previously when the context exceeded then we end up with an empty archive. 

I believe we don't need the context when saving records to the disk. IOW I think we want to store the records everytime regardless of the context. 
## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new test.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4118
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
