### PR TITLE
Bug 1988351: OCM controller - periodically pull the data and update corresponding

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -6,5 +6,8 @@ interval: "5m"
 storagePath: /tmp/insights-operator
 endpoint: http://[::1]:8081
 impersonate: system:serviceaccount:openshift-insights:gather
+ocm:
+  endpoint: https://jsonplaceholder.typicode.com/albums?id=1
+  interval: "4h"
 gather:
   - ALL

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -8,6 +8,7 @@ endpoint: http://[::1]:8081
 impersonate: system:serviceaccount:openshift-insights:gather
 ocm:
   endpoint: https://jsonplaceholder.typicode.com/albums?id=1
-  interval: "4h"
+  interval: "30s"
+  disabled: false
 gather:
   - ALL

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -8,7 +8,6 @@ endpoint: http://[::1]:8081
 impersonate: system:serviceaccount:openshift-insights:gather
 ocm:
   endpoint: https://jsonplaceholder.typicode.com/albums?id=1
-  interval: "30s"
-  disabled: false
+  interval: "6h"
 gather:
   - ALL

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -6,8 +6,5 @@ interval: "5m"
 storagePath: /tmp/insights-operator
 endpoint: http://[::1]:8081
 impersonate: system:serviceaccount:openshift-insights:gather
-ocm:
-  endpoint: https://jsonplaceholder.typicode.com/albums?id=1
-  interval: "6h"
 gather:
   - ALL

--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -11,5 +11,8 @@ pull_report:
   delay: "60s"
   timeout: "3000s"
   min_retry: "30s"
+ocm:
+  endpoint: https://api.openshift.com/api/accounts_mgmt/v1/certificates
+  interval: "8h"
 gather:
   - ALL

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -365,3 +365,42 @@ subjects:
 roleRef:
   kind: Role
   name: insights-operator-obfuscation-secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: insights-operator-etc-pki-entitlement
+  namespace: openshift-config-managed
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+      - watch
+      - list
+      - delete
+      - update
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: insights-operator-etc-pki-entitlement
+  namespace: openshift-config-managed
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+subjects:
+  - kind: ServiceAccount
+    name: operator
+    namespace: openshift-insights
+roleRef:
+  kind: Role
+  name: insights-operator-etc-pki-entitlement

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -212,7 +212,6 @@ rules:
       - get
       - list
       - watch
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -33,6 +33,10 @@ func NewOperator() *cobra.Command {
 			ReportPullingDelay:   60 * time.Second,
 			ReportMinRetryTime:   10 * time.Second,
 			ReportPullingTimeout: 30 * time.Minute,
+			OCMConfig: config.OCMConfig{
+				Interval: 8 * time.Hour,
+				Endpoint: "https://api.openshift.com/api/accounts_mgmt/v1/certificates",
+			},
 		},
 	}
 	cfg := controllercmd.NewControllerCommandConfig("openshift-insights-operator", version.Get(), operator.Run)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,10 @@ type Serialized struct {
 	Impersonate             string   `json:"impersonate"`
 	Gather                  []string `json:"gather"`
 	EnableGlobalObfuscation bool     `json:"enableGlobalObfuscation"`
+	Ocm         struct {
+		Endpoint string `json:"endpoint"`
+		Interval string `json:"interval"`
+	}
 }
 
 // Controller defines the standard config for this operator.
