### PR TITLE
Bug 1953743: Correctly detect workload shapes when gathering instead of only detecting the first match

### DIFF
--- a/pkg/gather/clusterconfig/workloads.go
+++ b/pkg/gather/clusterconfig/workloads.go
@@ -395,10 +395,10 @@ func workloadPodShapeIndex(shapes []workloadPodShape, shape workloadPodShape) in
 	for i := len(shapes) - 1; i >= 0; i-- {
 		existing := shapes[i]
 		if !workloadContainerShapesEqual(existing.InitContainers, shape.InitContainers) {
-			return -1
+			continue
 		}
 		if !workloadContainerShapesEqual(existing.Containers, shape.Containers) {
-			return -1
+			continue
 		}
 		return i
 	}


### PR DESCRIPTION
The find algorithm was returning no match unless the first shape
matched, which caused us to not collapse shapes correctly.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)