### PR TITLE
Bug 1934112: Adds memory usage to the metadata

### DIFF
--- a/docs/insights-archive-sample/insights-operator/gathers.json
+++ b/docs/insights-archive-sample/insights-operator/gathers.json
@@ -1,0 +1,214 @@
+{
+    "status_reports": [
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherMostRecentMetrics",
+            "duration_in_ms": 23,
+            "records_count": 0,
+            "errors": [
+                "Get \"https://prometheus-k8s.openshift-monitoring.svc:9091/federate?match%5B%5D=etcd_object_counts\u0026match%5B%5D=cluster_installer\u0026match%5B%5D=namespace%3Acontainer_cpu_usage_seconds_total%3Asum_rate\u0026match%5B%5D=namespace%3Acontainer_memory_usage_bytes%3Asum\": dial tcp: lookup prometheus-k8s.openshift-monitoring.svc: no such host"
+            ]
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherHostSubnet",
+            "duration_in_ms": 127,
+            "records_count": 6,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterInfrastructure",
+            "duration_in_ms": 128,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherSAPVsystemIptablesLogs",
+            "duration_in_ms": 240,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterIngress",
+            "duration_in_ms": 243,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterOAuth",
+            "duration_in_ms": 244,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOLMOperators",
+            "duration_in_ms": 246,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherMachineConfigPool",
+            "duration_in_ms": 247,
+            "records_count": 2,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterProxy",
+            "duration_in_ms": 248,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherPodDisruptionBudgets",
+            "duration_in_ms": 248,
+            "records_count": 2,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterNetwork",
+            "duration_in_ms": 248,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterAuthentication",
+            "duration_in_ms": 248,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterFeatureGates",
+            "duration_in_ms": 249,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterVersion",
+            "duration_in_ms": 249,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterID",
+            "duration_in_ms": 249,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherMachineSet",
+            "duration_in_ms": 360,
+            "records_count": 3,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterImagePruner",
+            "duration_in_ms": 368,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherContainerRuntimeConfig",
+            "duration_in_ms": 489,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherSAPPods",
+            "duration_in_ms": 518,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherSAPConfig",
+            "duration_in_ms": 623,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherNetNamespace",
+            "duration_in_ms": 648,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterImageRegistry",
+            "duration_in_ms": 650,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherCRD",
+            "duration_in_ms": 774,
+            "records_count": 2,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherCertificateSigningRequests",
+            "duration_in_ms": 791,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherNodes",
+            "duration_in_ms": 920,
+            "records_count": 6,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOpenShiftAPIServerOperatorLogs",
+            "duration_in_ms": 940,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherConfigMaps",
+            "duration_in_ms": 1018,
+            "records_count": 11,
+            "errors": [
+                "configmaps \"cluster-monitoring-config\" not found"
+            ]
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherContainerImages",
+            "duration_in_ms": 1105,
+            "records_count": 10,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOpenshiftAuthenticationLogs",
+            "duration_in_ms": 1177,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOpenshiftSDNControllerLogs",
+            "duration_in_ms": 1328,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOpenshiftSDNLogs",
+            "duration_in_ms": 2611,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterOperators",
+            "duration_in_ms": 3860,
+            "records_count": 49,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherInstallPlans",
+            "duration_in_ms": 10445,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherServiceAccounts",
+            "duration_in_ms": 11065,
+            "records_count": 1,
+            "errors": null
+        }
+    ],
+    "memory_alloc": 10924832,
+    "uptime": "54.024s"
+}

