### PR TITLE
Rename workload annotations

### DIFF
--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: insights-operator
     spec:


### PR DESCRIPTION
As per openshift/enhancements#739, the workload
annotations names are changing.

/hold
Hold until after openshift/kubernetes#632 is merged please

## Categories
- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Documentation
https://github.com/openshift/enhancements/pull/739
