### PR TITLE
[release-4.7] Bug 1934442: Gather info about unhealthy SAP pods

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -399,6 +399,20 @@ Relevant OpenShift API docs:
 Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
 
 
+## SAPPods
+
+collects information about pods running in SAP/SDI namespaces.
+Only pods with a failing status are collected.
+Failed pods belonging to a job that has later succeeded are ignored.
+
+Relevant Kubernetes API docs:
+  - https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1
+  - https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/batch/v1
+  - https://pkg.go.dev/k8s.io/client-go/dynamic
+
+Location in archive: config/pod/{namespace}/{pod-name}.json
+
+
 ## ServiceAccounts
 
 collects ServiceAccount stats

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -83,6 +83,7 @@ var gatherFunctions = map[string]gathering{
 	"openshift_sdn_controller_logs":     failable(GatherOpenshiftSDNControllerLogs),
 	"openshift_authentication_logs":     failable(GatherOpenshiftAuthenticationLogs),
 	"sap_config":                        failable(GatherSAPConfig),
+	"sap_pods":                          failable(GatherSAPPods),
 	"olm_operators":                     failable(GatherOLMOperators),
 }
 

--- a/pkg/gather/clusterconfig/sap_pods.go
+++ b/pkg/gather/clusterconfig/sap_pods.go
@@ -1,0 +1,118 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+// GatherSAPPods collects information about pods running in SAP/SDI namespaces.
+// Only pods with a failing status are collected.
+// Failed pods belonging to a job that has later succeeded are ignored.
+//
+// Relevant Kubernetes API docs:
+//   - https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1
+//   - https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/batch/v1
+//   - https://pkg.go.dev/k8s.io/client-go/dynamic
+//
+// Location in archive: config/pod/{namespace}/{pod-name}.json
+func GatherSAPPods(g *Gatherer, c chan<- gatherResult) {
+	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		c <- gatherResult{errors: []error{err}}
+		return
+	}
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		c <- gatherResult{errors: []error{err}}
+		return
+	}
+	gatherJobsClient, err := batchv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		c <- gatherResult{errors: []error{err}}
+		return
+	}
+
+	records, errors := gatherSAPPods(g.ctx, gatherDynamicClient, gatherKubeClient.CoreV1(), gatherJobsClient)
+	c <- gatherResult{records: records, errors: errors}
+}
+
+func gatherSAPPods(ctx context.Context, dynamicClient dynamic.Interface, coreClient corev1client.CoreV1Interface, jobsClient batchv1client.BatchV1Interface) ([]record.Record, []error) {
+	datahubsResource := schema.GroupVersionResource{Group: "installers.datahub.sap.com", Version: "v1alpha1", Resource: "datahubs"}
+
+	datahubsList, err := dynamicClient.Resource(datahubsResource).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	records := []record.Record{}
+	collectedNamespaces := map[string]struct{}{}
+	for _, datahub := range datahubsList.Items {
+		datahubNamespace := datahub.GetNamespace()
+		if _, exists := collectedNamespaces[datahubNamespace]; exists {
+			continue
+		}
+		collectedNamespaces[datahubNamespace] = struct{}{}
+
+		pods, err := coreClient.Pods(datahubNamespace).List(ctx, metav1.ListOptions{})
+		if errors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		for iPod, pod := range pods.Items {
+			// Skip pods that are running correctly or those that have already successfully finished.
+			if pod.Status.Phase == v1.PodRunning || pod.Status.Phase == v1.PodSucceeded {
+				continue
+			}
+
+			// Indicates if the pod belongs to a successful job.
+			successfulJob := false
+			for _, owner := range pod.ObjectMeta.OwnerReferences {
+				if owner.Kind != "Job" {
+					continue
+				}
+
+				ownerJob, err := jobsClient.Jobs(pod.Namespace).Get(ctx, owner.Name, metav1.GetOptions{})
+				if err != nil {
+					return nil, []error{err}
+				}
+
+				if ownerJob.Status.Succeeded > 0 {
+					successfulJob = true
+					break
+				}
+			}
+			// If the job succeeded using a different pod after this pod failed,
+			// this pod is no longer relevant and should not be gathered.
+			if successfulJob {
+				continue
+			}
+
+			records = append(records, record.Record{
+				// There are already some (OpenShift/OCP) pods in `/config/pod/**`
+				Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name),
+				// It is impossible to use `&pod` here because it would end up being
+				// the last returned pod as the reference keeps changing with each iteration.
+				Item: record.JSONMarshaller{Object: &pods.Items[iPod]},
+			})
+		}
+	}
+
+	return records, nil
+}

