### PR TITLE
Bug 1948943: Make the pods limit in the workload gatherer more accurate

### DIFF
--- a/pkg/gather/clusterconfig/workloads.go
+++ b/pkg/gather/clusterconfig/workloads.go
@@ -178,7 +178,6 @@ func gatherWorkloadInfo(ctx context.Context, coreClient corev1client.CoreV1Inter
 		if err != nil {
 			return nil, []error{err}
 		}
-
 		for _, pod := range pods.Items {
 			// initialize the running state, including the namespace hash
 			if pod.Namespace != namespace {
@@ -193,13 +192,13 @@ func gatherWorkloadInfo(ctx context.Context, coreClient corev1client.CoreV1Inter
 				namespaceHash = workloadHashString(h, namespace)
 				namespacePods = workloadNamespacePods{Shapes: make([]workloadPodShape, 0, 16)}
 			}
-
-			if info.PodCount >= podsLimit {
+			// we also need to check the number of pods in current namespace, because when
+			// there's a namespace with a lot of pods it could exceed the limit a lot
+			if info.PodCount >= podsLimit || info.PodCount+namespacePods.Count >= podsLimit {
 				pods.Continue = ""
 				limitReached = true
 				break
 			}
-
 			namespacePods.Count++
 
 			switch {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This updates the pod limit in the workload gatherer to be more accurate.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

No update

## Documentation
No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://bugzilla.redhat.com/show_bug.cgi?id=1948943

