### PR TITLE
[release-4.6] Bug 1935574: Extend the OLM operator data with related …

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -119,7 +119,7 @@ See: docs/insights-archive-sample/config/oauth
 
 ## ClusterOperators
 
-collects all ClusterOperators and their resources.
+collects all ClusterOperators and their resource.
 It finds unhealthy Pods for unhealthy operators
 
 The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusteroperator.go#L62
@@ -129,13 +129,6 @@ Location of operators in archive: config/clusteroperator/
 See: docs/insights-archive-sample/config/clusteroperator
 Location of pods in archive: config/pod/
 
-
-Output raw size: 245
-
-### Examples
-
-#### ClusterOperators
-[{"Name":"config/clusteroperator/","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":{"metadata":{"creationTimestamp":null},"spec":{},"status":{"conditions":[{"type":"Degraded","status":"","lastTransitionTime":null}],"extension":null}}}]
 
 ## ClusterProxy
 
@@ -184,6 +177,16 @@ Specifically, the age of pods, the set of running images and the container names
 Location in archive: config/running_containers.json
 
 
+## ContainerRuntimeConfig
+
+collects ContainerRuntimeConfig  information
+
+The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L402
+Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
+
+Location in archive: config/containerruntimeconfigs/
+
+
 ## HostSubnet
 
 collects HostSubnet information
@@ -204,6 +207,16 @@ It also collects Total number of all installplans and all non-unique installplan
 The Operators-Framework api https://github.com/operator-framework/api/blob/master/pkg/operators/v1alpha1/installplan_types.go#L26
 
 Location in archive: config/installplans/
+
+
+## MachineConfigPool
+
+collects MachineConfigPool information
+
+The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L197
+Response see https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.html
+
+Location in archive: config/machineconfigpools/
 
 
 ## MachineSet
@@ -231,13 +244,6 @@ Location in archive: config/metrics/
 See: docs/insights-archive-sample/config/metrics
 
 
-Output raw size: 148
-
-### Examples
-
-#### MostRecentMetrics
-[{"Name":"config/metrics","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":"SGVsbG8sIGNsaWVudAojIEFMRVJUUyAyLzEwMDAKSGVsbG8sIGNsaWVudAo="}]
-
 ## NetNamespace
 
 collects NetNamespaces networking information
@@ -259,12 +265,18 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 Location in archive: config/node/
 
 
-Output raw size: 491
+## OLMOperators
 
-### Examples
+collects list of installed OLM operators.
+Each OLM operator (in the list) contains following data:
+- OLM operator name
+- OLM operator version
+- related ClusterServiceVersion conditions
 
