### PR TITLE
[release-4.6] Bug 1939640: Do not degrade in case of gathering failure

### DIFF
--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -156,7 +156,8 @@ func (c *Controller) processNextWorkItem() bool {
 
 	utilruntime.HandleError(fmt.Errorf("%v failed after %s with: %v", dsKey, time.Now().Sub(start).Truncate(time.Millisecond), err))
 	c.queue.AddRateLimited(dsKey)
-	c.status[name].UpdateStatus(controllerstatus.Summary{Reason: "PeriodicGatherFailed", Message: fmt.Sprintf("Source %s could not be retrieved: %v", name, err)})
+	summary := controllerstatus.Summary{Operation: controllerstatus.GatheringReport, Reason: "PeriodicGatherFailed", Message: fmt.Sprintf("Source %s could not be retrieved: %v", name, err)}
+	c.status[name].UpdateStatus(summary)
 
 	return true
 }

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -169,6 +169,10 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 				disabledMessage = summary.Message
 			}
 		}
+		// Do not degrade in case of some gathering error
+		if summary.Operation == controllerstatus.GatheringReport {
+			degradingFailure = false
+		}
 		if degradingFailure {
 			reason = summary.Reason
 			errors = append(errors, summary.Message)

--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -13,8 +13,13 @@ type Interface interface {
 
 type Operation string
 
-// Specific flag for summary related to uploading process.
-const Uploading Operation = "Uploading"
+const (
+	// Specific flag for summary related to uploading process.
+	Uploading Operation = "Uploading"
+
+	// Specific flag for summary related to gathering process.
+	GatheringReport Operation = "GatheringReport"
+)
 
 type Summary struct {
 	Operation          Operation
@@ -55,6 +60,7 @@ func (s *Simple) UpdateStatus(summary Summary) {
 		klog.V(2).Infof("name=%s healthy=%t reason=%s message=%s", s.Name, summary.Healthy, summary.Reason, summary.Message)
 		s.summary.Reason = summary.Reason
 		s.summary.Message = summary.Message
+		s.summary.Operation = summary.Operation
 		return
 	}
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Some of the new gatherers can fail. We shouldn't degrade the IO in such case. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new unit test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->
https://bugzilla.redhat.com/show_bug.cgi?id=1939640

