### PR TITLE
Update resource request/limit in the deployment

### DIFF
--- a/docs/arch.md
+++ b/docs/arch.md
@@ -256,6 +256,27 @@ Api, we can still use non type safe custom build types called [dynamic client](k
 Such a client is used in [GatherMachineSet](pkg/gather/clusterconfig/clusterconfig.go).
 
 
+
+## Resource usage
+In the IO deployment [manifest](manifests/06-deployment.yaml) there are resource:
+- `requests` set to inform the cluster how much resources it needs at minimum.
+- `limits` set to make sure we don't overstay our welcome on a cluster.
+
+> Side note: Resource limits/requests are set for Containers, but because in our case the IO operator is the only Container in the Pod therefore these limits/requests are the same for the Pod as well.
+
+Effects of:
+- `requests`: These are checked when the pod is scheduled so to make sure that the place where it's going to be deployed has enough capacity to run it.
+- CPU `limit`: Slows down the work that the operator does, but as long as we are fast enough to not cause timeouts in network communication then we are fine.
+- Memory `limit`: If the memory usage of the pod exceeds the limit, the pod is killed without mercy and restarted. There is no easy way to notice from the operator's side that this happened, so we should tread carefully here.
+
+Both `requests` and `limits` were based on tests where we tried to starve the operator and some statistics based on the metadata.
+
+>Currently the memory usage `limit` is very generous because we found that there are few clusters that have very excessive memory usage.(~500 Mi)
+We identified a potential cause and are making steps to solve it also we plan to get further metadata so we can set a more reasonable limit in the future.
+In normal/average scenarios 200Mi memory is more then enough for the operator to work without any issue
+
+
+
 ## Gathering the data
 
 ### clusterconfig

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -260,7 +260,7 @@ Such a client is used in [GatherMachineSet](pkg/gather/clusterconfig/clusterconf
 ## Resource usage
 In the IO deployment [manifest](manifests/06-deployment.yaml) there are resource:
 - `requests` set to inform the cluster how much resources it needs at minimum.
-- `limits` set to make sure we don't overstay our welcome on a cluster.
+- `limits` set to inform the cluster how much resources it can use maximum.
 
 > Side note: Resource limits/requests are set for Containers, but because in our case the IO operator is the only Container in the Pod therefore these limits/requests are the same for the Pod as well.
 
@@ -272,7 +272,7 @@ Effects of:
 Both `requests` and `limits` were based on tests where we tried to starve the operator and some statistics based on the [metadata](https://github.com/openshift/insights-operator/tree/master/docs/insights-archive-sample/insights-operator/gathers.json).
 
 >Currently the memory usage `limit` is very generous because we found that there are few clusters that have very excessive memory usage.(~500 Mi)
-We identified a potential cause and are making steps to solve it also we plan to get further metadata so we can set a more reasonable limit in the future.
+We identified a potential cause and are taking steps to solve it also we plan to get further metadata so we can set a more reasonable limit in the future.
 In normal/average scenarios 200Mi memory is more then enough for the operator to work without any issue
 
 

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -267,9 +267,9 @@ In the IO deployment [manifest](manifests/06-deployment.yaml) there are resource
 Effects of:
 - `requests`: These are checked when the pod is scheduled so to make sure that the place where it's going to be deployed has enough capacity to run it.
 - CPU `limit`: Slows down the work that the operator does, but as long as we are fast enough to not cause timeouts in network communication then we are fine.
-- Memory `limit`: If the memory usage of the pod exceeds the limit, the pod is killed without mercy and restarted. There is no easy way to notice from the operator's side that this happened, so we should tread carefully here.
+- Memory `limit`: If the memory usage of the pod exceeds the limit, the pod is killed without mercy and restarted. There is no easy way to notice this from the operator's side that this happened, so we should tread carefully here.
 
-Both `requests` and `limits` were based on tests where we tried to starve the operator and some statistics based on the metadata.
+Both `requests` and `limits` were based on tests where we tried to starve the operator and some statistics based on the [metadata](https://github.com/openshift/insights-operator/tree/master/docs/insights-archive-sample/insights-operator/gathers.json).
 
 >Currently the memory usage `limit` is very generous because we found that there are few clusters that have very excessive memory usage.(~500 Mi)
 We identified a potential cause and are making steps to solve it also we plan to get further metadata so we can set a more reasonable limit in the future.

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -72,8 +72,11 @@ spec:
           name: https
         resources:
           requests:
-            cpu: 10m
-            memory: 30Mi
+            cpu: 40m
+            memory: 80Mi
+          limits:
+            cpu: 100m
+            memory: 1Gi
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Updates the resource limits and request in the deployment according to research done previous sprints.

### Raises the resource requests to `40m` cpu and `80Mi` memory: 

> During testing it turned that if we used the original amounts as limits the operator couldn't even start up, and the new amounts are close to the minimum for the operator to start up and run at least one gather. (I was a bit more generous with the CPU)

### The limit is set to a `100m` cpu and a veery generous `1Gi` memory:

> After analyzing the metadata in 4.7 clusters we found that there are very few clusters that have very excessive memory usage.(~500 Mi)
> We identified a potential cause and are making steps to solve it also we plant to get further metadata so we can set a more reasonable limit in the future.
> This limit is just a final safe-guard so the operator wouldn't consume the sun in an unforeseen error.
> In normal/average scenarios 200Mi memory is more then enough for the operator to work without any issue. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- None

## Documentation
<!-- Are these changes reflected in documentation? -->

- Updated the `arch.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- None

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

