### PR TITLE
Bug 1942271: Gather openshift-cluster-version pods and events

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -54,18 +54,6 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 * Id in config: feature_gates
 
 
-## ClusterID
-
-stores ClusterID from ClusterVersion version
-This method uses data already collected by Get ClusterVersion. In particular field .Spec.ClusterID
-The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusterversion.go#L50
-Response see https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go#L38
-
-* Location in archive: config/id/
-* See: docs/insights-archive-sample/config/id
-* Id in config: id
-
-
 ## ClusterImagePruner
 
 fetches the image pruner configuration
@@ -154,6 +142,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 * Location of operators in archive: config/clusteroperator/
 * See: docs/insights-archive-sample/config/clusteroperator
 * Location of pods in archive: config/pod/
+* Location of events in archive: events/
 * Id in config: operators
 * Spec config for CO resources since versions:
   * 4.6.16+
@@ -174,14 +163,18 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 ## ClusterVersion
 
-fetches the ClusterVersion - the ClusterVersion with name version.
+fetches the ClusterVersion (including the cluster ID) with the name 'version' and its resources.
 
 The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusterversion.go#L50
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#clusterversion-v1config-openshift-io
 
-Location in archive: config/version/
-See: docs/insights-archive-sample/config/version
-Id in config: version
+* Location in archive: config/version/
+* See: docs/insights-archive-sample/config/version
+* Location of pods in archive: config/pod/
+* Location of events in archive: events/
+* Location of cluster ID: config/id
+* See: docs/insights-archive-sample/config/id
+* Id in config: version
 
 
 ## ConfigMaps

--- a/docs/insights-archive-sample/insights-operator/gathers.json
+++ b/docs/insights-archive-sample/insights-operator/gathers.json
@@ -83,12 +83,6 @@
             "errors": null
         },
         {
-            "name": "clusterconfig.GatherClusterID",
-            "duration_in_ms": 1002,
-            "records_count": 1,
-            "errors": null
-        },
-        {
             "name": "clusterconfig.GatherClusterOAuth",
             "duration_in_ms": 1152,
             "records_count": 1,

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -66,7 +66,6 @@ var gatherFunctions = map[string]gathering{
 	"nodes":                             important(GatherNodes),
 	"config_maps":                       failable(GatherConfigMaps),
 	"version":                           important(GatherClusterVersion),
-	"id":                                important(GatherClusterID),
 	"infrastructures":                   important(GatherClusterInfrastructure),
 	"networks":                          important(GatherClusterNetwork),
 	"authentication":                    important(GatherClusterAuthentication),

--- a/pkg/gather/clusterconfig/operators.go
+++ b/pkg/gather/clusterconfig/operators.go
@@ -73,6 +73,7 @@ type CompactedEventList struct {
 // * Location of operators in archive: config/clusteroperator/
 // * See: docs/insights-archive-sample/config/clusteroperator
 // * Location of pods in archive: config/pod/
+// * Location of events in archive: events/
 // * Id in config: operators
 // * Spec config for CO resources since versions:
 //   * 4.6.16+

--- a/pkg/gather/clusterconfig/version.go
+++ b/pkg/gather/clusterconfig/version.go
@@ -5,7 +5,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -15,59 +14,45 @@ import (
 	"github.com/openshift/insights-operator/pkg/utils/marshal"
 )
 
-// GatherClusterVersion fetches the ClusterVersion - the ClusterVersion with name version.
+// GatherClusterVersion fetches the ClusterVersion (including the cluster ID) with the name 'version' and its resources.
 //
 // The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusterversion.go#L50
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#clusterversion-v1config-openshift-io
 //
-// Location in archive: config/version/
-// See: docs/insights-archive-sample/config/version
-// Id in config: version
+// * Location in archive: config/version/
+// * See: docs/insights-archive-sample/config/version
+// * Location of cluster ID: config/id
+// * See: docs/insights-archive-sample/config/id
+// * Id in config: version
 func GatherClusterVersion(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)
-	config, err := getClusterVersion(g.ctx, g.gatherKubeConfig)
+	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
 		c <- gatherResult{nil, []error{err}}
 		return
 	}
-	c <- gatherResult{[]record.Record{{Name: "config/version", Item: record.JSONMarshaller{Object: anonymizeClusterVersion(config)}}}, nil}
+	records, errors := getClusterVersion(g.ctx, gatherConfigClient)
+	c <- gatherResult{records, errors}
 }
 
-func getClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.ClusterVersion, error) {
-	gatherConfigClient, err := configv1client.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-	config, err := gatherConfigClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+func getClusterVersion(ctx context.Context, configClient configv1client.ConfigV1Interface) ([]record.Record, []error) {
+	config, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, []error{err}
 	}
-	return config, nil
-}
 
