### PR TITLE
Bug 1948943: Workloads - Add limit for the number of pods gathered

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -448,6 +448,7 @@ collects `datahubs.installers.datahub.sap.com` resources from SAP/SDI clusters.
 
 * Location in archive: customresources/installers.datahub.sap.com/datahubs/<namespace>/<name>.json
 * Since versions:
+  * 4.7.5+
   * 4.8+
 
 
@@ -464,6 +465,8 @@ Relevant Kubernetes API docs:
 
 * Location in archive: config/pod/{namespace}/{pod-name}.json
 * Since versions:
+  * 4.6.24+
+  * 4.7.5+
   * 4.8+
 
 
@@ -478,6 +481,8 @@ Response see https://docs.openshift.com/container-platform/4.6/rest_api/workload
 
 * Location in archive: config/pod/{namespace}/logs/{pod-name}/errors.log
 * Since versions:
+  * 4.6.25+
+  * 4.7.5+
   * 4.8+
 
 
@@ -496,5 +501,14 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
   * 4.5.34+
   * 4.6.20+
   * 4.7+
+
+
+## WorkloadInfo
+
+collects summarized info about the workloads on a cluster
+in a generic fashion
+
+Location in archive: config/workload_info
+Id in config: workload_info
 
 

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -72,7 +72,7 @@ var gatherFunctions = map[string]gathering{
 	"metrics":                           failable(GatherMostRecentMetrics),
 	"operators":                         important(GatherClusterOperators),
 	"container_images":                  important(GatherContainerImages),
-	"workload_info":                     important(GatherWorkloadInfo),
+	"workload_info":                     failable(GatherWorkloadInfo),
 	"nodes":                             important(GatherNodes),
 	"config_maps":                       failable(GatherConfigMaps),
 	"version":                           important(GatherClusterVersion),

--- a/pkg/gather/clusterconfig/sap_datahubs.go
+++ b/pkg/gather/clusterconfig/sap_datahubs.go
@@ -15,6 +15,7 @@ import (
 //
 // * Location in archive: customresources/installers.datahub.sap.com/datahubs/<namespace>/<name>.json
 // * Since versions:
+//   * 4.7.5+
 //   * 4.8+
 func GatherSAPDatahubs(g *Gatherer, c chan<- gatherResult) {
 	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)

--- a/pkg/gather/clusterconfig/sap_pods.go
+++ b/pkg/gather/clusterconfig/sap_pods.go
@@ -27,6 +27,8 @@ import (
 //
 // * Location in archive: config/pod/{namespace}/{pod-name}.json
 // * Since versions:
+//   * 4.6.24+
+//   * 4.7.5+
 //   * 4.8+
 func GatherSAPPods(g *Gatherer, c chan<- gatherResult) {
 	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)

--- a/pkg/gather/clusterconfig/sap_vsystem_iptables_logs.go
+++ b/pkg/gather/clusterconfig/sap_vsystem_iptables_logs.go
@@ -22,6 +22,8 @@ import (
 //
 // * Location in archive: config/pod/{namespace}/logs/{pod-name}/errors.log
 // * Since versions:
+//   * 4.6.25+
+//   * 4.7.5+
 //   * 4.8+
 func GatherSAPVsystemIptablesLogs(g *Gatherer, c chan<- gatherResult) {
 	defer close(c)

--- a/pkg/gather/clusterconfig/workloads.go
+++ b/pkg/gather/clusterconfig/workloads.go
@@ -34,7 +34,9 @@ import (
 const (
 	// workloadGatherPageSize is 500 (the default for Kube).
 	workloadGatherPageSize = 500
-	podsLimit              = 3000
+	// limit the number of collected Pods in this gatherer. In the worst case, one Pod can add around 600 bytes (before compression)
+	// This limit can be removed in the future.
+	podsLimit = 3000
 )
 
 // workloadPods is the top level description of the workloads on the cluster, primarily


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR adds limit 3000 for number of gathered pods in the new workload fingerprint gatherer

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No new documentation

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->
