### PR TITLE
[release-4.7] Bug 1935070: Extend the OLM operator data with related …

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -311,7 +311,11 @@ Output raw size: 491
 
 ## OLMOperators
 
-collects list of all names (including version) of installed OLM operators.
+collects list of installed OLM operators.
+Each OLM operator (in the list) contains following data:
+- OLM operator name
+- OLM operator version
+- related ClusterServiceVersion conditions
 
 See: docs/insights-archive-sample/config/olm_operators
 Location of in archive: config/olm_operators

--- a/docs/insights-archive-sample/config/olm_operators.json
+++ b/docs/insights-archive-sample/config/olm_operators.json
@@ -1,22 +1,207 @@
 [
     {
         "name": "eap.openshift-operators",
-        "version": "v2.0.2"
+        "version": "v2.1.1",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:25Z",
+                "message": "installing: waiting for deployment eap-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:46Z",
+                "lastUpdateTime": "2021-03-02T08:52:46Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     },
     {
         "name": "elasticsearch-operator.openshift-operators-redhat",
-        "version": "4.6.0-202011221454.p0"
+        "version": "4.6.0-202102200141.p0",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T06:38:14Z",
+                "lastUpdateTime": "2021-03-02T06:38:14Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:15Z",
+                "lastUpdateTime": "2021-03-02T06:38:15Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:16Z",
+                "lastUpdateTime": "2021-03-02T06:38:16Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:16Z",
+                "lastUpdateTime": "2021-03-02T06:38:17Z",
+                "message": "installing: waiting for deployment elasticsearch-operator to become ready: Waiting for rollout to finish: 1 old replicas are pending termination...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:26Z",
+                "lastUpdateTime": "2021-03-02T06:38:26Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     },
     {
         "name": "kiali-ossm.openshift-operators",
-        "version": "v1.24.4"
+        "version": "v1.24.5",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:10Z",
+                "message": "installing: waiting for deployment kiali-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:29Z",
+                "lastUpdateTime": "2021-03-02T08:52:29Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     },
     {
-        "name": "postgresql-operator-dev4devs-com.postgresql-operator",
-        "version": "v0.1.1"
+        "name": "postgresql-operator-dev4devs-com.psql-test",
+        "version": "v0.1.1",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:53:34Z",
+                "lastUpdateTime": "2021-03-02T08:53:34Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:35Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:35Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:36Z",
+                "message": "installing: waiting for deployment postgresql-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:47Z",
+                "lastUpdateTime": "2021-03-02T08:53:47Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     },
     {
         "name": "radanalytics-spark.openshift-operators",
-        "version": "v1.1.0"
+        "version": "v1.1.0",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:55:36Z",
+                "lastUpdateTime": "2021-03-02T08:55:36Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:37Z",
+                "lastUpdateTime": "2021-03-02T08:55:37Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:38Z",
+                "lastUpdateTime": "2021-03-02T08:55:38Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:38Z",
+                "lastUpdateTime": "2021-03-02T08:55:38Z",
+                "message": "installing: waiting for deployment spark-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:51Z",
+                "lastUpdateTime": "2021-03-02T08:55:51Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
     }
 ]

--- a/pkg/gather/clusterconfig/olm_operators_test.go
+++ b/pkg/gather/clusterconfig/olm_operators_test.go
@@ -79,6 +79,7 @@ func createUnstructuredResource(content []byte, client *dynamicfake.FakeDynamicC
 
 func readFromFile(filePath string) ([]byte, error) {
 	f, err := os.Open(filePath)
+	defer f.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gather/clusterconfig/olm_operators_test.go
+++ b/pkg/gather/clusterconfig/olm_operators_test.go
@@ -15,29 +15,26 @@ import (
 )
 
 func TestOLMOperatorsGather(t *testing.T) {
-	f, err := os.Open("testdata/olm_operator_1.yaml")
+	olmOpContent, err := readFromFile("testdata/olm_operator_1.yaml")
 	if err != nil {
 		t.Fatal("test failed to read OLM operator data", err)
 	}
-	olmOpContent, err := ioutil.ReadAll(f)
+
+	csvContent, err := readFromFile("testdata/csv_1.yaml")
 	if err != nil {
-		t.Fatal("error reading test data file", err)
+		t.Fatal("test failed to read CSV ", err)
 	}
-	gvr := schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1", Resource: "operators"}
 	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
-		gvr: "OperatorsList",
+		operatorGVR:              "OperatorsList",
+		clusterServiceVersionGVR: "ClusterServiceVersionsList",
 	})
-	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-
-	testOLMOperator := &unstructured.Unstructured{}
-
-	_, _, err = decUnstructured.Decode(olmOpContent, nil, testOLMOperator)
+	err = createUnstructuredResource(olmOpContent, client, operatorGVR)
 	if err != nil {
-		t.Fatal("unable to decode OLM operator ", err)
+		t.Fatal("cannot create OLM operator ", err)
 	}
-	_, err = client.Resource(gvr).Create(context.Background(), testOLMOperator, metav1.CreateOptions{})
+	err = createUnstructuredResource(csvContent, client, clusterServiceVersionGVR)
 	if err != nil {
-		t.Fatal("unable to create fake OLM operator ", err)
+		t.Fatal("cannot create ClusterServiceVersion ", err)
 	}
 
 	ctx := context.Background()
@@ -54,9 +51,40 @@ func TestOLMOperatorsGather(t *testing.T) {
 		t.Fatalf("returned item is not of type OlmOperatorAnonymizer")
 	}
 	if ooa.operators[0].Name != "test-olm-operator" {
-		t.Fatalf("unexpected name of gathered OLM operator %s", ooa.operators[0])
+		t.Fatalf("unexpected name of gathered OLM operator %s", ooa.operators[0].Name)
 	}
 	if ooa.operators[0].Version != "v1.2.3" {
-		t.Fatalf("unexpected version of gathered OLM operator %s", ooa.operators[0])
+		t.Fatalf("unexpected version of gathered OLM operator %s", ooa.operators[0].Version)
 	}
+	if len(ooa.operators[0].Conditions) != 2 {
+		t.Fatalf("unexpected number of conditions %s", ooa.operators[0].Conditions...)
+	}
+}
+
+func createUnstructuredResource(content []byte, client *dynamicfake.FakeDynamicClient, gvr schema.GroupVersionResource) error {
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	unstructuredResource := &unstructured.Unstructured{}
+
+	_, _, err := decUnstructured.Decode(content, nil, unstructuredResource)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Resource(gvr).Namespace("test-olm-operator").Create(context.Background(), unstructuredResource, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func readFromFile(filePath string) ([]byte, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	content, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
 }

--- a/pkg/gather/clusterconfig/testdata/csv_1.yaml
+++ b/pkg/gather/clusterconfig/testdata/csv_1.yaml
@@ -1,0 +1,17 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+    name: test-olm-operator.v1.2.3
+    namespace: test-olm-operator
+status:
+    conditions:
+        - lastTransitionTime: "2021-03-02T08:52:24Z"
+          lastUpdateTime: "2021-03-02T08:52:24Z"
+          message: requirements not yet checked
+          phase: Pending
+          reason: RequirementsUnknown
+        - lastTransitionTime: "2021-03-02T08:52:24Z"
+          lastUpdateTime: "2021-03-02T08:52:24Z"
+          message: all requirements found, attempting install
+          phase: InstallReady
+          reason: AllRequirementsMet


### PR DESCRIPTION
…ClusterServiceVersion conditions (#358)

<!-- Short description of the PR. What does it do? -->
Getting more data about installed OLM operators and create corresponding upgrade report is one of the CCX goals. This PR extends the data with corresponding Operator/ClusterServiceVersion conditions and doesn't add any new gatherer or other functionality. See the CCX epics below.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->
Updated in:
- `docs/insights-archive-sample/config/olm_operators.json`

## Documentation
<!-- Are these changes reflected in documentation? -->
Documentation updated in:
- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Unit test updated in:
- `pkg/gather/clusterconfig/olm_operators_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->
https://issues.redhat.com/browse/CCXDEV-719
https://issues.redhat.com/browse/CCXDEV-3965
https://issues.redhat.com/browse/CCXDEV-3966
https://bugzilla.redhat.com/show_bug.cgi?id=1935070
https://access.redhat.com/solutions/???