--- a/docs/insights-archive-sample/insights-operator/gathers.json
+++ b/docs/insights-archive-sample/insights-operator/gathers.json
@@ -1,214 +1,220 @@
 {
     "status_reports": [
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherMostRecentMetrics",
-            "duration_in_ms": 23,
+            "name": "clusterconfig.GatherMostRecentMetrics",
+            "duration_in_ms": 0,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherSAPConfig",
+            "duration_in_ms": 204,
             "records_count": 0,
             "errors": [
-                "Get \"https://prometheus-k8s.openshift-monitoring.svc:9091/federate?match%5B%5D=etcd_object_counts\u0026match%5B%5D=cluster_installer\u0026match%5B%5D=namespace%3Acontainer_cpu_usage_seconds_total%3Asum_rate\u0026match%5B%5D=namespace%3Acontainer_memory_usage_bytes%3Asum\": dial tcp: lookup prometheus-k8s.openshift-monitoring.svc: no such host"
+                "datahubs.installers.datahub.sap.com is forbidden: User \"system:serviceaccount:openshift-insights:gather\" cannot list resource \"datahubs\" in API group \"installers.datahub.sap.com\" at the cluster scope"
             ]
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherHostSubnet",
-            "duration_in_ms": 127,
+            "name": "clusterconfig.GatherClusterVersion",
+            "duration_in_ms": 205,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterImagePruner",
+            "duration_in_ms": 207,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherOLMOperators",
+            "duration_in_ms": 335,
+            "records_count": 0,
+            "errors": [
+                "operators.operators.coreos.com is forbidden: User \"system:serviceaccount:openshift-insights:gather\" cannot list resource \"operators\" in API group \"operators.coreos.com\" at the cluster scope"
+            ]
+        },
+        {
+            "name": "clusterconfig.GatherClusterNetwork",
+            "duration_in_ms": 337,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherContainerRuntimeConfig",
+            "duration_in_ms": 338,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherHostSubnet",
+            "duration_in_ms": 339,
             "records_count": 6,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterInfrastructure",
-            "duration_in_ms": 128,
+            "name": "clusterconfig.GatherClusterInfrastructure",
+            "duration_in_ms": 470,
             "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherSAPVsystemIptablesLogs",
-            "duration_in_ms": 240,
-            "records_count": 0,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterIngress",
-            "duration_in_ms": 243,
+            "name": "clusterconfig.GatherClusterAuthentication",
+            "duration_in_ms": 871,
             "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterOAuth",
-            "duration_in_ms": 244,
+            "name": "clusterconfig.GatherClusterIngress",
+            "duration_in_ms": 879,
             "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOLMOperators",
-            "duration_in_ms": 246,
-            "records_count": 0,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherMachineConfigPool",
-            "duration_in_ms": 247,
-            "records_count": 2,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterProxy",
-            "duration_in_ms": 248,
+            "name": "clusterconfig.GatherClusterProxy",
+            "duration_in_ms": 882,
             "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherPodDisruptionBudgets",
-            "duration_in_ms": 248,
-            "records_count": 2,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterNetwork",
-            "duration_in_ms": 248,
-            "records_count": 1,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterAuthentication",
-            "duration_in_ms": 248,
-            "records_count": 1,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterFeatureGates",
-            "duration_in_ms": 249,
-            "records_count": 1,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterVersion",
-            "duration_in_ms": 249,
-            "records_count": 1,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterID",
-            "duration_in_ms": 249,
-            "records_count": 1,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherMachineSet",
-            "duration_in_ms": 360,
+            "name": "clusterconfig.GatherMachineSet",
+            "duration_in_ms": 891,
             "records_count": 3,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterImagePruner",
-            "duration_in_ms": 368,
+            "name": "clusterconfig.GatherClusterID",
+            "duration_in_ms": 1002,
             "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherContainerRuntimeConfig",
-            "duration_in_ms": 489,
-            "records_count": 0,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherSAPPods",
-            "duration_in_ms": 518,
-            "records_count": 0,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherSAPConfig",
-            "duration_in_ms": 623,
-            "records_count": 0,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherNetNamespace",
-            "duration_in_ms": 648,
+            "name": "clusterconfig.GatherClusterOAuth",
+            "duration_in_ms": 1152,
             "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterImageRegistry",
-            "duration_in_ms": 650,
+            "name": "clusterconfig.GatherSAPVsystemIptablesLogs",
+            "duration_in_ms": 1289,
+            "records_count": 0,
+            "errors": [
+                "datahubs.installers.datahub.sap.com is forbidden: User \"system:serviceaccount:openshift-insights:gather\" cannot list resource \"datahubs\" in API group \"installers.datahub.sap.com\" at the cluster scope"
+            ]
+        },
+        {
+            "name": "clusterconfig.GatherClusterImageRegistry",
+            "duration_in_ms": 1289,
             "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherCRD",
-            "duration_in_ms": 774,
+            "name": "clusterconfig.GatherCertificateSigningRequests",
+            "duration_in_ms": 1424,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherSAPPods",
+            "duration_in_ms": 1558,
+            "records_count": 0,
+            "errors": [
+                "datahubs.installers.datahub.sap.com is forbidden: User \"system:serviceaccount:openshift-insights:gather\" cannot list resource \"datahubs\" in API group \"installers.datahub.sap.com\" at the cluster scope"
+            ]
+        },
+        {
+            "name": "clusterconfig.GatherPodDisruptionBudgets",
+            "duration_in_ms": 1560,
             "records_count": 2,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherCertificateSigningRequests",
-            "duration_in_ms": 791,
-            "records_count": 0,
+            "name": "clusterconfig.GatherClusterFeatureGates",
+            "duration_in_ms": 1699,
+            "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherNodes",
-            "duration_in_ms": 920,
+            "name": "clusterconfig.GatherNetNamespace",
+            "duration_in_ms": 2176,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherMachineConfigPool",
+            "duration_in_ms": 2228,
+            "records_count": 2,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherCRD",
+            "duration_in_ms": 2396,
+            "records_count": 2,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherNodes",
+            "duration_in_ms": 2640,
             "records_count": 6,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOpenShiftAPIServerOperatorLogs",
-            "duration_in_ms": 940,
-            "records_count": 0,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherConfigMaps",
-            "duration_in_ms": 1018,
-            "records_count": 11,
+            "name": "clusterconfig.GatherConfigMaps",
+            "duration_in_ms": 3047,
+            "records_count": 10,
             "errors": [
                 "configmaps \"cluster-monitoring-config\" not found"
             ]
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherContainerImages",
-            "duration_in_ms": 1105,
-            "records_count": 10,
-            "errors": null
-        },
-        {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOpenshiftAuthenticationLogs",
-            "duration_in_ms": 1177,
+            "name": "clusterconfig.GatherOpenShiftAPIServerOperatorLogs",
+            "duration_in_ms": 3316,
             "records_count": 0,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOpenshiftSDNControllerLogs",
-            "duration_in_ms": 1328,
+            "name": "clusterconfig.GatherOpenshiftAuthenticationLogs",
+            "duration_in_ms": 3578,
             "records_count": 0,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherOpenshiftSDNLogs",
-            "duration_in_ms": 2611,
+            "name": "clusterconfig.GatherOpenshiftSDNControllerLogs",
+            "duration_in_ms": 3578,
             "records_count": 0,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherClusterOperators",
-            "duration_in_ms": 3860,
-            "records_count": 49,
+            "name": "clusterconfig.GatherContainerImages",
+            "duration_in_ms": 4162,
+            "records_count": 19,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherInstallPlans",
-            "duration_in_ms": 10445,
+            "name": "clusterconfig.GatherOpenshiftSDNLogs",
+            "duration_in_ms": 5635,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterOperators",
+            "duration_in_ms": 7744,
+            "records_count": 31,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherInstallPlans",
+            "duration_in_ms": 13408,
             "records_count": 1,
             "errors": null
         },
         {
-            "name": "github.com/openshift/insights-operator/pkg/gather/clusterconfig.GatherServiceAccounts",
-            "duration_in_ms": 11065,
+            "name": "clusterconfig.GatherServiceAccounts",
+            "duration_in_ms": 14211,
             "records_count": 1,
             "errors": null
         }
     ],
-    "memory_alloc": 10924832,
-    "uptime": "54.024s"
+    "memory_alloc_bytes": 20949008,
+    "uptime_seconds": 58.282
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR adds 2 new fields to the metadata (`gathers.json`).
`uptime`: the duration since the start of the first gather
`memory_alloc`: the memory allocated at the time of creating the report. (in bytes)

Some disclaimers:
- I intended to have memory usage stats for each gather-function, but it wasn't really viable. The only way I could measure it was by marshaling the produced records, which is not only inefficient but we can just as easily measure the size of the produced archive and get the same idea.
- The `memory_alloc` stat wont show the peak memory allocation. Even if we are only talking about the gather cycle, knowing when to measure to get the max usage is impossible so we would need to monitor the entire process, which would more complex without much benefit IMO. The purpose of this field is to be able to notice if over a long period there might be a memory leak.    

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/insights-operator/gathers.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- none

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- none

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

none