@@ -50,6 +54,8 @@ type Controller struct {
 	// EnableGlobalObfuscation enables obfuscation of domain names and IP addresses
 	// To see the detailed info about how anonymization works, go to the docs of package anonymization.
 	EnableGlobalObfuscation bool
+	OcmEndpoint          string
+	OcmInterval          time.Duration
 
 	Username string
 	Password string
@@ -159,6 +165,17 @@ func ToController(s *Serialized, cfg *Controller) (*Controller, error) { // noli
 		return nil, fmt.Errorf("storagePath must point to a directory where snapshots can be stored")
 	}
 
+	if len(s.Ocm.Endpoint) > 0 {
+		cfg.OcmEndpoint = s.Ocm.Endpoint
+	}
+
+	if len(s.Ocm.Interval) > 0 {
+		i, err := time.ParseDuration(s.Ocm.Interval)
+		if err != nil {
+			return nil, fmt.Errorf("ocm interval must be a valid duration: %v", err)
+		}
+		cfg.OcmInterval = i
+	}
 	return cfg, nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,9 +24,10 @@ type Serialized struct {
 	Impersonate             string   `json:"impersonate"`
 	Gather                  []string `json:"gather"`
 	EnableGlobalObfuscation bool     `json:"enableGlobalObfuscation"`
-	Ocm         struct {
+	Ocm                     struct {
 		Endpoint string `json:"endpoint"`
 		Interval string `json:"interval"`
+		Disabled bool   `json:"disabled"`
 	}
 }
 
@@ -54,14 +55,13 @@ type Controller struct {
 	// EnableGlobalObfuscation enables obfuscation of domain names and IP addresses
 	// To see the detailed info about how anonymization works, go to the docs of package anonymization.
 	EnableGlobalObfuscation bool
-	OcmEndpoint          string
-	OcmInterval          time.Duration
 
 	Username string
 	Password string
 	Token    string
 
 	HTTPConfig HTTPConfig
+	OCMConfig  OCMConfig
 }
 
 // HTTPConfig configures http proxy and exception settings if they come from config
@@ -69,6 +69,13 @@ type HTTPConfig struct {
 	HTTPProxy  string
 	HTTPSProxy string
 	NoProxy    string
+}
+
+// OCMConfig configures the interval and endpoint for retrieving the data from OCM API
+type OCMConfig struct {
+	Interval time.Duration
+	Endpoint string
+	Disabled bool
 }
 
 type Converter func(s *Serialized, cfg *Controller) (*Controller, error)
@@ -166,15 +173,16 @@ func ToController(s *Serialized, cfg *Controller) (*Controller, error) { // noli
 	}
 
 	if len(s.Ocm.Endpoint) > 0 {
-		cfg.OcmEndpoint = s.Ocm.Endpoint
+		cfg.OCMConfig.Endpoint = s.Ocm.Endpoint
 	}
+	cfg.OCMConfig.Disabled = s.Ocm.Disabled
 
 	if len(s.Ocm.Interval) > 0 {
 		i, err := time.ParseDuration(s.Ocm.Interval)
 		if err != nil {
 			return nil, fmt.Errorf("ocm interval must be a valid duration: %v", err)
 		}
-		cfg.OcmInterval = i
+		cfg.OCMConfig.Interval = i
 	}
 	return cfg, nil
 }

--- a/pkg/config/configobserver/configobserver.go
+++ b/pkg/config/configobserver/configobserver.go
@@ -114,7 +114,7 @@ func (c *Controller) retrieveToken(ctx context.Context) error {
 }
 
 // Updates the stored configs from the secrets in the cluster. (if present)
-func (c *Controller) retrieveConfig(ctx context.Context) error { //nolint: gocyclo
+func (c *Controller) retrieveConfig(ctx context.Context) error { //nolint: gocyclo,funlen
 	var nextConfig config.Controller
 
 	klog.V(2).Infof("Refreshing configuration from cluster secret")
@@ -208,8 +208,9 @@ func (c *Controller) retrieveConfig(ctx context.Context) error { //nolint: gocyc
 			nextConfig.OCMConfig.Endpoint = string(ocmEndpoint)
 		}
 		if ocmInterval, ok := secret.Data["ocmInterval"]; ok {
-			if oi, err := time.ParseDuration(string(ocmInterval)); err == nil {
-				nextConfig.OCMConfig.Interval = oi
+			var newInterval time.Duration
+			if newInterval, err = time.ParseDuration(string(ocmInterval)); err == nil {
+				nextConfig.OCMConfig.Interval = newInterval
 			} else {
 				klog.Warningf(
 					"secret contains an invalid value (%s) for ocmInterval. Using previous value",

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -167,7 +167,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	go reportGatherer.Run(ctx)
 
 	klog.Warning("started")
-	
+
 	// OMC controller periodically checks and pull data from the OCM API
 	// the data is exposed in the OpenShift API
 	ocmController := ocm.New(ctx, kubeClient.CoreV1(), configObserver, insightsClient)

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -113,10 +113,6 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 			klog.Errorf(anonymization.UnableToCreateAnonymizerErrorMessage, err)
 		}
 	}
-	// OMC controller periodically checks and pull data from the OCM API
-	// the data is exposed in the OpenShift API
-	ocmController := ocm.New(ctx, gatherKubeClient.CoreV1(), configObserver)
-	go ocmController.Run()
 
 	// the recorder periodically flushes any recorded data to disk as tar.gz files
 	// in s.StoragePath, and also prunes files above a certain age

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -167,6 +167,11 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	go reportGatherer.Run(ctx)
 
 	klog.Warning("started")
+	
+	// OMC controller periodically checks and pull data from the OCM API
+	// the data is exposed in the OpenShift API
+	ocmController := ocm.New(ctx, kubeClient.CoreV1(), configObserver, insightsClient)
+	go ocmController.Run()
 
 	<-ctx.Done()
 

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -156,7 +157,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	//   a threshold
 
 	// start reporting status now that all controller loops are added as sources
-	if err := statusReporter.Start(ctx); err != nil {
+	if err = statusReporter.Start(ctx); err != nil {
 		return fmt.Errorf("unable to set initial cluster status: %v", err)
 	}
 	// start uploading status, so that we
@@ -166,12 +167,8 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	reportGatherer := insightsreport.New(insightsClient, configObserver, uploader)
 	go reportGatherer.Run(ctx)
 
+	runOCMController(ctx, configClient, kubeClient, configObserver, insightsClient)
 	klog.Warning("started")
-
-	// OMC controller periodically checks and pull data from the OCM API
-	// the data is exposed in the OpenShift API
-	ocmController := ocm.New(ctx, kubeClient.CoreV1(), configObserver, insightsClient)
-	go ocmController.Run()
 
 	<-ctx.Done()
 
@@ -205,4 +202,50 @@ func isRunning(ctx context.Context, kubeConfig *rest.Config) wait.ConditionFunc 
 		}
 		return true, nil
 	}
+}
+
+// runOCMController checks the "InsightsOperatorPullingSCA" feature and if it's enabled then run the OCM controller
+func runOCMController(ctx context.Context, configClient *configv1client.ConfigV1Client,
+	kubeClient *kubernetes.Clientset, configObserver *configobserver.Controller, insightsClient *insightsclient.Client) {
+	ocmEnabled, err := featureEnabled(ctx, configClient, "InsightsOperatorPullingSCA")
+	if err != nil {
+		klog.Errorf("Pulling of SCA certs from the OCM is disabled. Unable to get cluster FeatureGate: %v", err)
+	}
+	if ocmEnabled {
+		klog.Info("Pulling of SCA certs from the OCM is enabled.")
+		// OMC controller periodically checks and pull data from the OCM API
+		// the data is exposed in the OpenShift API
+		ocmController := ocm.New(ctx, kubeClient.CoreV1(), configObserver, insightsClient)
+		go ocmController.Run()
+	}
+}
+
+// featureEnabled checks if the feature is enabled in the "cluster" FeatureGate
+func featureEnabled(ctx context.Context, client *configv1client.ConfigV1Client, feature string) (bool, error) {
+	fg, err := client.FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	enabled := getEnabledFeatures(fg)
+	for _, f := range enabled {
+		if f == feature {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// getEnabledFeatures returns a list of enabled features in provided FeatureGate
+func getEnabledFeatures(fg *configv1.FeatureGate) []string {
+	if fg.Spec.FeatureSet == "" {
+		return nil
+	}
+	if fg.Spec.FeatureSet == configv1.CustomNoUpgrade {
+		return fg.Spec.CustomNoUpgrade.Enabled
+	}
+	gates := configv1.FeatureSets[fg.Spec.FeatureSet]
+	if gates == nil {
+		return nil
+	}
+	return gates.Enabled
 }

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openshift/insights-operator/pkg/insights/insightsclient"
 	"github.com/openshift/insights-operator/pkg/insights/insightsreport"
 	"github.com/openshift/insights-operator/pkg/insights/insightsuploader"
+	"github.com/openshift/insights-operator/pkg/ocm"
 	"github.com/openshift/insights-operator/pkg/recorder"
 	"github.com/openshift/insights-operator/pkg/recorder/diskrecorder"
 )
@@ -112,6 +113,10 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 			klog.Errorf(anonymization.UnableToCreateAnonymizerErrorMessage, err)
 		}
 	}
+	// OMC controller periodically checks and pull data from the OCM API
+	// the data is exposed in the OpenShift API
+	ocmController := ocm.New(ctx, gatherKubeClient.CoreV1(), configObserver)
+	go ocmController.Run()
 
 	// the recorder periodically flushes any recorded data to disk as tar.gz files
 	// in s.StoragePath, and also prunes files above a certain age

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -342,7 +342,7 @@ func (c Client) RecvReport(ctx context.Context, endpoint string) (*io.ReadCloser
 			StatusCode: resp.StatusCode,
 			Err:        fmt.Errorf("insights report not found: %s (request=%s): %s", resp.Request.URL, requestID, string(body)),
 		}
-		return nil, notFoundErr
+		return notFoundErr
 	}
 
 	if resp.StatusCode >= 300 || resp.StatusCode < 200 {

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -262,12 +262,12 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 	counterRequestSend.WithLabelValues(c.metricsName, strconv.Itoa(resp.StatusCode)).Inc()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		klog.V(2).Infof("gateway server %s returned 401, %s=%s", insightsReqId, resp.Request.URL, requestID)
+		klog.V(2).Infof("gateway server %s returned 401, %s=%s", resp.Request.URL, insightsReqId, requestID)
 		return authorizer.Error{Err: fmt.Errorf("your Red Hat account is not enabled for remote support or your token has expired: %s", responseBody(resp))}
 	}
 
 	if resp.StatusCode == http.StatusForbidden {
-		klog.V(2).Infof("gateway server %s returned 403, %s=%s", insightsReqId, resp.Request.URL, requestID)
+		klog.V(2).Infof("gateway server %s returned 403, %s=%s", resp.Request.URL, insightsReqId, requestID)
 		return authorizer.Error{Err: fmt.Errorf("your Red Hat account is not enabled for remote support")}
 	}
 
@@ -280,7 +280,7 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 	}
 
 	if len(requestID) > 0 {
-		klog.V(2).Infof("Successfully reported id=%s %s=%s, wrote=%d", insightsReqId, source.ID, requestID, bytesRead)
+		klog.V(2).Infof("Successfully reported id=%s %s=%s, wrote=%d", source.ID, insightsReqId, requestID, bytesRead)
 	}
 
 	return nil

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	targetNamespaceName = "openshift-config-managed"
-	secretName          = "simple-content-access-cert"
+	secretName          = "etc-pki-entitlement"
 )
 
 // Controller holds all the required resources to be able to communicate with OCM API

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -1,0 +1,161 @@
+package ocm
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/openshift/insights-operator/pkg/config"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	targetNamespaceName = "openshift-config-managed"
+	secretName          = "simple-content-access-cert"
+)
+
+// Controller holds all the required resources to be able to communicate with OCM API
+type Controller struct {
+	coreClient   corev1client.CoreV1Interface
+	context      context.Context
+	configurator Configurator
+}
+
+// Configurator represents the interface to retrieve the configuration for the gatherer
+type Configurator interface {
+	Config() *config.Controller
+	ConfigChanged() (<-chan struct{}, func())
+}
+
+// New creates new instance
+func New(ctx context.Context, coreClient corev1client.CoreV1Interface, configurator Configurator) *Controller {
+	return &Controller{
+		coreClient:   coreClient,
+		context:      ctx,
+		configurator: configurator,
+	}
+}
+
+// Run periodically queries the OCM API and update corresponding secret accordingly
+func (c *Controller) Run() {
+	cfg := c.configurator.Config()
+	endpoint := cfg.OcmEndpoint
+	interval := cfg.OcmInterval
+	configCh, cancel := c.configurator.ConfigChanged()
+	defer cancel()
+
+	c.requestDataAndCheckSecret(endpoint)
+	for {
+		select {
+		case <-time.After(interval):
+			c.requestDataAndCheckSecret(endpoint)
+		case <-configCh:
+			cfg := c.configurator.Config()
+			interval = cfg.OcmInterval
+			endpoint = cfg.OcmEndpoint
+		}
+	}
+}
+
+func (c *Controller) requestDataAndCheckSecret(endpoint string) {
+	data, err := requestData(endpoint)
+	if err != nil {
+		klog.Errorf("errror requesting data from %s: %v", endpoint, err)
+	}
+	// check & update the secret here
+	ok, err := c.checkSecret(data)
+	if !ok {
+		// TODO - change IO status in case of failure ?
+		klog.Errorf("error when checking the %s secret: %v", secretName, err)
+		return
+	}
+	klog.Infof("%s secret successfuly updated", secretName)
+
+}
+
+// checkSecret checks "simple-content-access" secret in the "openshift-config-managed" namespace.
+// If the secret doesn't exist then it will create a new one.
+// If the secret already exist then it will update the data.
+func (c *Controller) checkSecret(data []byte) (bool, error) {
+	scaSec, err := c.coreClient.Secrets(targetNamespaceName).Get(c.context, secretName, metav1.GetOptions{})
+
+	//if the secret doesn't exist then create one
+	if errors.IsNotFound(err) {
+		_, err = c.createSecret(data)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	_, err = c.updateSecret(scaSec, data)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (o *Controller) createSecret(data []byte) (*v1.Secret, error) {
+	newSCA := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: targetNamespaceName,
+		},
+		// TODO set the data correctly
+		Data: map[string][]byte{
+			v1.TLSCertKey:       data,
+			v1.TLSPrivateKeyKey: data,
+		},
+		Type: v1.SecretTypeTLS,
+	}
+	cm, err := o.coreClient.Secrets(targetNamespaceName).Create(o.context, newSCA, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return cm, nil
+}
+
+// updateSecret updates provided secret with given data
+func (o *Controller) updateSecret(s *v1.Secret, data []byte) (*v1.Secret, error) {
+
+	// TODO set the data correctly
+	s.Data = map[string][]byte{
+		v1.TLSCertKey:       data,
+		v1.TLSPrivateKeyKey: data,
+	}
+	s, err := o.coreClient.Secrets(s.Namespace).Update(o.context, s, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// TODO
+// - no need to create new HTTP client every time
+// - add authorization
+// - add response status check
+// - move this to insightsclient?
+func requestData(endpoint string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	d, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -1,0 +1,63 @@
+package ocm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	tlsSecretCrt = "tls.crt"
+	tlsSecretKey = "tls.key"
+	secTestData  = "secret testing data"
+)
+
+func Test_OCMController_SecretIsCreated(t *testing.T) {
+	kube := kubefake.NewSimpleClientset()
+	coreClient := kube.CoreV1()
+	ocmController := New(context.TODO(), coreClient, nil, nil)
+
+	err := ocmController.checkSecret([]byte(secTestData))
+	assert.NoError(t, err, "failed to check the secret")
+
+	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
+	assert.NoError(t, err, "can't get secret")
+	assert.Contains(t, testSecret.Data, tlsSecretKey, "can't find %s in the %s secret data", tlsSecretKey, secretName)
+	assert.Contains(t, testSecret.Data, tlsSecretCrt, "can't find %s in the %s secret data", tlsSecretCrt, secretName)
+	assert.Equal(t, secTestData, string(testSecret.Data[tlsSecretKey]), "unexpected data in %s secret", secretName)
+	assert.Equal(t, secTestData, string(testSecret.Data[tlsSecretCrt]), "unexpected data in %s secret", secretName)
+}
+
+func Test_OCMController_SecretIsUpdated(t *testing.T) {
+	kube := kubefake.NewSimpleClientset()
+	coreClient := kube.CoreV1()
+
+	existingSec := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretName,
+		},
+		Type: v1.SecretTypeTLS,
+		Data: map[string][]byte{
+			v1.TLSCertKey:       []byte(secTestData),
+			v1.TLSPrivateKeyKey: []byte(secTestData),
+		},
+	}
+	_, err := coreClient.Secrets(targetNamespaceName).Create(context.Background(), existingSec, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	ocmController := New(context.TODO(), coreClient, nil, nil)
+
+	updatedTestData := "new secret testing data"
+	err = ocmController.checkSecret([]byte(updatedTestData))
+	assert.NoError(t, err, "failed to check the secret")
+
+	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
+	assert.NoError(t, err, "can't get secret")
+	assert.Contains(t, testSecret.Data, tlsSecretKey, "can't find %s in the %s secret data", tlsSecretKey, secretName)
+	assert.Contains(t, testSecret.Data, tlsSecretCrt, "can't find %s in the %s secret data", tlsSecretCrt, secretName)
+	assert.Equal(t, updatedTestData, string(testSecret.Data[tlsSecretKey]), "unexpected data in %s secret", secretName)
+	assert.Equal(t, updatedTestData, string(testSecret.Data[tlsSecretCrt]), "unexpected data in %s secret", secretName)
+}

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -16,20 +16,25 @@ var (
 	secTestData  = "secret testing data"
 )
 
+var testRes = &ScaResponse{
+	Key:  "secret key",
+	Cert: "secret cert",
+}
+
 func Test_OCMController_SecretIsCreated(t *testing.T) {
 	kube := kubefake.NewSimpleClientset()
 	coreClient := kube.CoreV1()
 	ocmController := New(context.TODO(), coreClient, nil, nil)
 
-	err := ocmController.checkSecret([]byte(secTestData))
+	err := ocmController.checkSecret(testRes)
 	assert.NoError(t, err, "failed to check the secret")
 
 	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
 	assert.NoError(t, err, "can't get secret")
 	assert.Contains(t, testSecret.Data, tlsSecretKey, "can't find %s in the %s secret data", tlsSecretKey, secretName)
 	assert.Contains(t, testSecret.Data, tlsSecretCrt, "can't find %s in the %s secret data", tlsSecretCrt, secretName)
-	assert.Equal(t, secTestData, string(testSecret.Data[tlsSecretKey]), "unexpected data in %s secret", secretName)
-	assert.Equal(t, secTestData, string(testSecret.Data[tlsSecretCrt]), "unexpected data in %s secret", secretName)
+	assert.Equal(t, "secret key", string(testSecret.Data[tlsSecretKey]), "unexpected data in %s secret", secretName)
+	assert.Equal(t, "secret cert", string(testSecret.Data[tlsSecretCrt]), "unexpected data in %s secret", secretName)
 }
 
 func Test_OCMController_SecretIsUpdated(t *testing.T) {
@@ -50,14 +55,15 @@ func Test_OCMController_SecretIsUpdated(t *testing.T) {
 	assert.NoError(t, err)
 	ocmController := New(context.TODO(), coreClient, nil, nil)
 
-	updatedTestData := "new secret testing data"
-	err = ocmController.checkSecret([]byte(updatedTestData))
+	testRes.Cert = "new secret testing cert"
+	testRes.Key = "new secret testing key"
+	err = ocmController.checkSecret(testRes)
 	assert.NoError(t, err, "failed to check the secret")
 
 	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
 	assert.NoError(t, err, "can't get secret")
 	assert.Contains(t, testSecret.Data, tlsSecretKey, "can't find %s in the %s secret data", tlsSecretKey, secretName)
 	assert.Contains(t, testSecret.Data, tlsSecretCrt, "can't find %s in the %s secret data", tlsSecretCrt, secretName)
-	assert.Equal(t, updatedTestData, string(testSecret.Data[tlsSecretKey]), "unexpected data in %s secret", secretName)
-	assert.Equal(t, updatedTestData, string(testSecret.Data[tlsSecretCrt]), "unexpected data in %s secret", secretName)
+	assert.Equal(t, "new secret testing key", string(testSecret.Data[tlsSecretKey]), "unexpected data in %s secret", secretName)
+	assert.Equal(t, "new secret testing cert", string(testSecret.Data[tlsSecretCrt]), "unexpected data in %s secret", secretName)
 }


### PR DESCRIPTION
secret

<!-- Short description of the PR. What does it do? -->
This adds a new OCM controller which periodically (each 8 hours) tries to pull the SCA (Simple content access) data from the OCM API. The SCA data (basically a x509 certificate) is exposed in the `etc-pki-entitlement` secret in the `openshift-config-managed` namespace. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No update here

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Basic test covered in `pkg/ocm/ocm_test.go ` 

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4211

