### PR TITLE
[release-4.7] Bug 1939061: Sap license management logs gatherer 4.7

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -399,6 +399,18 @@ Relevant OpenShift API docs:
 Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
 
 
+## SAPVsystemIptablesLogs
+
+collects logs from SAP vsystem-iptables containers
+including one from license management pods with the following substring:
+  - "can't initialize iptables table",
+
+The Kubernetes API https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+
+Location in archive: config/pod/{namespace}/logs/{pod-name}/errors.log
+
+
 ## ServiceAccounts
 
 collects ServiceAccount stats

--- a/docs/insights-archive-sample/config/pod/sdi/logs/license-manager-da1d2e8fadfb8dd7022f08-4hjh7-6887768c5b-qzxb6/errors.log
+++ b/docs/insights-archive-sample/config/pod/sdi/logs/license-manager-da1d2e8fadfb8dd7022f08-4hjh7-6887768c5b-qzxb6/errors.log
@@ -1,0 +1,1 @@
+iptables v1.6.2: can't initialize iptables table `nat': Permission denied

--- a/pkg/authorizer/clusterauthorizer/clusterauthorizer_test.go
+++ b/pkg/authorizer/clusterauthorizer/clusterauthorizer_test.go
@@ -19,7 +19,6 @@ func nonCachedProxyFromEnvironment() func(*http.Request) (*url.URL, error) {
 	}
 }
 