-// GatherClusterID stores ClusterID from ClusterVersion version
-// This method uses data already collected by Get ClusterVersion. In particular field .Spec.ClusterID
-// The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusterversion.go#L50
-// Response see https://github.com/openshift/api/blob/master/config/v1/types_cluster_version.go#L38
-//
-// * Location in archive: config/id/
-// * See: docs/insights-archive-sample/config/id
-// * Id in config: id
-func GatherClusterID(g *Gatherer, c chan<- gatherResult) {
-	defer close(c)
-	version, err := getClusterVersion(g.ctx, g.gatherKubeConfig)
-	if err != nil {
-		c <- gatherResult{nil, []error{err}}
-		return
+	records := []record.Record{
+		{Name: "config/version", Item: record.JSONMarshaller{Object: anonymizeClusterVersion(config)}},
 	}
-	if version == nil {
-		c <- gatherResult{nil, nil}
-		return
+
+	if config.Spec.ClusterID != "" {
+		records = append(records, record.Record{Name: "config/id", Item: marshal.Raw{Str: string(config.Spec.ClusterID)}})
 	}
-	c <- gatherResult{[]record.Record{{Name: "config/id", Item: marshal.Raw{Str: string(version.Spec.ClusterID)}}}, nil}
+
+	return records, nil
 }
 
 func anonymizeClusterVersion(version *configv1.ClusterVersion) *configv1.ClusterVersion {

--- a/pkg/gather/clusterconfig/version.go
+++ b/pkg/gather/clusterconfig/version.go
@@ -25,7 +25,7 @@ import (
 // Id in config: version
 func GatherClusterVersion(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)
-	config, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
+	config, err := getClusterVersion(g.ctx, g.gatherKubeConfig)
 	if err != nil {
 		c <- gatherResult{nil, []error{err}}
 		return
@@ -33,7 +33,7 @@ func GatherClusterVersion(g *Gatherer, c chan<- gatherResult) {
 	c <- gatherResult{[]record.Record{{Name: "config/version", Item: record.JSONMarshaller{Object: anonymizeClusterVersion(config)}}}, nil}
 }
 
-func GetClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.ClusterVersion, error) {
+func getClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.ClusterVersion, error) {
 	gatherConfigClient, err := configv1client.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func GetClusterVersion(ctx context.Context, kubeConfig *rest.Config) (*configv1.
 // * Id in config: id
 func GatherClusterID(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)
-	version, err := GetClusterVersion(g.ctx, g.gatherKubeConfig)
+	version, err := getClusterVersion(g.ctx, g.gatherKubeConfig)
 	if err != nil {
 		c <- gatherResult{nil, []error{err}}
 		return


### PR DESCRIPTION
Using similar logic to what `gatherClusterOperators` uses, but for the ClusterVersion operator's namespace.  Usually we'd only gather the pod YAML if the pod was failing, but in order to help audit tolerations for [rhbz#1941901][1], at the moment I'm gathering it every time.

With two initial pivots to set the stage:

* pkg/gather/clusterconfig: Collapse GatherClusterID into GatherClusterVersion
* pkg/insights/insightsclient: Inline client handling for ClusterVersion

Details on everything in the respective commit messages.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1941901