### PR TITLE
Bug 1948966: One-off gather

### DIFF
--- a/docs/gather-job.yaml
+++ b/docs/gather-job.yaml
@@ -29,18 +29,9 @@ spec:
       volumes:
       - name: snapshots
         emptyDir: {}
-          #sizeLimit: 1Gi # bug https://bugzilla.redhat.com/show_bug.cgi?id=1713207
-      - name: trusted-ca-bundle
-        configMap:
-          name: trusted-ca-bundle
-          optional: true
       - name: service-ca-bundle
         configMap:
           name: service-ca-bundle
-          optional: true
-      - name: serving-cert
-        secret:
-          secretName: openshift-insights-serving-cert
           optional: true
       initContainers:
       - name: insights-operator
@@ -49,14 +40,9 @@ spec:
         volumeMounts:
         - name: snapshots
           mountPath: /var/lib/insights-operator
-        - mountPath: /var/run/configmaps/trusted-ca-bundle
-          name: trusted-ca-bundle
+        - name: service-ca-bundle
+          mountPath: /var/run/configmaps/service-ca-bundle
           readOnly: true
-        - mountPath: /var/run/configmaps/service-ca-bundle
-          name: service-ca-bundle
-          readOnly: true
-        - mountPath: /var/run/secrets/serving-cert
-          name: serving-cert
         ports:
         - containerPort: 8443
           name: https
@@ -64,17 +50,6 @@ spec:
           requests:
             cpu: 10m
             memory: 70Mi
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: RELEASE_VERSION
-          value: "0.0.1-snapshot"
         args:
         - gather
         - -v=4

--- a/docs/gather-job.yaml
+++ b/docs/gather-job.yaml
@@ -42,7 +42,7 @@ spec:
         secret:
           secretName: openshift-insights-serving-cert
           optional: true
-      containers:
+      initContainers:
       - name: insights-operator
         image: quay.io/openshift/origin-insights-operator:latest
         terminationMessagePolicy: FallbackToLogsOnError
@@ -79,3 +79,11 @@ spec:
         - gather
         - -v=4
         - --config=/etc/insights-operator/server.yaml
+      containers:
+        - name: sleepy
+          image: busybox
+          args:
+            - /bin/sh
+            - -c
+            - sleep 10m
+          volumeMounts: [{name: snapshots, mountPath: /var/lib/insights-operator}]

--- a/docs/gather-job.yaml
+++ b/docs/gather-job.yaml
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: insights-operator-job
+  annotations:
+    config.openshift.io/inject-proxy: insights-operator
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: operator
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 900
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 900
+      volumes:
+      - name: snapshots
+        emptyDir: {}
+          #sizeLimit: 1Gi # bug https://bugzilla.redhat.com/show_bug.cgi?id=1713207
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
+          optional: true
+      - name: service-ca-bundle
+        configMap:
+          name: service-ca-bundle
+          optional: true
+      - name: serving-cert
+        secret:
+          secretName: openshift-insights-serving-cert
+          optional: true
+      containers:
+      - name: insights-operator
+        image: quay.io/openshift/origin-insights-operator:latest
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: snapshots
+          mountPath: /var/lib/insights-operator
+        - mountPath: /var/run/configmaps/trusted-ca-bundle
+          name: trusted-ca-bundle
+          readOnly: true
+        - mountPath: /var/run/configmaps/service-ca-bundle
+          name: service-ca-bundle
+          readOnly: true
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+        ports:
+        - containerPort: 8443
+          name: https
+        resources:
+          requests:
+            cpu: 10m
+            memory: 30Mi
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
+        args:
+        - gather
+        - -v=4
+        - --config=/etc/insights-operator/server.yaml

--- a/docs/gather-job.yaml
+++ b/docs/gather-job.yaml
@@ -63,7 +63,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 30Mi
+            memory: 70Mi
         env:
         - name: POD_NAME
           valueFrom:

--- a/pkg/controller/const.go
+++ b/pkg/controller/const.go
@@ -1,0 +1,6 @@
+package controller
+
+const (
+	metricCAFile = "/var/run/configmaps/service-ca-bundle/service-ca.crt"
+	metricHost   = "https://prometheus-k8s.openshift-monitoring.svc:9091"
+)

--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -93,6 +93,6 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig *rest.Config, protoKu
 	}
 
 	recorder.Flush()
-	// sleep forever
-	select{}
+	klog.Info("Finished")
+	return nil
 }

--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -84,6 +84,7 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	// the recorder stores the collected data and we flush at the end.
 	recdriver := diskrecorder.New(d.StoragePath)
 	rec := recorder.New(recdriver, d.Interval, anonymizer)
+	defer rec.Flush()
 
 	// the gatherers check the state of the cluster and report any
 	// config to the recorder
@@ -92,8 +93,5 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	if err != nil {
 		return err
 	}
-
-	rec.Flush()
-	klog.Info("Finished")
 	return nil
 }

--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -83,7 +83,6 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig *rest.Config, protoKu
 	// the recorder stores the collected data and we flush at the end.
 	recdriver := diskrecorder.New(d.StoragePath)
 	recorder := recorder.New(recdriver, d.Interval, anonymizer)
-	defer recorder.Flush()
 
 	// the gatherers check the state of the cluster and report any
 	// config to the recorder
@@ -93,6 +92,7 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig *rest.Config, protoKu
 		return err
 	}
 
-	klog.Warning("stopped")
-	return nil
+	recorder.Flush()
+	// sleep forever
+	select{}
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Updates the gather_job.go so that it doesn't always require a `--kubeconfig` param, also adds the `docs/gather-job.yaml` which is a one off job to run a single gather.
```
# Create Job
$ kubectl apply -n openshift-insights -f docs/gather-job.yaml
...


# Get Job's pod's name
$ kubectl describe -n openshift-insights job/insights-operator-job
...
Events:
  Type    Reason            Age    From            Message
  ----    ------            ----   ----            -------
  Normal  SuccessfulCreate  7m18s  job-controller  Created pod: insights-operator-job-zhmrd <-- THIS


# Check if the gather finished (optional)
$ kubectl logs -n openshift-insights insights-operator-job-zhmrd insights-operator
...
I0407 11:55:38.192084       1 diskrecorder.go:34] Wrote 108 records to disk in 33ms <-- THIS


# Get the archives
$ kubectl cp openshift-insights/insights-operator-job-zhmrd:/var/lib/insights-operator ./insights-data
...


# Cleanup
$ kubectl delete -n openshift-insights job insights-operator-job
...
```

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- nope

## Documentation
<!-- Are these changes reflected in documentation? -->

- TODO

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- nope

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->
