### PR TITLE
Bug 1952906: Add a few tests to configobserver_test.go

### DIFF
--- a/pkg/config/configobserver/configobserver_test.go
+++ b/pkg/config/configobserver/configobserver_test.go
@@ -19,6 +19,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 )
 
+//nolint: lll, funlen
 func Test_ConfigObserver_ChangeSupportConfig(t *testing.T) {
 	var cases = []struct {
 		name      string
@@ -40,6 +41,50 @@ func Test_ConfigObserver_ChangeSupportConfig(t *testing.T) {
 			},
 			expErr: fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to ten seconds: too short"),
 		},
+		{name: "interval incorrect format",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": nil,
+				}},
+				supportKey: {Data: map[string][]byte{
+					"interval": []byte("every second"),
+				}},
+			},
+			expErr: fmt.Errorf("insights secret interval must be a duration (1h, 10m) greater than or equal to ten seconds: time: invalid duration \"every second\""),
+		},
+		{name: "reportPullingDelay incorrect format",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": nil,
+				}},
+				supportKey: {Data: map[string][]byte{
+					"reportPullingDelay": []byte("every second"),
+				}},
+			},
+			expConfig: &config.Controller{}, // it only produces a warning in the log
+		},
+		{name: "reportMinRetryTime incorrect format",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": nil,
+				}},
+				supportKey: {Data: map[string][]byte{
+					"reportMinRetryTime": []byte("every second"),
+				}},
+			},
+			expConfig: &config.Controller{}, // it only produces a warning in the log
+		},
+		{name: "reportPullingDelay incorrect format",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": nil,
+				}},
+				supportKey: {Data: map[string][]byte{
+					"reportPullingDelay": []byte("every second"),
+				}},
+			},
+			expConfig: &config.Controller{}, // it only produces a warning in the log
+		},
 		{name: "correct interval",
 			config: map[string]*corev1.Secret{
 				pullSecretKey: {Data: map[string][]byte{
@@ -53,6 +98,44 @@ func Test_ConfigObserver_ChangeSupportConfig(t *testing.T) {
 				Interval: 1 * time.Minute,
 			},
 			expErr: nil,
+		},
+		{name: "set-all-config",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": nil,
+				}},
+				supportKey: {Data: map[string][]byte{
+					"username":                []byte("Dude"),
+					"password":                []byte("pswd123"),
+					"endpoint":                []byte("http://po.rt"),
+					"httpProxy":               []byte("http://pro.xy"),
+					"httpsProxy":              []byte("https://pro.xy"),
+					"noProxy":                 []byte("http://no.xy"),
+					"enableGlobalObfuscation": []byte("true"),
+					"reportEndpoint":          []byte("http://rep.rt"),
+					"reportPullingDelay":      []byte("10m"),
+					"reportMinRetryTime":      []byte("10m"),
+					"reportPullingTimeout":    []byte("10m"),
+					"interval":                []byte("10m"),
+				}},
+			},
+			expConfig: &config.Controller{
+				Report:   true,
+				Username: "Dude",
+				Password: "pswd123",
+				Endpoint: "http://po.rt",
+				HTTPConfig: config.HTTPConfig{
+					HTTPProxy:  "http://pro.xy",
+					HTTPSProxy: "https://pro.xy",
+					NoProxy:    "http://no.xy",
+				},
+				EnableGlobalObfuscation: true,
+				ReportEndpoint:          "http://rep.rt",
+				ReportPullingDelay:      10 * time.Minute,
+				ReportMinRetryTime:      10 * time.Minute,
+				ReportPullingTimeout:    10 * time.Minute,
+				Interval:                10 * time.Minute,
+			},
 		},
 	}
 
@@ -94,6 +177,62 @@ func Test_ConfigObserver_ChangeSupportConfig(t *testing.T) {
 				t.Fatalf("The test expected config doesn't match actual config.\nExpected: %v Actual: %v", tt.expConfig, c.config)
 			}
 		})
+	}
+}
+
+func Test_ConfigObserver_ConfigChanged(t *testing.T) {
+	ctrl := config.Controller{}
+	kube := kubeClientResponder{}
+	// Imitates New function
+	c := &Controller{
+		kubeClient:    &kube,
+		defaultConfig: ctrl,
+	}
+	c.mergeConfigLocked()
+
+	// Subscribe to config change event
+	configCh, closeFn := c.ConfigChanged()
+	if len(configCh) > 0 {
+		t.Fatalf("Config channel is not empty on start.")
+	}
+	// Setup mock for 1. config update
+	provideSecretMock(&kube, map[string]*corev1.Secret{
+		pullSecretKey: {Data: map[string][]byte{
+			".dockerconfigjson": nil,
+		}},
+		supportKey: {Data: map[string][]byte{
+			"username": []byte("test2"),
+		}},
+	})
+	// 1. config update
+	err := c.retrieveConfig(context.TODO())
+	if err != nil {
+		t.Fatalf("Unexpected error %s", err)
+	}
+	// Check if the event arrived on the channel
+	if len(configCh) != 1 {
+		t.Fatalf("Config channel has more/less then 1 event on a singal config change. len(configCh)==%d", len(configCh))
+	}
+
+	// Unsubscribe from config change
+	closeFn()
+	// Setup mock for 2. config update
+	provideSecretMock(&kube, map[string]*corev1.Secret{
+		pullSecretKey: {Data: map[string][]byte{
+			".dockerconfigjson": nil,
+		}},
+		supportKey: {Data: map[string][]byte{
+			"username": []byte("test3"),
+		}},
+	})
+	// 2. config update
+	err = c.retrieveConfig(context.TODO())
+	if err != nil {
+		t.Fatalf("Unexpected error %s", err)
+	}
+	// Check if unsubscribe worked. ie: no new event on the channel
+	if len(configCh) != 1 {
+		t.Fatalf("The closing function failed to unsubscribe from the config change event. len(configCh)==%d", len(configCh))
 	}
 }
 

--- a/pkg/config/configobserver/configobserver_test.go
+++ b/pkg/config/configobserver/configobserver_test.go
@@ -23,8 +23,6 @@ type kubeClientResponder struct {
 	clsetfake.Clientset
 }
 
-var _ kubernetes.Interface = (*kubeClientResponder)(nil)
-
 const (
 	pullSecretKey = "(/v1, Resource=secrets) openshift-config.pull-secret" //nolint: gosec
 	supportKey    = "(/v1, Resource=secrets) openshift-config.support"


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Adds a few extra tests for the configoberver

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ]Enhancement
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- no change

## Documentation
<!-- Are these changes reflected in documentation? -->

- no change

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- see `pkg/config/configobserver/configobserver_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->
