### PR TITLE
Bug 1949990: Extend OLM data with CSV display name

### DIFF
--- a/docs/insights-archive-sample/config/olm_operators.json
+++ b/docs/insights-archive-sample/config/olm_operators.json
@@ -1,6 +1,7 @@
 [
     {
         "name": "eap.openshift-operators",
+        "displayName": "JBoss EAP",
         "version": "v2.1.1",
         "csv_conditions": [
             {
@@ -42,6 +43,7 @@
     },
     {
         "name": "elasticsearch-operator.openshift-operators-redhat",
+        "displayName": "OpenShift Elasticsearch Operator",
         "version": "4.6.0-202102200141.p0",
         "csv_conditions": [
             {
@@ -83,6 +85,7 @@
     },
     {
         "name": "kiali-ossm.openshift-operators",
+        "displayName": "Kiali Operator",
         "version": "v1.24.5",
         "csv_conditions": [
             {
@@ -124,6 +127,7 @@
     },
     {
         "name": "postgresql-operator-dev4devs-com.psql-test",
+        "displayName": "PostgreSQL Operator by Dev4Ddevs.com",
         "version": "v0.1.1",
         "csv_conditions": [
             {
@@ -165,6 +169,7 @@
     },
     {
         "name": "radanalytics-spark.openshift-operators",
+        "displayName": "Apache Spark Operator",
         "version": "v1.1.0",
         "csv_conditions": [
             {

--- a/pkg/gather/clusterconfig/olm_operators_test.go
+++ b/pkg/gather/clusterconfig/olm_operators_test.go
@@ -2,8 +2,10 @@ package clusterconfig
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/openshift/insights-operator/pkg/record"
@@ -16,49 +18,114 @@ import (
 )
 
 func Test_OLMOperators_Gather(t *testing.T) {
-	olmOpContent, err := readFromFile("testdata/olm_operator_1.yaml")
-	if err != nil {
-		t.Fatal("test failed to read OLM operator data", err)
+	var cases = []struct {
+		testName            string
+		olmOperatorFileName string
+		csvFileName         string
+		expectedError       error
+		expecteOlmOperator  olmOperator
+	}{
+		{
+			"All OLM operator data is available",
+			"testdata/olm_operator_1.yaml",
+			"testdata/csv_1.yaml",
+			nil,
+			olmOperator{
+				Name:        "test-olm-operator",
+				DisplayName: "Testing operator",
+				Version:     "v1.2.3",
+				Conditions: []interface{}{
+					map[string]interface{}{
+						"lastTransitionTime": "2021-03-02T08:52:24Z",
+						"lastUpdateTime":     "2021-03-02T08:52:24Z",
+						"message":            "requirements not yet checked",
+						"phase":              "Pending",
+						"reason":             "RequirementsUnknown",
+					},
+					map[string]interface{}{
+						"lastTransitionTime": "2021-03-02T08:52:24Z",
+						"lastUpdateTime":     "2021-03-02T08:52:24Z",
+						"message":            "all requirements found, attempting install",
+						"phase":              "InstallReady",
+						"reason":             "AllRequirementsMet",
+					},
+				},
+			},
+		},
+		{
+			"Operator doesn't have CSV reference",
+			"testdata/olm_operator_2.yaml",
+			"testdata/csv_1.yaml",
+			fmt.Errorf("cannot find \"status.components.refs\" in test-olm-operator-with-no-ref definition: key refs wasn't found in map[] "),
+			olmOperator{
+				Name: "test-olm-operator-with-no-ref",
+			},
+		},
+		{
+			"Operator CSV doesn't have the displayName",
+			"testdata/olm_operator_1.yaml",
+			"testdata/csv_2.yaml",
+			fmt.Errorf("cannot read test-olm-operator.v1.2.3 ClusterServiceVersion attributes: key displayName wasn't found in map[] "),
+			olmOperator{
+				Name:    "test-olm-operator",
+				Version: "v1.2.3",
+			},
+		},
+		{
+			"Operator with unrecognizable CSV version",
+			"testdata/olm_operator_3.yaml",
+			"testdata/csv_1.yaml",
+			fmt.Errorf("clusterserviceversion \"name-without-version\" probably doesn't include version"),
+			olmOperator{
+				Name: "test-olm-operator-no-version",
+			},
+		},
 	}
 
-	csvContent, err := readFromFile("testdata/csv_1.yaml")
-	if err != nil {
-		t.Fatal("test failed to read CSV ", err)
-	}
-	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
-		operatorGVR:              "OperatorsList",
-		clusterServiceVersionGVR: "ClusterServiceVersionsList",
-	})
-	err = createUnstructuredResource(olmOpContent, client, operatorGVR)
-	if err != nil {
-		t.Fatal("cannot create OLM operator ", err)
-	}
-	err = createUnstructuredResource(csvContent, client, clusterServiceVersionGVR)
-	if err != nil {
-		t.Fatal("cannot create ClusterServiceVersion ", err)
-	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.testName, func(t *testing.T) {
+			olmOpContent, err := readFromFile(tt.olmOperatorFileName)
+			if err != nil {
+				t.Fatal("test failed to read OLM operator data", err)
+			}
 
-	ctx := context.Background()
-	records, errs := gatherOLMOperators(ctx, client)
-	if len(errs) > 0 {
-		t.Errorf("unexpected errors: %#v", errs)
-		return
-	}
-	if len(records) != 1 {
-		t.Fatalf("unexpected number or records %d", len(records))
-	}
-	ooa, ok := records[0].Item.(record.JSONMarshaller).Object.([]olmOperator)
-	if !ok {
-		t.Fatalf("returned item is not of type []olmOperator")
-	}
-	if ooa[0].Name != "test-olm-operator" {
-		t.Fatalf("unexpected name of gathered OLM operator %s", ooa[0].Name)
-	}
-	if ooa[0].Version != "v1.2.3" {
-		t.Fatalf("unexpected version of gathered OLM operator %s", ooa[0].Version)
-	}
-	if len(ooa[0].Conditions) != 2 {
-		t.Fatalf("unexpected number of conditions %s", ooa[0].Conditions...)
+			csvContent, err := readFromFile(tt.csvFileName)
+			if err != nil {
+				t.Fatal("test failed to read CSV ", err)
+			}
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+				operatorGVR:              "OperatorsList",
+				clusterServiceVersionGVR: "ClusterServiceVersionsList",
+			})
+			err = createUnstructuredResource(olmOpContent, client, operatorGVR)
+			if err != nil {
+				t.Fatal("cannot create OLM operator ", err)
+			}
+			err = createUnstructuredResource(csvContent, client, clusterServiceVersionGVR)
+			if err != nil {
+				t.Fatal("cannot create ClusterServiceVersion ", err)
+			}
+
+			ctx := context.Background()
+			records, errs := gatherOLMOperators(ctx, client)
+			if len(errs) > 0 {
+				if errs[0].Error() != tt.expectedError.Error() {
+					t.Fatalf("unexpected errors: %v", errs[0].Error())
+				}
+			}
+			if len(records) != 1 {
+				t.Fatalf("unexpected number or records %d", len(records))
+			}
+			ooa, ok := records[0].Item.(record.JSONMarshaller).Object.([]olmOperator)
+			if !ok {
+				t.Fatalf("returned item is not of type []olmOperator")
+			}
+			sameOp := reflect.DeepEqual(ooa[0], tt.expecteOlmOperator)
+			if !sameOp {
+				t.Fatalf("Gathered %s operator is not equal to expected %s ", ooa[0], tt.expecteOlmOperator)
+			}
+		})
 	}
 }
 

--- a/pkg/gather/clusterconfig/testdata/csv_2.yaml
+++ b/pkg/gather/clusterconfig/testdata/csv_2.yaml
@@ -3,8 +3,7 @@ kind: ClusterServiceVersion
 metadata:
     name: test-olm-operator.v1.2.3
     namespace: test-olm-operator
-spec:
-    displayName: "Testing operator"    
+spec: {}    
 status:
     conditions:
         - lastTransitionTime: "2021-03-02T08:52:24Z"

--- a/pkg/gather/clusterconfig/testdata/olm_operator_2.yaml
+++ b/pkg/gather/clusterconfig/testdata/olm_operator_2.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+    name: test-olm-operator-with-no-ref
+status:
+    components: {}

--- a/pkg/gather/clusterconfig/testdata/olm_operator_3.yaml
+++ b/pkg/gather/clusterconfig/testdata/olm_operator_3.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+    name: test-olm-operator-no-version
+status:
+    components:
+        refs:
+            - apiVersion: operators.coreos.com/v1alpha1
+              kind: ClusterServiceVersion
+              name: name-without-version
+              namespace: test-olm-operator


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR refactors a bit the original OLM Operator gatherer and extends the data with the `ClusterServiceVersion` display name. The unit is also extended. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->
Sample archive updated in:
- `docs/insights-archive-sample/config/olm_operators.json `

## Documentation
<!-- Are these changes reflected in documentation? -->
No documentation update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
Test significantly extended in:

- `pkg/gather/clusterconfig/olm_operators_test.go `

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
