### PR TITLE
[release-4.7] Bug 1950926: Extend OLM data with CSV display name

### DIFF
--- a/docs/insights-archive-sample/config/olm_operators.json
+++ b/docs/insights-archive-sample/config/olm_operators.json
@@ -1,6 +1,7 @@
 [
     {
         "name": "eap.openshift-operators",
+        "displayName": "JBoss EAP",
         "version": "v2.1.1",
         "csv_conditions": [
             {
@@ -42,6 +43,7 @@
     },
     {
         "name": "elasticsearch-operator.openshift-operators-redhat",
+        "displayName": "OpenShift Elasticsearch Operator",
         "version": "4.6.0-202102200141.p0",
         "csv_conditions": [
             {
@@ -83,6 +85,7 @@
     },
     {
         "name": "kiali-ossm.openshift-operators",
+        "displayName": "Kiali Operator",
         "version": "v1.24.5",
         "csv_conditions": [
             {
@@ -124,6 +127,7 @@
     },
     {
         "name": "postgresql-operator-dev4devs-com.psql-test",
+        "displayName": "PostgreSQL Operator by Dev4Ddevs.com",
         "version": "v0.1.1",
         "csv_conditions": [
             {
@@ -165,6 +169,7 @@
     },
     {
         "name": "radanalytics-spark.openshift-operators",
+        "displayName": "Apache Spark Operator",
         "version": "v1.1.0",
         "csv_conditions": [
             {

--- a/pkg/gather/clusterconfig/olm_operators.go
+++ b/pkg/gather/clusterconfig/olm_operators.go
@@ -2,12 +2,11 @@ package clusterconfig
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -17,13 +16,17 @@ import (
 
 var (
 	operatorGVR              = schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1", Resource: "operators"}
-	clusterServiceVersionGVR = schema.GroupVersionResource{Group: "operators.coreos.com", Version: "v1alpha1", Resource: "clusterserviceversions"}
+	clusterServiceVersionGVR = schema.GroupVersionResource{
+		Group:    "operators.coreos.com",
+		Version:  "v1alpha1",
+		Resource: "clusterserviceversions"}
 )
 
 type olmOperator struct {
-	Name       string        `json:"name"`
-	Version    string        `json:"version"`
-	Conditions []interface{} `json:"csv_conditions"`
+	Name        string        `json:"name"`
+	DisplayName string        `json:"displayName"`
+	Version     string        `json:"version"`
+	Conditions  []interface{} `json:"csv_conditions"`
 }
 
 // ClusterServiceVersion helper struct
@@ -63,31 +66,45 @@ func gatherOLMOperators(ctx context.Context, dynamicClient dynamic.Interface) ([
 	}
 	var refs []interface{}
 	olms := []olmOperator{}
+	errs := []error{}
 	for _, i := range olmOperators.Items {
+		newOlm := olmOperator{
+			Name: i.GetName(),
+		}
 		err := parseJSONQuery(i.Object, "status.components.refs", &refs)
 		if err != nil {
-			klog.Errorf("Cannot find \"status.components.refs\" in %s definition: %v", i.GetName(), err)
+			// if no references are found then add an error and OLM operator with only name and continue
+			errs = append(errs, fmt.Errorf("cannot find \"status.components.refs\" in %s definition: %v", i.GetName(), err))
+			olms = append(olms, newOlm)
 			continue
 		}
 		for _, r := range refs {
-			csvRef := getCSVRefFromRefs(r)
+			csvRef, err := findCSVRefInRefs(r)
+			if err != nil {
+				errs = append(errs, err)
+				olms = append(olms, newOlm)
+				continue
+			}
+			// CSV reference can still be nil
 			if csvRef == nil {
 				continue
 			}
-			conditions, err := getCSVConditions(ctx, dynamicClient, csvRef)
+			newOlm.Version = csvRef.Version
+
+			name, conditions, err := getCSVAndParse(ctx, dynamicClient, csvRef)
 			if err != nil {
-				klog.Errorf("failed to get %s conditions: %v", csvRef.Name, err)
+				// append the error and the OLM data we already have and continue
+				errs = append(errs, err)
+				olms = append(olms, newOlm)
 				continue
 			}
-			olmO := olmOperator{
-				Name:       i.GetName(),
-				Version:    csvRef.Version,
-				Conditions: conditions,
-			}
-			if isInArray(olmO, olms) {
+			newOlm.DisplayName = name
+			newOlm.Conditions = conditions
+
+			if isInArray(newOlm, olms) {
 				continue
 			}
-			olms = append(olms, olmO)
+			olms = append(olms, newOlm)
 		}
 	}
 	if len(olms) == 0 {
@@ -95,7 +112,10 @@ func gatherOLMOperators(ctx context.Context, dynamicClient dynamic.Interface) ([
 	}
 	r := record.Record{
 		Name: "config/olm_operators",
-		Item: OlmOperatorAnonymizer{operators: olms},
+		Item: record.JSONMarshaller{Object: olms},
+	}
+	if len(errs) != 0 {
+		return []record.Record{r}, errs
 	}
 	return []record.Record{r}, nil
 }
@@ -109,48 +129,67 @@ func isInArray(o olmOperator, a []olmOperator) bool {
 	return false
 }
 
-func getCSVRefFromRefs(r interface{}) *csvRef {
+//getCSVAndParse gets full CSV definition from csvRef and tries to parse the definition
+func getCSVAndParse(ctx context.Context, dynamicClient dynamic.Interface, csvRef *csvRef) (name string, conditions []interface{}, err error) {
+	csv, err := getCsvFromRef(ctx, dynamicClient, csvRef)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get %s ClusterServiceVersion: %v", csvRef.Name, err)
+	}
+	name, conditions, err = parseCsv(csv)
+
+	if err != nil {
+		return "", nil, fmt.Errorf("cannot read %s ClusterServiceVersion attributes: %v", csvRef.Name, err)
+	}
+
+	return name, conditions, nil
+}
+
+//findCSVRefInRefs tries to find ClusterServiceVersion reference in the references
+//and parse the ClusterServiceVersion if successful.
+//It can return nil with no error if the CSV was not found
+func findCSVRefInRefs(r interface{}) (*csvRef, error) {
 	refMap, ok := r.(map[string]interface{})
 	if !ok {
-		klog.Errorf("Cannot convert %s to map[string]interface{}", r)
-		return nil
+		return nil, fmt.Errorf("cannot convert %s to map[string]interface{}", r)
 	}
 	// version is part of the name of ClusterServiceVersion
 	if refMap["kind"] == "ClusterServiceVersion" {
 		name := refMap["name"].(string)
+		if !strings.Contains(name, ".") {
+			return nil, fmt.Errorf("clusterserviceversion \"%s\" probably doesn't include version", name)
+		}
 		nameVer := strings.SplitN(name, ".", 2)
 		csvRef := &csvRef{
 			Name:      name,
 			Namespace: refMap["namespace"].(string),
 			Version:   nameVer[1],
 		}
-		return csvRef
+		return csvRef, nil
 	}
-	return nil
+	return nil, nil
 }
 
-func getCSVConditions(ctx context.Context, dynamicClient dynamic.Interface, csvRef *csvRef) ([]interface{}, error) {
+func getCsvFromRef(ctx context.Context, dynamicClient dynamic.Interface, csvRef *csvRef) (map[string]interface{}, error) {
 	csv, err := dynamicClient.Resource(clusterServiceVersionGVR).Namespace(csvRef.Namespace).Get(ctx, csvRef.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
+	return csv.Object, nil
+}
+
+//parseCsv tries to parse "status.conditions" and "spec.displayName" from the input map.
+// Returns an error if any of the values cannot be parsed.
+func parseCsv(csv map[string]interface{}) (string, []interface{}, error) {
 	var conditions []interface{}
-	err = parseJSONQuery(csv.Object, "status.conditions", &conditions)
+	var name string
+	err := parseJSONQuery(csv, "status.conditions", &conditions)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
-	return conditions, nil
-}
+	err = parseJSONQuery(csv, "spec.displayName", &name)
+	if err != nil {
+		return "", nil, err
+	}
 
-// OlmOperatorAnonymizer implements HostSubnet serialization
-type OlmOperatorAnonymizer struct{ operators []olmOperator }
-
-// Marshal implements OlmOperator serialization
-func (a OlmOperatorAnonymizer) Marshal(_ context.Context) ([]byte, error) {
-	return json.Marshal(a.operators)
-}
-
-// GetExtension returns extension for OlmOperator object
-func (a OlmOperatorAnonymizer) GetExtension() string {
-	return "json"
+	return name, conditions, nil
 }

--- a/pkg/gather/clusterconfig/olm_operators_test.go
+++ b/pkg/gather/clusterconfig/olm_operators_test.go
@@ -2,10 +2,13 @@ package clusterconfig
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
 
+	"github.com/openshift/insights-operator/pkg/record"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,50 +17,115 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
-func TestOLMOperatorsGather(t *testing.T) {
-	olmOpContent, err := readFromFile("testdata/olm_operator_1.yaml")
-	if err != nil {
-		t.Fatal("test failed to read OLM operator data", err)
+func Test_OLMOperators_Gather(t *testing.T) {
+	var cases = []struct {
+		testName            string
+		olmOperatorFileName string
+		csvFileName         string
+		expectedError       error
+		expecteOlmOperator  olmOperator
+	}{
+		{
+			"All OLM operator data is available",
+			"testdata/olm_operator_1.yaml",
+			"testdata/csv_1.yaml",
+			nil,
+			olmOperator{
+				Name:        "test-olm-operator",
+				DisplayName: "Testing operator",
+				Version:     "v1.2.3",
+				Conditions: []interface{}{
+					map[string]interface{}{
+						"lastTransitionTime": "2021-03-02T08:52:24Z",
+						"lastUpdateTime":     "2021-03-02T08:52:24Z",
+						"message":            "requirements not yet checked",
+						"phase":              "Pending",
+						"reason":             "RequirementsUnknown",
+					},
+					map[string]interface{}{
+						"lastTransitionTime": "2021-03-02T08:52:24Z",
+						"lastUpdateTime":     "2021-03-02T08:52:24Z",
+						"message":            "all requirements found, attempting install",
+						"phase":              "InstallReady",
+						"reason":             "AllRequirementsMet",
+					},
+				},
+			},
+		},
+		{
+			"Operator doesn't have CSV reference",
+			"testdata/olm_operator_2.yaml",
+			"testdata/csv_1.yaml",
+			fmt.Errorf("cannot find \"status.components.refs\" in test-olm-operator-with-no-ref definition: key refs wasn't found in map[] "),
+			olmOperator{
+				Name: "test-olm-operator-with-no-ref",
+			},
+		},
+		{
+			"Operator CSV doesn't have the displayName",
+			"testdata/olm_operator_1.yaml",
+			"testdata/csv_2.yaml",
+			fmt.Errorf("cannot read test-olm-operator.v1.2.3 ClusterServiceVersion attributes: key displayName wasn't found in map[] "),
+			olmOperator{
+				Name:    "test-olm-operator",
+				Version: "v1.2.3",
+			},
+		},
+		{
+			"Operator with unrecognizable CSV version",
+			"testdata/olm_operator_3.yaml",
+			"testdata/csv_1.yaml",
+			fmt.Errorf("clusterserviceversion \"name-without-version\" probably doesn't include version"),
+			olmOperator{
+				Name: "test-olm-operator-no-version",
+			},
+		},
 	}
 
-	csvContent, err := readFromFile("testdata/csv_1.yaml")
-	if err != nil {
-		t.Fatal("test failed to read CSV ", err)
-	}
-	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
-		operatorGVR:              "OperatorsList",
-		clusterServiceVersionGVR: "ClusterServiceVersionsList",
-	})
-	err = createUnstructuredResource(olmOpContent, client, operatorGVR)
-	if err != nil {
-		t.Fatal("cannot create OLM operator ", err)
-	}
-	err = createUnstructuredResource(csvContent, client, clusterServiceVersionGVR)
-	if err != nil {
-		t.Fatal("cannot create ClusterServiceVersion ", err)
-	}
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.testName, func(t *testing.T) {
+			olmOpContent, err := readFromFile(tt.olmOperatorFileName)
+			if err != nil {
+				t.Fatal("test failed to read OLM operator data", err)
+			}
 
-	ctx := context.Background()
-	records, errs := gatherOLMOperators(ctx, client)
-	if len(errs) > 0 {
-		t.Errorf("unexpected errors: %#v", errs)
-		return
-	}
-	if len(records) != 1 {
-		t.Fatalf("unexpected number or records %d", len(records))
-	}
-	ooa, ok := records[0].Item.(OlmOperatorAnonymizer)
-	if !ok {
-		t.Fatalf("returned item is not of type OlmOperatorAnonymizer")
-	}
-	if ooa.operators[0].Name != "test-olm-operator" {
-		t.Fatalf("unexpected name of gathered OLM operator %s", ooa.operators[0].Name)
-	}
-	if ooa.operators[0].Version != "v1.2.3" {
-		t.Fatalf("unexpected version of gathered OLM operator %s", ooa.operators[0].Version)
-	}
-	if len(ooa.operators[0].Conditions) != 2 {
-		t.Fatalf("unexpected number of conditions %s", ooa.operators[0].Conditions...)
+			csvContent, err := readFromFile(tt.csvFileName)
+			if err != nil {
+				t.Fatal("test failed to read CSV ", err)
+			}
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+				operatorGVR:              "OperatorsList",
+				clusterServiceVersionGVR: "ClusterServiceVersionsList",
+			})
+			err = createUnstructuredResource(olmOpContent, client, operatorGVR)
+			if err != nil {
+				t.Fatal("cannot create OLM operator ", err)
+			}
+			err = createUnstructuredResource(csvContent, client, clusterServiceVersionGVR)
+			if err != nil {
+				t.Fatal("cannot create ClusterServiceVersion ", err)
+			}
+
+			ctx := context.Background()
+			records, errs := gatherOLMOperators(ctx, client)
+			if len(errs) > 0 {
+				if errs[0].Error() != tt.expectedError.Error() {
+					t.Fatalf("unexpected errors: %v", errs[0].Error())
+				}
+			}
+			if len(records) != 1 {
+				t.Fatalf("unexpected number or records %d", len(records))
+			}
+			ooa, ok := records[0].Item.(record.JSONMarshaller).Object.([]olmOperator)
+			if !ok {
+				t.Fatalf("returned item is not of type []olmOperator")
+			}
+			sameOp := reflect.DeepEqual(ooa[0], tt.expecteOlmOperator)
+			if !sameOp {
+				t.Fatalf("Gathered %s operator is not equal to expected %s ", ooa[0], tt.expecteOlmOperator)
+			}
+		})
 	}
 }
 

--- a/pkg/gather/clusterconfig/testdata/csv_2.yaml
+++ b/pkg/gather/clusterconfig/testdata/csv_2.yaml
@@ -3,8 +3,7 @@ kind: ClusterServiceVersion
 metadata:
     name: test-olm-operator.v1.2.3
     namespace: test-olm-operator
-spec:
-    displayName: "Testing operator"    
+spec: {}    
 status:
     conditions:
         - lastTransitionTime: "2021-03-02T08:52:24Z"

--- a/pkg/gather/clusterconfig/testdata/olm_operator_2.yaml
+++ b/pkg/gather/clusterconfig/testdata/olm_operator_2.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+    name: test-olm-operator-with-no-ref
+status:
+    components: {}

--- a/pkg/gather/clusterconfig/testdata/olm_operator_3.yaml
+++ b/pkg/gather/clusterconfig/testdata/olm_operator_3.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: Operator
+metadata:
+    name: test-olm-operator-no-version
+status:
+    components:
+        refs:
+            - apiVersion: operators.coreos.com/v1alpha1
+              kind: ClusterServiceVersion
+              name: name-without-version
+              namespace: test-olm-operator


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This updates the OLM operator gatherer to include corresponding `ClusterServiceVersion` display name. This is required for the nomination listed below. This PR also updates the gatherer to better handle the errors and extends the corresponding unit test. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->
Sample data updated in:
- `docs/insights-archive-sample/config/olm_operators.json `

## Documentation
<!-- Are these changes reflected in documentation? -->
No documentation updated

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
Test updated and extended in:
- ` pkg/gather/clusterconfig/olm_operators_test.go `

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://bugzilla.redhat.com/show_bug.cgi?id=1950926
https://issues.redhat.com/browse/INSIGHTOCP-280
