### PR TITLE
[release-4.7] Bug 1936802: Authentication log gatherer - do not scan …

### DIFF
--- a/pkg/gather/clusterconfig/openshift_authentication_logs.go
+++ b/pkg/gather/clusterconfig/openshift_authentication_logs.go
@@ -32,7 +32,7 @@ func GatherOpenshiftAuthenticationLogs(g *Gatherer, c chan<- gatherResult) {
 		86400,   // last day
 		1024*64, // maximum 64 kb of logs
 		"errors",
-		"",
+		"app=oauth-openshift",
 		false,
 	)
 	if err != nil {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Do not scan all the pod logs in the `openshift-authentication` namespace.  

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No update

## Documentation
<!-- Are these changes reflected in documentation? -->

No update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No update

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->
https://bugzilla.redhat.com/show_bug.cgi?id=1936802

