### PR TITLE
[release 4.6] Bug 1942457: Adds metadata to the IO archive

### DIFF
--- a/docs/insights-archive-sample/insights-operator/gathers.json
+++ b/docs/insights-archive-sample/insights-operator/gathers.json
@@ -1,0 +1,180 @@
+{
+    "status_reports": [
+        {
+            "name": "clusterconfig.GatherPodDisruptionBudgets",
+            "duration_in_ms": 123,
+            "records_count": 2,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherMostRecentMetrics",
+            "duration_in_ms": 0,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterOperators",
+            "duration_in_ms": 3365,
+            "records_count": 50,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherContainerImages",
+            "duration_in_ms": 368,
+            "records_count": 13,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherNodes",
+            "duration_in_ms": 154,
+            "records_count": 6,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherConfigMaps",
+            "duration_in_ms": 260,
+            "records_count": 11,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterVersion",
+            "duration_in_ms": 130,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterID",
+            "duration_in_ms": 0,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterInfrastructure",
+            "duration_in_ms": 125,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterNetwork",
+            "duration_in_ms": 125,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterAuthentication",
+            "duration_in_ms": 140,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterImageRegistry",
+            "duration_in_ms": 131,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterImagePruner",
+            "duration_in_ms": 128,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterFeatureGates",
+            "duration_in_ms": 136,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterOAuth",
+            "duration_in_ms": 124,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterIngress",
+            "duration_in_ms": 128,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherClusterProxy",
+            "duration_in_ms": 125,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherCertificateSigningRequests",
+            "duration_in_ms": 124,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherCRD",
+            "duration_in_ms": 268,
+            "records_count": 2,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherHostSubnet",
+            "duration_in_ms": 130,
+            "records_count": 6,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherMachineSet",
+            "duration_in_ms": 137,
+            "records_count": 3,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherMachineConfigPool",
+            "duration_in_ms": 130,
+            "records_count": 2,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherInstallPlans",
+            "duration_in_ms": 10278,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherContainerRuntimeConfig",
+            "duration_in_ms": 129,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherOpenshiftSDNLogs",
+            "duration_in_ms": 6843,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherNetNamespace",
+            "duration_in_ms": 255,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherServiceAccounts",
+            "duration_in_ms": 11544,
+            "records_count": 1,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherSAPConfig",
+            "duration_in_ms": 121,
+            "records_count": 0,
+            "errors": null
+        },
+        {
+            "name": "clusterconfig.GatherOpenshiftSDNControllerLogs",
+            "duration_in_ms": 549,
+            "records_count": 0,
+            "errors": null
+        }
+    ],
+    "memory_alloc_bytes": 11303784,
+    "uptime_seconds": 36.113
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR is a backport of https://github.com/openshift/insights-operator/pull/364
It introduces the metadata gathering to 4.6 and the recently added 2 new fields. (gathers.json).

#### Info about each gather-function:
- name
- duration in milliseconds
- the count of records collected
- errors (if any)

#### Info about the whole gather process:
- uptime_seconds: the duration since the start of the first `record.Collect`
- memory_alloc_bytes: the memory allocated at the time of creating the report. (in bytes)

Some disclaimers:

I intended to have memory usage stats for each gather-function, but it wasn't really viable. The only way I could measure it was by marshaling the produced records, which is not only inefficient but we can just as easily measure the size of the produced archive and get the same idea.
The memory_alloc stat wont show the peak memory allocation. Even if we are only talking about the gather cycle, knowing when to measure to get the max usage is impossible so we would need to monitor the entire process, which would more complex without much benefit IMO. The purpose of this field is to be able to notice if over a long period there might be a memory leak.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- see docs/insights-archive-sample/insights-operator/gathers.json

## Documentation
<!-- Are these changes reflected in documentation? -->

- no

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- no

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://bugzilla.redhat.com/show_bug.cgi?id=???
