### PR TITLE
[release-4.7] Bug 1936861: Include namespace name in binarydata confi…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -180,7 +180,7 @@ and tries to fetch "cluster-monitoring-config" ConfigMap from openshift-monitori
 
 Anonymization: If the content of ConfigMap contains a parseable PEM structure (like certificate) it removes the inside of PEM blocks.
 For ConfigMap of type BinaryData it is encoded as standard base64.
-In the archive under configmaps we store name of the namesapce, name of the ConfigMap and then each ConfigMap Key.
+In the archive under configmaps we store name of the namespace, name of the ConfigMap and then each ConfigMap Key.
 For example config/configmaps/NAMESPACENAME/CONFIGMAPNAME/CONFIGMAPKEY1
 
 The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/configmap.go#L80

--- a/pkg/gather/clusterconfig/config_maps.go
+++ b/pkg/gather/clusterconfig/config_maps.go
@@ -20,7 +20,7 @@ import (
 //
 // Anonymization: If the content of ConfigMap contains a parseable PEM structure (like certificate) it removes the inside of PEM blocks.
 // For ConfigMap of type BinaryData it is encoded as standard base64.
-// In the archive under configmaps we store name of the namesapce, name of the ConfigMap and then each ConfigMap Key.
+// In the archive under configmaps we store name of the namespace, name of the ConfigMap and then each ConfigMap Key.
 // For example config/configmaps/NAMESPACENAME/CONFIGMAPNAME/CONFIGMAPKEY1
 //
 // The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/configmap.go#L80
@@ -58,7 +58,7 @@ func gatherConfigMaps(ctx context.Context, coreClient corev1client.CoreV1Interfa
 		}
 		for dk, dv := range cms.Items[i].BinaryData {
 			records = append(records, record.Record{
-				Name: fmt.Sprintf("config/configmaps/%s/%s", cms.Items[i].Name, dk),
+				Name: fmt.Sprintf("config/configmaps/%s/%s/%s", cms.Items[i].Namespace, cms.Items[i].Name, dk),
 				Item: ConfigMapAnonymizer{v: dv, encodeBase64: true},
 			})
 		}

--- a/pkg/gather/clusterconfig/config_maps_test.go
+++ b/pkg/gather/clusterconfig/config_maps_test.go
@@ -3,8 +3,10 @@ package clusterconfig
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,6 +14,8 @@ import (
 
 	"github.com/openshift/insights-operator/pkg/record"
 	"github.com/openshift/insights-operator/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestConfigMapAnonymizer(t *testing.T) {
@@ -48,13 +52,8 @@ func TestConfigMapAnonymizer(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.testName, func(t *testing.T) {
-			f, err := os.Open("testdata/configmaps.json")
-			mustNotFail(t, err, "error opening test data file. %+v")
-			defer f.Close()
-			bts, err := ioutil.ReadAll(f)
-			mustNotFail(t, err, "error reading test data file. %+v")
-			var cml *corev1.ConfigMapList
-			mustNotFail(t, json.Unmarshal([]byte(bts), &cml), "error unmarshalling json %+v")
+			cml, err := readConfigMapsTestData()
+			mustNotFail(t, err, "error creating test data %+v")
 			cm := findMap(cml, tt.configMapName)
 			mustNotFail(t, cm != nil, "haven't found a ConfigMap %+v")
 			var res []byte
@@ -104,4 +103,51 @@ func findMap(cml *corev1.ConfigMapList, name string) *corev1.ConfigMap {
 		}
 	}
 	return nil
+}
+
+func readConfigMapsTestData() (*corev1.ConfigMapList, error) {
+	f, err := os.Open("testdata/configmaps.json")
+	if err != nil {
+		return nil, fmt.Errorf("error reading test data file %+v ", err)
+	}
+	defer f.Close()
+	bts, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("error reading test data file %+v ", err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error reading test data file %+v ", err)
+	}
+	var cml *corev1.ConfigMapList
+	err = json.Unmarshal([]byte(bts), &cml)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling json %+v ", err)
+	}
+	return cml, nil
+}
+
+func TestGatherConfigMap(t *testing.T) {
+	cml, err := readConfigMapsTestData()
+	mustNotFail(t, err, "error creating test data %+v")
+	coreClient := kubefake.NewSimpleClientset()
+
+	for _, cm := range cml.Items {
+		_, err := coreClient.CoreV1().ConfigMaps(cm.Namespace).Create(context.Background(), &cm, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("error creating configmap %s", cm.Name)
+		}
+	}
+	records, errs := gatherConfigMaps(context.Background(), coreClient.CoreV1())
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %#v", errs)
+		return
+	}
+	if len(records) != 8 {
+		t.Fatalf("unexpected number of configmaps gathered %d", len(records))
+	}
+	for _, r := range records {
+		if !strings.HasPrefix(r.Name, "config/configmaps/openshift-config/") {
+			t.Fatalf("unexpected configmap path in archive %s", r.Name)
+		}
+	}
 }


### PR DESCRIPTION
…gmap path & test (#368)

<!-- Short description of the PR. What does it do? -->
Fix the missing namespace name in the path of binarydata configmap

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No update. 

## Documentation
<!-- Are these changes reflected in documentation? -->
Minor fix in:
- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
Added new basic test in:
- `pkg/gather/clusterconfig/config_maps_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->
https://bugzilla.redhat.com/show_bug.cgi?id=1936861

