### PR TITLE
Add management workload annotations

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/node-selector: ""
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
     name: openshift-insights

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -16,6 +16,8 @@ spec:
       app: insights-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: insights-operator
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

## Categories
- [ ] Bugfix
- [x] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## References
https://github.com/openshift/enhancements/pull/703