--- a/pkg/gather/clusterconfig/sap_pods_test.go
+++ b/pkg/gather/clusterconfig/sap_pods_test.go
@@ -1,0 +1,173 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	batchv1fake "k8s.io/client-go/kubernetes/typed/batch/v1/fake"
+)
+
+func TestSAPPods(t *testing.T) {
+	// Initialize the fake dynamic client.
+	var datahubYAML = `apiVersion: installers.datahub.sap.com/v1alpha1
+kind: DataHub
+metadata:
+    name: example-datahub
+    namespace: example-namespace
+`
+
+	datahubsResource := schema.GroupVersionResource{Group: "installers.datahub.sap.com", Version: "v1alpha1", Resource: "datahubs"}
+	datahubsClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		datahubsResource: "DataHubsList",
+	})
+
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	testDatahub := &unstructured.Unstructured{}
+
+	_, _, err := decUnstructured.Decode([]byte(datahubYAML), nil, testDatahub)
+	if err != nil {
+		t.Fatal("unable to decode datahub YAML", err)
+	}
+
+	// Initialize the remaining K8s/OS fake clients.
+	coreClient := kubefake.NewSimpleClientset()
+	jobsClient := &batchv1fake.FakeBatchV1{Fake: &coreClient.Fake}
+
+	coreClient.CoreV1().Pods("example-namespace").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-pod1",
+			Namespace: "example-namespace",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+		},
+	}, metav1.CreateOptions{})
+
+	records, errs := gatherSAPPods(context.Background(), datahubsClient, coreClient.CoreV1(), jobsClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// 0 records because there is no datahubs resource in the namespace.
+	if len(records) != 0 {
+		t.Fatalf("unexpected number or records in the first run: %d", len(records))
+	}
+
+	// Create the DataHubs resource and now the SCCs and CRBs should be gathered.
+	datahubsClient.Resource(datahubsResource).Namespace("example-namespace").Create(context.Background(), testDatahub, metav1.CreateOptions{})
+
+	records, errs = gatherSAPPods(context.Background(), datahubsClient, coreClient.CoreV1(), jobsClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// 1 record because the pod is now in the same namespace as a datahubs resource.
+	if len(records) != 1 {
+		t.Fatalf("unexpected number or records in the second run: %d", len(records))
+	}
+
+	// Create a failed job.
+	_, err = jobsClient.Jobs("example-namespace").Create(context.Background(), &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "example-job1",
+			GenerateName: "example-namespace",
+		},
+		Status: batchv1.JobStatus{
+			Failed:    1,
+			Succeeded: 0,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("unable to create job: %#v", err)
+	}
+
+	// Add a failed pod to the failed job.
+	coreClient.CoreV1().Pods("example-namespace").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-pod2",
+			Namespace: "example-namespace",
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind: "Job",
+				Name: "example-job1",
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+		},
+	}, metav1.CreateOptions{})
+
+	records, errs = gatherSAPPods(context.Background(), datahubsClient, coreClient.CoreV1(), jobsClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// 2 records because the second pod belongs to a failed job.
+	if len(records) != 2 {
+		t.Fatalf("unexpected number or records in the third run: %d", len(records))
+	}
+
+	// Create a successful job.
+	_, err = jobsClient.Jobs("example-namespace").Create(context.Background(), &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "example-job2",
+			GenerateName: "example-namespace",
+		},
+		Status: batchv1.JobStatus{
+			Failed:    1,
+			Succeeded: 1,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("unable to create job: %#v", err)
+	}
+
+	// Add a failed pod to the successful job.
+	coreClient.CoreV1().Pods("example-namespace").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-pod3",
+			Namespace: "example-namespace",
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind: "Job",
+				Name: "example-job2",
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+		},
+	}, metav1.CreateOptions{})
+
+	records, errs = gatherSAPPods(context.Background(), datahubsClient, coreClient.CoreV1(), jobsClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// Still 2 records because the third pod belongs to a successful job.
+	if len(records) != 2 {
+		t.Fatalf("unexpected number or records in the fourth run: %d", len(records))
+	}
+
+	// Create a healthy successful pod.
+	coreClient.CoreV1().Pods("example-namespace").Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-pod4",
+			Namespace: "example-namespace",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+		},
+	}, metav1.CreateOptions{})
+
+	records, errs = gatherSAPPods(context.Background(), datahubsClient, coreClient.CoreV1(), jobsClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// Still 2 records because the fourth pod is successful.
+	if len(records) != 2 {
+		t.Fatalf("unexpected number or records in the fifth run: %d", len(records))
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This is a backport of #347. It is necessary to get this enhancement to 4.6.z in order to see useful results in a reasonable time. After a discussion with a patch manager, it has been determined that it is necessary to backport to 4.7.z as well, even though this version is not supported by the SAP team.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [x] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

N/A; just like with #347:

> The newly gathered data are JSON pod dumps, which are no different from all the other currently gathered pods. Due to the challenging nature of the SAP enhancement development, it was not possible to properly anonymous sample data.

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md` - "SAPPods" section

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gather/clusterconfig/sap_pods_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

This is just a backport, so it is no different form the upstream implementation.

## Changelog
<!-- Was changelog updated? -->

No manual change.

## References
<!-- What are related references for this PR? -->

### This backport

Bugzilla Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1934442
Jira Task: https://issues.redhat.com/browse/CCXDEV-4124

### Upstream implementation (4.8.0)

GitHub PR: #347
Bugzilla Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1930393
Jira Task: https://issues.redhat.com/browse/CCXDEV-3483