-
 func TestProxy(tt *testing.T) {
 	testCases := []struct {
 		Name       string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,8 +17,8 @@ type Serialized struct {
 		Timeout      string `json:"timeout"`
 		MinRetryTime string `json:"min_retry"`
 	} `json:"pull_report"`
-	Impersonate string `json:"impersonate"`
-	Gather []string `json:"gather"`
+	Impersonate string   `json:"impersonate"`
+	Gather      []string `json:"gather"`
 }
 
 func (s *Serialized) ToController(cfg *Controller) (*Controller, error) {
@@ -100,7 +100,7 @@ type Controller struct {
 	ReportMinRetryTime   time.Duration
 	ReportPullingTimeout time.Duration
 	Impersonate          string
-	Gather				 []string
+	Gather               []string
 
 	Username string
 	Password string

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -88,13 +88,13 @@ func (c *Controller) Gather() {
 	// IMPORTANT: We NEED to run retry $threshold times or we will never set status to degraded.
 	backoff := wait.Backoff{
 		Duration: duration,
-		Factor: 1.35,
-		Jitter: 0,
-		Steps:  threshold,
-		Cap:    interval,
+		Factor:   1.35,
+		Jitter:   0,
+		Steps:    threshold,
+		Cap:      interval,
 	}
 	for name := range c.gatherers {
-		_ = wait.ExponentialBackoff(backoff, func() (bool,error) {
+		_ = wait.ExponentialBackoff(backoff, func() (bool, error) {
 			start := time.Now()
 			err := c.runGatherer(name)
 			if err == nil {

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -83,6 +83,7 @@ var gatherFunctions = map[string]gathering{
 	"openshift_sdn_controller_logs":     failable(GatherOpenshiftSDNControllerLogs),
 	"openshift_authentication_logs":     failable(GatherOpenshiftAuthenticationLogs),
 	"sap_config":                        failable(GatherSAPConfig),
+	"sap_license_management_logs":       failable(GatherSAPVsystemIptablesLogs),
 	"olm_operators":                     failable(GatherOLMOperators),
 }
 

--- a/pkg/gather/clusterconfig/const.go
+++ b/pkg/gather/clusterconfig/const.go
@@ -1,0 +1,11 @@
+package clusterconfig
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	datahubGroupVersionResource = schema.GroupVersionResource{
+		Group: "installers.datahub.sap.com", Version: "v1alpha1", Resource: "datahubs",
+	}
+)

--- a/pkg/gather/clusterconfig/custom_resource_definitions.go
+++ b/pkg/gather/clusterconfig/custom_resource_definitions.go
@@ -22,7 +22,7 @@ import (
 //
 // Location in archive: config/crd/
 // Id in config: crds
-func GatherCRD(g *Gatherer, c chan<- gatherResult){
+func GatherCRD(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)
 	crdClient, err := apixv1.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/gather_logs_test.go
+++ b/pkg/gather/clusterconfig/gather_logs_test.go
@@ -43,18 +43,21 @@ func testGatherLogs(t *testing.T, regexSearch bool, stringToSearch string, shoul
 		t.Fatal(err)
 	}
 
-	records, err := gatherLogsFromPodsInNamespace(
+	records, err := gatherLogsFromContainers(
 		ctx,
 		coreClient,
-		testPodName,
-		[]string{
-			stringToSearch,
+		logContainersFilter{
+			namespace: testPodName,
 		},
-		86400,   // last day
-		1024*64, // maximum 64 kb of logs
+		logMessagesFilter{
+			messagesToSearch: []string{
+				stringToSearch,
+			},
+			isRegexSearch: regexSearch,
+			sinceSeconds:  86400,     // last day
+			limitBytes:    1024 * 64, // maximum 64 kb of logs
+		},
 		testLogFileName,
-		"",
-		regexSearch,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/gather/clusterconfig/image_pruners.go
+++ b/pkg/gather/clusterconfig/image_pruners.go
@@ -21,7 +21,7 @@ import (
 //
 // Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
 // Id in config: image_pruners
-func GatherClusterImagePruner(g *Gatherer, c chan<- gatherResult){
+func GatherClusterImagePruner(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)
 	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/ingresses.go
+++ b/pkg/gather/clusterconfig/ingresses.go
@@ -21,7 +21,7 @@ import (
 // Location in archive: config/ingress/
 // See: docs/insights-archive-sample/config/ingress
 // Id in config: ingress
-func GatherClusterIngress(g *Gatherer, c chan<- gatherResult){
+func GatherClusterIngress(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gather/clusterconfig/openshift_authentication_logs.go
+++ b/pkg/gather/clusterconfig/openshift_authentication_logs.go
@@ -15,8 +15,8 @@ func GatherOpenshiftAuthenticationLogs(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)
 
 	containersFilter := logContainersFilter{
-		namespace: "openshift-authentication",
-    labelSelector: "app=oauth-openshift",
+		namespace:     "openshift-authentication",
+		labelSelector: "app=oauth-openshift",
 	}
 	messagesFilter := logMessagesFilter{
 		messagesToSearch: []string{
@@ -41,7 +41,7 @@ func GatherOpenshiftAuthenticationLogs(g *Gatherer, c chan<- gatherResult) {
 		containersFilter,
 		messagesFilter,
 		"errors",
-  )
+	)
 	if err != nil {
 		c <- gatherResult{nil, []error{err}}
 		return

--- a/pkg/gather/clusterconfig/openshift_sdn_controller_logs.go
+++ b/pkg/gather/clusterconfig/openshift_sdn_controller_logs.go
@@ -21,11 +21,22 @@ import (
 //
 // Location in archive: config/pod/openshift-sdn/logs/{pod-name}/errors.log
 func GatherOpenshiftSDNControllerLogs(g *Gatherer, c chan<- gatherResult) {
-	messagesToSearch := []string{
-		"Node.+is not Ready",
-		"Node.+may be offline\\.\\.\\. retrying",
-		"Node.+is offline",
-		"Node.+is back online",
+	defer close(c)
+
+	containersFilter := logContainersFilter{
+		namespace:     "openshift-sdn",
+		labelSelector: "app=sdn-controller",
+	}
+	messagesFilter := logMessagesFilter{
+		messagesToSearch: []string{
+			"Node.+is not Ready",
+			"Node.+may be offline\\.\\.\\. retrying",
+			"Node.+is offline",
+			"Node.+is back online",
+		},
+		isRegexSearch: true,
+		sinceSeconds:  86400,     // last day
+		limitBytes:    1024 * 64, // maximum 64 kb of logs
 	}
 
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
@@ -36,16 +47,12 @@ func GatherOpenshiftSDNControllerLogs(g *Gatherer, c chan<- gatherResult) {
 
 	coreClient := gatherKubeClient.CoreV1()
 
-	records, err := gatherLogsFromPodsInNamespace(
+	records, err := gatherLogsFromContainers(
 		g.ctx,
 		coreClient,
-		"openshift-sdn",
-		messagesToSearch,
-		86400,   // last day
-		1024*64, // maximum 64 kb of logs
+		containersFilter,
+		messagesFilter,
 		"errors",
-		"app=sdn-controller",
-		true,
 	)
 	if err != nil {
 		c <- gatherResult{nil, []error{err}}

--- a/pkg/gather/clusterconfig/sap_config.go
+++ b/pkg/gather/clusterconfig/sap_config.go
@@ -7,7 +7,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -27,6 +26,8 @@ import (
 //
 // Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
 func GatherSAPConfig(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
+
 	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
 		c <- gatherResult{errors: []error{err}}
@@ -56,9 +57,7 @@ func gatherSAPConfig(ctx context.Context, dynamicClient dynamic.Interface, coreC
 	sccToGather := []string{"anyuid", "privileged"}
 	crbToGather := []string{"system:openshift:scc:anyuid", "system:openshift:scc:privileged"}
 
-	datahubsResource := schema.GroupVersionResource{Group: "installers.datahub.sap.com", Version: "v1alpha1", Resource: "datahubs"}
-
-	datahubsList, err := dynamicClient.Resource(datahubsResource).List(ctx, metav1.ListOptions{})
+	datahubsList, err := dynamicClient.Resource(datahubGroupVersionResource).List(ctx, metav1.ListOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
 	}

--- a/pkg/gather/clusterconfig/sap_config_test.go
+++ b/pkg/gather/clusterconfig/sap_config_test.go
@@ -26,9 +26,8 @@ metadata:
     namespace: example-namespace
 `
 
-	datahubsResource := schema.GroupVersionResource{Group: "installers.datahub.sap.com", Version: "v1alpha1", Resource: "datahubs"}
 	datahubsClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
-		datahubsResource: "DataHubsList",
+		datahubGroupVersionResource: "DataHubsList",
 	})
 
 	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
@@ -89,7 +88,7 @@ metadata:
 	}
 
 	// Create the DataHubs resource and now the SCCs and CRBs should be gathered.
-	datahubsClient.Resource(datahubsResource).Namespace("example-namespace").Create(context.Background(), testDatahub, metav1.CreateOptions{})
+	datahubsClient.Resource(datahubGroupVersionResource).Namespace("example-namespace").Create(context.Background(), testDatahub, metav1.CreateOptions{})
 
 	records, errs = gatherSAPConfig(context.Background(), datahubsClient, coreClient.CoreV1(), securityClient.SecurityV1(), authClient.AuthorizationV1())
 	if len(errs) > 0 {

--- a/pkg/gather/clusterconfig/sap_vsystem_iptables_logs.go
+++ b/pkg/gather/clusterconfig/sap_vsystem_iptables_logs.go
@@ -1,0 +1,98 @@
+package clusterconfig
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+// GatherSAPVsystemIptablesLogs collects logs from SAP vsystem-iptables containers
+// including one from license management pods with the following substring:
+//   - "can't initialize iptables table",
+//
+// The Kubernetes API https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+// Response see https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+//
+// Location in archive: config/pod/{namespace}/logs/{pod-name}/errors.log
+func GatherSAPVsystemIptablesLogs(g *Gatherer, c chan<- gatherResult) {
+	defer close(c)
+
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		c <- gatherResult{errors: []error{err}}
+		return
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		c <- gatherResult{nil, []error{err}}
+		return
+	}
+
+	datahubsList, err := dynamicClient.Resource(datahubGroupVersionResource).List(g.ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		c <- gatherResult{nil, nil}
+		return
+	}
+	if err != nil {
+		c <- gatherResult{nil, []error{err}}
+		return
+	}
+	// If no DataHubs resource exists on the cluster, skip this gathering.
+	// This may already be handled by the IsNotFound check, but it's better to be sure.
+	if len(datahubsList.Items) == 0 {
+		c <- gatherResult{nil, nil}
+		return
+	}
+
+	coreClient := kubeClient.CoreV1()
+
+	records, errs := gatherSAPLicenseManagementLogs(g.ctx, coreClient, datahubsList.Items)
+	c <- gatherResult{records, errs}
+}
+
+func gatherSAPLicenseManagementLogs(
+	ctx context.Context,
+	coreClient corev1client.CoreV1Interface,
+	datahubs []unstructured.Unstructured,
+) ([]record.Record, []error) {
+	var records []record.Record
+	var errs []error
+
+	for _, item := range datahubs {
+		containersFilter := logContainersFilter{
+			namespace:                item.GetNamespace(),
+			containerNameRegexFilter: "^vsystem-iptables$",
+		}
+		messagesFilter := logMessagesFilter{
+			messagesToSearch: []string{
+				"can't initialize iptables table",
+			},
+			isRegexSearch: false,
+			sinceSeconds:  86400,
+			limitBytes:    1024 * 64,
+		}
+
+		namespaceRecords, err := gatherLogsFromContainers(
+			ctx,
+			coreClient,
+			containersFilter,
+			messagesFilter,
+			"errors",
+		)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			records = append(records, namespaceRecords...)
+		}
+	}
+
+	return records, errs
+}

--- a/pkg/gather/interface.go
+++ b/pkg/gather/interface.go
@@ -9,4 +9,3 @@ import (
 type Interface interface {
 	Gather(context.Context, []string, record.Interface) error
 }
-

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -37,13 +37,13 @@ const (
 )
 
 type Client struct {
-	client      		*http.Client
-	maxBytes    		int64
-	metricsName 		string
+	client      *http.Client
+	maxBytes    int64
+	metricsName string
 
-	authorizer  		Authorizer
-	gatherKubeConfig	*rest.Config
-	clusterVersion  	*configv1.ClusterVersion
+	authorizer       Authorizer
+	gatherKubeConfig *rest.Config
+	clusterVersion   *configv1.ClusterVersion
 }
 
 type Authorizer interface {
@@ -68,11 +68,11 @@ func New(client *http.Client, maxBytes int64, metricsName string, authorizer Aut
 		maxBytes = 10 * 1024 * 1024
 	}
 	return &Client{
-		client:      		client,
-		maxBytes:    		maxBytes,
-		metricsName: 		metricsName,
-		authorizer:  		authorizer,
-		gatherKubeConfig:	gatherKubeConfig,
+		client:           client,
+		maxBytes:         maxBytes,
+		metricsName:      metricsName,
+		authorizer:       authorizer,
+		gatherKubeConfig: gatherKubeConfig,
 	}
 }
 


### PR DESCRIPTION
Backport

```
The SAP installation may fail in license management pod, so We need error logs to detect the failure.

Get the filtered error logs as followings.

# oc logs deploy/license-management-l4rvh
Found 2 pods, using pod/license-management-l4rvh-74595f8c9b-flgz9
+ iptables -D PREROUTING -t nat -j VSYSTEM-AGENT-PREROUTING
+ true
+ iptables -F VSYSTEM-AGENT-PREROUTING -t nat
+ true
+ iptables -X VSYSTEM-AGENT-PREROUTING -t nat
+ true
+ iptables -N VSYSTEM-AGENT-PREROUTING -t nat
iptables v1.6.2: can't initialize iptables table `nat': Permission denied
Perhaps iptables or your kernel needs to be upgraded.
```
Tested on SAP cluster with different substrings.

## Categories

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive

No changes

## Documentation

- `docs/gathered-data.md`

## Unit Tests

No changes

## Privacy

Yes. There are no sensitive data in the newly collected information.

## References

https://issues.redhat.com/browse/CCXDEV-4172
https://bugzilla.redhat.com/show_bug.cgi?id=1939061
https://access.redhat.com/articles/5100521#license-manager-cannot-be-initialized