-#### Nodes
-[{"Name":"config/node/","Captured":"0001-01-01T00:00:00Z","Fingerprint":"","Item":{"metadata":{"creationTimestamp":null},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False","lastHeartbeatTime":null,"lastTransitionTime":null}],"daemonEndpoints":{"kubeletEndpoint":{"Port":0}},"nodeInfo":{"machineID":"","systemUUID":"","bootID":"","kernelVersion":"","osImage":"","containerRuntimeVersion":"","kubeletVersion":"","kubeProxyVersion":"","operatingSystem":"","architecture":""}}}}]
+See: docs/insights-archive-sample/config/olm_operators
+Location of in archive: config/olm_operators
+Id in config: olm_operators
+
 
 ## OpenshiftSDNControllerLogs
 
@@ -310,25 +322,18 @@ Response see https://docs.okd.io/latest/rest_api/policy_apis/poddisruptionbudget
 Location in archive: config/pdbs/
 See: docs/insights-archive-sample/config/pdbs
 
-## MachineConfigPool
 
-gathers the cluster's MachineConfigPools.
+## SAPConfig
 
-The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L197
-Response see https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.html
+collects selected security context constraints
+and cluster role bindings from clusters running a SAP payload.
 
-Location in archive: config/machineconfigpools/
-See: docs/insights-archive-sample/config/machineconfigpools/
+Relevant OpenShift API docs:
+  - https://pkg.go.dev/github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1
+  - https://pkg.go.dev/github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
 
-## ContainerRuntimeConfig
+Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
 
-collects ContainerRuntimeConfig information
-
-The Kubernetes api https://github.com/openshift/machine-config-operator/blob/master/pkg/apis/machineconfiguration.openshift.io/v1/types.go#L402
-Response see https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
-
-Location in archive: config/containerruntimeconfigs/
-See: docs/insights-archive-sample/config/containerruntimeconfigs
 
 ## SAPVsystemIptablesLogs
 
@@ -353,14 +358,6 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 Location of serviceaccounts in archive: config/serviceaccounts
 See: docs/insights-archive-sample/config/serviceaccounts
 
-## SAPConfig
-
-collects selected security context constraints
-and cluster role bindings from clusters running a SAP payload.
-
-Relevant OpenShift API docs:
-  - https://pkg.go.dev/github.com/openshift/client-go/authorization/clientset/versioned/typed/authorization/v1
-  - https://pkg.go.dev/github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
 
 Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
 

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -335,6 +335,27 @@ Relevant OpenShift API docs:
 Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
 
 
+## SAPDatahubs
+
+collects `datahubs.installers.datahub.sap.com` resources from SAP/SDI clusters.
+
+Location in archive: customresources/installers.datahub.sap.com/datahubs/<namespace>/<name>.json
+
+
+## SAPPods
+
+collects information about pods running in SAP/SDI namespaces.
+Only pods with a failing status are collected.
+Failed pods belonging to a job that has later succeeded are ignored.
+
+Relevant Kubernetes API docs:
+  - https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1
+  - https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/batch/v1
+  - https://pkg.go.dev/k8s.io/client-go/dynamic
+
+Location in archive: config/pod/{namespace}/{pod-name}.json
+
+
 ## SAPVsystemIptablesLogs
 
 collects logs from SAP vsystem-iptables containers
@@ -359,23 +380,3 @@ Location of serviceaccounts in archive: config/serviceaccounts
 See: docs/insights-archive-sample/config/serviceaccounts
 
 
-Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
-
-## SAPPods
-
-collects information about pods running in SAP/SDI namespaces.
-Only pods with a failing status are collected.
-Failed pods belonging to a job that has later succeeded are ignored.
-
-Relevant Kubernetes API docs:
-  - https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1
-  - https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/batch/v1
-  - https://pkg.go.dev/k8s.io/client-go/dynamic
-
-Location in archive: config/pod/{namespace}/{pod-name}.json
-
-## SAPDatahubs
-
-collects `datahubs.installers.datahub.sap.com` resources from SAP/SDI clusters.
-
-Location in archive: customresources/installers.datahub.sap.com/datahubs/<namespace>/<name>.json

--- a/docs/insights-archive-sample/config/olm_operators.json
+++ b/docs/insights-archive-sample/config/olm_operators.json
@@ -1,0 +1,207 @@
+[
+    {
+        "name": "eap.openshift-operators",
+        "version": "v2.1.1",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:24Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:24Z",
+                "lastUpdateTime": "2021-03-02T08:52:25Z",
+                "message": "installing: waiting for deployment eap-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:46Z",
+                "lastUpdateTime": "2021-03-02T08:52:46Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
+    },
+    {
+        "name": "elasticsearch-operator.openshift-operators-redhat",
+        "version": "4.6.0-202102200141.p0",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T06:38:14Z",
+                "lastUpdateTime": "2021-03-02T06:38:14Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:15Z",
+                "lastUpdateTime": "2021-03-02T06:38:15Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:16Z",
+                "lastUpdateTime": "2021-03-02T06:38:16Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:16Z",
+                "lastUpdateTime": "2021-03-02T06:38:17Z",
+                "message": "installing: waiting for deployment elasticsearch-operator to become ready: Waiting for rollout to finish: 1 old replicas are pending termination...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T06:38:26Z",
+                "lastUpdateTime": "2021-03-02T06:38:26Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
+    },
+    {
+        "name": "kiali-ossm.openshift-operators",
+        "version": "v1.24.5",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:09Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:09Z",
+                "lastUpdateTime": "2021-03-02T08:52:10Z",
+                "message": "installing: waiting for deployment kiali-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:52:29Z",
+                "lastUpdateTime": "2021-03-02T08:52:29Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
+    },
+    {
+        "name": "postgresql-operator-dev4devs-com.psql-test",
+        "version": "v0.1.1",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:53:34Z",
+                "lastUpdateTime": "2021-03-02T08:53:34Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:35Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:35Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:35Z",
+                "lastUpdateTime": "2021-03-02T08:53:36Z",
+                "message": "installing: waiting for deployment postgresql-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:53:47Z",
+                "lastUpdateTime": "2021-03-02T08:53:47Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
+    },
+    {
+        "name": "radanalytics-spark.openshift-operators",
+        "version": "v1.1.0",
+        "csv_conditions": [
+            {
+                "lastTransitionTime": "2021-03-02T08:55:36Z",
+                "lastUpdateTime": "2021-03-02T08:55:36Z",
+                "message": "requirements not yet checked",
+                "phase": "Pending",
+                "reason": "RequirementsUnknown"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:37Z",
+                "lastUpdateTime": "2021-03-02T08:55:37Z",
+                "message": "all requirements found, attempting install",
+                "phase": "InstallReady",
+                "reason": "AllRequirementsMet"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:38Z",
+                "lastUpdateTime": "2021-03-02T08:55:38Z",
+                "message": "waiting for install components to report healthy",
+                "phase": "Installing",
+                "reason": "InstallSucceeded"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:38Z",
+                "lastUpdateTime": "2021-03-02T08:55:38Z",
+                "message": "installing: waiting for deployment spark-operator to become ready: Waiting for rollout to finish: 0 of 1 updated replicas are available...\n",
+                "phase": "Installing",
+                "reason": "InstallWaiting"
+            },
+            {
+                "lastTransitionTime": "2021-03-02T08:55:51Z",
+                "lastUpdateTime": "2021-03-02T08:55:51Z",
+                "message": "install strategy completed with no errors",
+                "phase": "Succeeded",
+                "reason": "InstallSucceeded"
+            }
+        ]
+    }
+]

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -160,6 +160,14 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -66,6 +66,7 @@ func (g *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherSAPPods(g),
 		GatherSAPDatahubs(g),
 		GatherOpenshiftSDNControllerLogs(g),
+		GatherOLMOperators(g),
 	)
 }
 

--- a/pkg/gather/clusterconfig/image_registries.go
+++ b/pkg/gather/clusterconfig/image_registries.go
@@ -32,6 +32,8 @@ type PersistentVolumeAnonymizer struct {
 }
 
 // GatherClusterImageRegistry fetches the cluster Image Registry configuration
+// If the Image Registry configuration uses some PersistentVolumeClaim for the storage then the corresponding
+// PersistentVolume definition is gathered
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 func GatherClusterImageRegistry(g *Gatherer) func() ([]record.Record, []error) {

--- a/pkg/gather/clusterconfig/machine_sets.go
+++ b/pkg/gather/clusterconfig/machine_sets.go
@@ -14,6 +14,12 @@ import (
 
 var machineSetSchema = schema.GroupVersionResource{Group: "machine.openshift.io", Version: "v1beta1", Resource: "machinesets"}
 
+// GatherMachineSet collects MachineSet information
+//
+// The Kubernetes api https://github.com/openshift/machine-api-operator/blob/master/pkg/generated/clientset/versioned/typed/machine/v1beta1/machineset.go
+// Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machineset-v1beta1-machine-openshift-io
+//
+// Location in archive: machinesets/
 func GatherMachineSet(g *Gatherer) func() ([]record.Record, []error) {
 	return func() ([]record.Record, []error) {
 		dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
@@ -24,12 +30,6 @@ func GatherMachineSet(g *Gatherer) func() ([]record.Record, []error) {
 	}
 }
 
-//GatherMachineSet collects MachineSet information
-//
-// The Kubernetes api https://github.com/openshift/machine-api-operator/blob/master/pkg/generated/clientset/versioned/typed/machine/v1beta1/machineset.go
-// Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machineset-v1beta1-machine-openshift-io
-//
-// Location in archive: machinesets/
 func gatherMachineSet(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
 	machineSets, err := dynamicClient.Resource(machineSetSchema).List(ctx, metav1.ListOptions{})
 	if errors.IsNotFound(err) {

--- a/pkg/gather/clusterconfig/olm_operators.go
+++ b/pkg/gather/clusterconfig/olm_operators.go
@@ -1,0 +1,141 @@
+package clusterconfig
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+var (
+	operatorGVR              = schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1", Resource: "operators"}
+	clusterServiceVersionGVR = schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1alpha1", Resource: "clusterserviceversions"}
+)
+
+type olmOperator struct {
+	Name       string        `json:"name"`
+	Version    string        `json:"version"`
+	Conditions []interface{} `json:"csv_conditions"`
+}
+
+// ClusterServiceVersion helper struct
+type csvRef struct {
+	Name      string
+	Namespace string
+	Version   string
+}
+
+// GatherOLMOperators collects list of installed OLM operators.
+// Each OLM operator (in the list) contains following data:
+// - OLM operator name
+// - OLM operator version
+// - related ClusterServiceVersion conditions
+//
+// See: docs/insights-archive-sample/config/olm_operators
+// Location of in archive: config/olm_operators
+// Id in config: olm_operators
+func GatherOLMOperators(g *Gatherer) func() ([]record.Record, []error) {
+	return func() ([]record.Record, []error) {
+		dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+		if err != nil {
+			return nil, []error{err}
+		}
+		return gatherOLMOperators(g.ctx, dynamicClient)
+	}
+}
+
+func gatherOLMOperators(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	olmOperators, err := dynamicClient.Resource(operatorGVR).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	var refs []interface{}
+	olms := []olmOperator{}
+	for _, i := range olmOperators.Items {
+		err := parseJSONQuery(i.Object, "status.components.refs", &refs)
+		if err != nil {
+			klog.Errorf("Cannot find \"status.components.refs\" in %s definition: %v", i.GetName(), err)
+			continue
+		}
+		for _, r := range refs {
+			csvRef := getCSVRefFromRefs(r)
+			if csvRef == nil {
+				continue
+			}
+			conditions, err := getCSVConditions(ctx, dynamicClient, csvRef)
+			if err != nil {
+				klog.Errorf("failed to get %s conditions: %v", csvRef.Name, err)
+				continue
+			}
+			olmO := olmOperator{
+				Name:       i.GetName(),
+				Version:    csvRef.Version,
+				Conditions: conditions,
+			}
+			if isInArray(olmO, olms) {
+				continue
+			}
+			olms = append(olms, olmO)
+		}
+	}
+	if len(olms) == 0 {
+		return nil, nil
+	}
+	r := record.Record{
+		Name: "config/olm_operators",
+		Item: record.JSONMarshaller{Object: olms},
+	}
+	return []record.Record{r}, nil
+}
+
+func isInArray(o olmOperator, a []olmOperator) bool {
+	for _, op := range a {
+		if o.Name == op.Name && o.Version == op.Version {
+			return true
+		}
+	}
+	return false
+}
+
+func getCSVRefFromRefs(r interface{}) *csvRef {
+	refMap, ok := r.(map[string]interface{})
+	if !ok {
+		klog.Errorf("Cannot convert %s to map[string]interface{}", r)
+		return nil
+	}
+	// version is part of the name of ClusterServiceVersion
+	if refMap["kind"] == "ClusterServiceVersion" {
+		name := refMap["name"].(string)
+		nameVer := strings.SplitN(name, ".", 2)
+		csvRef := &csvRef{
+			Name:      name,
+			Namespace: refMap["namespace"].(string),
+			Version:   nameVer[1],
+		}
+		return csvRef
+	}
+	return nil
+}
+
+func getCSVConditions(ctx context.Context, dynamicClient dynamic.Interface, csvRef *csvRef) ([]interface{}, error) {
+	csv, err := dynamicClient.Resource(clusterServiceVersionGVR).Namespace(csvRef.Namespace).Get(ctx, csvRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var conditions []interface{}
+	err = parseJSONQuery(csv.Object, "status.conditions", &conditions)
+	if err != nil {
+		return nil, err
+	}
+	return conditions, nil
+}

--- a/pkg/gather/clusterconfig/olm_operators_test.go
+++ b/pkg/gather/clusterconfig/olm_operators_test.go
@@ -1,0 +1,88 @@
+package clusterconfig
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestOLMOperatorsGather(t *testing.T) {
+	olmOpContent, err := readFromFile("testdata/olm_operator_1.yaml")
+	if err != nil {
+		t.Fatal("test failed to read OLM operator data", err)
+	}
+
+	csvContent, err := readFromFile("testdata/csv_1.yaml")
+	if err != nil {
+		t.Fatal("test failed to read CSV ", err)
+	}
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	err = createUnstructuredResource(olmOpContent, client, operatorGVR)
+	if err != nil {
+		t.Fatal("cannot create OLM operator ", err)
+	}
+	err = createUnstructuredResource(csvContent, client, clusterServiceVersionGVR)
+	if err != nil {
+		t.Fatal("cannot create ClusterServiceVersion ", err)
+	}
+
+	ctx := context.Background()
+	records, errs := gatherOLMOperators(ctx, client)
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %#v", errs)
+		return
+	}
+	if len(records) != 1 {
+		t.Fatalf("unexpected number or records %d", len(records))
+	}
+	ooa, ok := records[0].Item.(record.JSONMarshaller).Object.([]olmOperator)
+	if !ok {
+		t.Fatalf("returned item is not of type []olmOperator")
+	}
+	if ooa[0].Name != "test-olm-operator" {
+		t.Fatalf("unexpected name of gathered OLM operator %s", ooa[0].Name)
+	}
+	if ooa[0].Version != "v1.2.3" {
+		t.Fatalf("unexpected version of gathered OLM operator %s", ooa[0].Version)
+	}
+	if len(ooa[0].Conditions) != 2 {
+		t.Fatalf("unexpected number of conditions %s", ooa[0].Conditions...)
+	}
+}
+
+func createUnstructuredResource(content []byte, client *dynamicfake.FakeDynamicClient, gvr schema.GroupVersionResource) error {
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	unstructuredResource := &unstructured.Unstructured{}
+
+	_, _, err := decUnstructured.Decode(content, nil, unstructuredResource)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Resource(gvr).Namespace("test-olm-operator").Create(context.Background(), unstructuredResource, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func readFromFile(filePath string) ([]byte, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	content, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}

--- a/pkg/gather/clusterconfig/olm_operators_test.go
+++ b/pkg/gather/clusterconfig/olm_operators_test.go
@@ -77,6 +77,7 @@ func createUnstructuredResource(content []byte, client *dynamicfake.FakeDynamicC
 
 func readFromFile(filePath string) ([]byte, error) {
 	f, err := os.Open(filePath)
+	defer f.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gather/clusterconfig/testdata/csv_1.yaml
+++ b/pkg/gather/clusterconfig/testdata/csv_1.yaml
@@ -1,0 +1,17 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+    name: test-olm-operator.v1.2.3
+    namespace: test-olm-operator
+status:
+    conditions:
+        - lastTransitionTime: "2021-03-02T08:52:24Z"
+          lastUpdateTime: "2021-03-02T08:52:24Z"
+          message: requirements not yet checked
+          phase: Pending
+          reason: RequirementsUnknown
+        - lastTransitionTime: "2021-03-02T08:52:24Z"
+          lastUpdateTime: "2021-03-02T08:52:24Z"
+          message: all requirements found, attempting install
+          phase: InstallReady
+          reason: AllRequirementsMet

--- a/pkg/gather/clusterconfig/testdata/olm_operator_1.yaml
+++ b/pkg/gather/clusterconfig/testdata/olm_operator_1.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+    name: test-olm-operator
+status:
+    components:
+        refs:
+            - apiVersion: operators.coreos.com/v1alpha1
+              kind: ClusterServiceVersion
+              name: test-olm-operator.v1.2.3
+              namespace: test-olm-operator


### PR DESCRIPTION
…ClusterServiceVersion conditions

<!-- Short description of the PR. What does it do? -->
Getting more data about installed OLM operators and create corresponding upgrade report is one of the CCX goals. This PR adds the new gatherer to collect information (name, version and conditions) about installed OLM operators. See the CCX epics below.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->
Updated in:
- `docs/insights-archive-sample/config/olm_operators.json`

## Documentation
<!-- Are these changes reflected in documentation? -->
The documentation updated in:
- `docs/gathered-data.md`

**THERE ARE MORE UPDATES TO FIX SOME MISSING STUFF AND THE ORDERING**. The doc is generated so it shouldn't hopefully cause conflicts in the future. 

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
New unit test in:
- `pkg/gather/clusterconfig/olm_operators_test.go `

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-719
https://issues.redhat.com/browse/CCXDEV-3965
https://issues.redhat.com/browse/CCXDEV-3966
https://bugzilla.redhat.com/show_bug.cgi?id=1935574
https://access.redhat.com/solutions/???
