### PR TITLE
Bug 1934397:  Extend the OLM operator data with related ClusterServiceVersion conditions

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -311,7 +311,11 @@ Output raw size: 491
 
 ## OLMOperators
 
-collects list of all names (including version) of installed OLM operators.
+collects list of installed OLM operators.
+Each OLM operator (in the list) contains following data:
+- OLM operator name
+- OLM operator version
+- related ClusterServiceVersion conditions
 
 See: docs/insights-archive-sample/config/olm_operators
 Location of in archive: config/olm_operators

--- a/docs/insights-archive-sample/config/olm_operators.json
+++ b/docs/insights-archive-sample/config/olm_operators.json
@@ -1,22 +1,207 @@
 [
     {
         "name": "eap.openshift-operators",
-        "version": "v2.0.2"
+        "version": "v2.1.1",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:25Z",
+                "message": "installing: waiting for deployment eap-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:46Z",
+                "lastUpdateTime": "2021-03-02T08:52:46Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     },
     {
         "name": "elasticsearch-operator.openshift-operators-redhat",
-        "version": "4.6.0-202011221454.p0"
+        "version": "4.6.0-202102200141.p0",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T06:38:14Z",
+                "lastUpdateTime": "2021-03-02T06:38:14Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:15Z",
+                "lastUpdateTime": "2021-03-02T06:38:15Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:16Z",
+                "lastUpdateTime": "2021-03-02T06:38:16Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:16Z",
+                "lastUpdateTime": "2021-03-02T06:38:17Z",
+                "message": "installing: waiting for deployment elasticsearch-operator to become ready: Waiting for rollout to finish: 1 old replicas are pending termination...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:26Z",
+                "lastUpdateTime": "2021-03-02T06:38:26Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     },
     {
         "name": "kiali-ossm.openshift-operators",
-        "version": "v1.24.4"
+        "version": "v1.24.5",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:10Z",
+                "message": "installing: waiting for deployment kiali-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:29Z",
+                "lastUpdateTime": "2021-03-02T08:52:29Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     },
     {
-        "name": "postgresql-operator-dev4devs-com.postgresql-operator",
-        "version": "v0.1.1"
+        "name": "postgresql-operator-dev4devs-com.psql-test",
+        "version": "v0.1.1",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:53:34Z",
+                "lastUpdateTime": "2021-03-02T08:53:34Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:35Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:35Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:36Z",
+                "message": "installing: waiting for deployment postgresql-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:47Z",
+                "lastUpdateTime": "2021-03-02T08:53:47Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     },
     {
         "name": "radanalytics-spark.openshift-operators",
-        "version": "v1.1.0"
+        "version": "v1.1.0",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:55:36Z",
+                "lastUpdateTime": "2021-03-02T08:55:36Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:37Z",
+                "lastUpdateTime": "2021-03-02T08:55:37Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:38Z",
+                "lastUpdateTime": "2021-03-02T08:55:38Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:38Z",
+                "lastUpdateTime": "2021-03-02T08:55:38Z",
+                "message": "installing: waiting for deployment spark-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:51Z",
+                "lastUpdateTime": "2021-03-02T08:55:51Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     }
 ]

--- a/pkg/gather/clusterconfig/olm_operators.go
+++ b/pkg/gather/clusterconfig/olm_operators.go
@@ -15,12 +15,29 @@ import (
 	"github.com/openshift/insights-operator/pkg/utils"
 )
 
+var (
+	operatorGVR              = schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1", Resource: "operators"}
+	clusterServiceVersionGVR = schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1alpha1", Resource: "clusterserviceversions"}
+)
+
 type olmOperator struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name       string        `json:"name"`
+	Version    string        `json:"version"`
+	Conditions []interface{} `json:"csv_conditions"`
 }
 
-// GatherOLMOperators collects list of all names (including version) of installed OLM operators.
+// ClusterServiceVersion helper struct
+type csvRef struct {
+	Name      string
+	Namespace string
+	Version   string
+}
+
+// GatherOLMOperators collects list of installed OLM operators.
+// Each OLM operator (in the list) contains following data:
+// - OLM operator name
+// - OLM operator version
+// - related ClusterServiceVersion conditions
 //
 // See: docs/insights-archive-sample/config/olm_operators
 // Location of in archive: config/olm_operators
@@ -37,8 +54,7 @@ func GatherOLMOperators(g *Gatherer, c chan<- gatherResult) {
 }
 
 func gatherOLMOperators(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
-	gvr := schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1", Resource: "operators"}
-	olmOperators, err := dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+	olmOperators, err := dynamicClient.Resource(operatorGVR).List(ctx, metav1.ListOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -54,13 +70,19 @@ func gatherOLMOperators(ctx context.Context, dynamicClient dynamic.Interface) ([
 			continue
 		}
 		for _, r := range refs {
-			ver := readVersionFromRefs(r)
-			if ver == "" {
+			csvRef := getCSVRefFromRefs(r)
+			if csvRef == nil {
+				continue
+			}
+			conditions, err := getCSVConditions(ctx, dynamicClient, csvRef)
+			if err != nil {
+				klog.Errorf("failed to get %s conditions: %v", csvRef.Name, err)
 				continue
 			}
 			olmO := olmOperator{
-				Name:    i.GetName(),
-				Version: ver,
+				Name:       i.GetName(),
+				Version:    csvRef.Version,
+				Conditions: conditions,
 			}
 			if isInArray(olmO, olms) {
 				continue
@@ -80,24 +102,42 @@ func gatherOLMOperators(ctx context.Context, dynamicClient dynamic.Interface) ([
 
 func isInArray(o olmOperator, a []olmOperator) bool {
 	for _, op := range a {
-		if o == op {
+		if o.Name == op.Name && o.Version == op.Version {
 			return true
 		}
 	}
 	return false
 }
 
-func readVersionFromRefs(r interface{}) string {
+func getCSVRefFromRefs(r interface{}) *csvRef {
 	refMap, ok := r.(map[string]interface{})
 	if !ok {
 		klog.Errorf("Cannot convert %s to map[string]interface{}", r)
-		return ""
+		return nil
 	}
 	// version is part of the name of ClusterServiceVersion
 	if refMap["kind"] == "ClusterServiceVersion" {
 		name := refMap["name"].(string)
 		nameVer := strings.SplitN(name, ".", 2)
-		return nameVer[1]
+		csvRef := &csvRef{
+			Name:      name,
+			Namespace: refMap["namespace"].(string),
+			Version:   nameVer[1],
+		}
+		return csvRef
 	}
-	return ""
+	return nil
+}
+
+func getCSVConditions(ctx context.Context, dynamicClient dynamic.Interface, csvRef *csvRef) ([]interface{}, error) {
+	csv, err := dynamicClient.Resource(clusterServiceVersionGVR).Namespace(csvRef.Namespace).Get(ctx, csvRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var conditions []interface{}
+	err = utils.ParseJSONQuery(csv.Object, "status.conditions", &conditions)
+	if err != nil {
+		return nil, err
+	}
+	return conditions, nil
 }

--- a/pkg/gather/clusterconfig/testdata/csv_1.yaml
+++ b/pkg/gather/clusterconfig/testdata/csv_1.yaml
@@ -1,0 +1,17 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+    name: test-olm-operator.v1.2.3
+    namespace: test-olm-operator
+status:
+    conditions:
+        - lastTransitionTime: "2021-03-02T08:52:24Z"
+          lastUpdateTime: "2021-03-02T08:52:24Z"
+          message: requirements not yet checked
+          phase: Pending
+          reason: RequirementsUnknown
+        - lastTransitionTime: "2021-03-02T08:52:24Z"
+          lastUpdateTime: "2021-03-02T08:52:24Z"
+          message: all requirements found, attempting install
+          phase: InstallReady
+          reason: AllRequirementsMet


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Getting more data about installed OLM operators and create corresponding upgrade report is one of the CCX goals. This PR extends the data with corresponding Operator/ClusterServiceVersion conditions. See the CCX epics below. 


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

Sample archive updated in:
- `docs/insights-archive-sample/config/olm_operators.json `

## Documentation
<!-- Are these changes reflected in documentation? -->
Documentation updated:
- `docs/gathered-data.md `

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Test updated in:
- `pkg/gather/clusterconfig/olm_operators_test.go `

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->
https://issues.redhat.com/browse/CCXDEV-719
https://issues.redhat.com/browse/CCXDEV-3965
https://issues.redhat.com/browse/CCXDEV-3966
https://bugzilla.redhat.com/show_bug.cgi?id=1934397
https://access.redhat.com/solutions/???
