### PR TITLE
Bug 1954931: Remove URL anonymization from ClusterOperator resources

### DIFF
--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/authentication/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/authentication/cluster.json
@@ -16,7 +16,9 @@
                         "//localhost(:|$)"
                     ],
                     "etcd-servers": [
-                        "xxxxxxxxxxxxxxxxxxxxxxx"
+                        "https://10.0.0.3:2379",
+                        "https://10.0.0.4:2379",
+                        "https://10.0.0.5:2379"
                     ],
                     "tls-cipher-suites": [
                         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
@@ -35,8 +37,8 @@
                     "//localhost(:|$)"
                 ],
                 "oauthConfig": {
-                    "assetPublicURL": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-                    "loginURL": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                    "assetPublicURL": "https://console-openshift-console.apps.ci-ln-qwj5ixk-f76d1.origin-ci-int-gce.dev.openshift.com",
+                    "loginURL": "https://api.ci-ln-qwj5ixk-f76d1.origin-ci-int-gce.dev.openshift.com:6443",
                     "templates": {
                         "error": "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/errors.html",
                         "login": "/var/config/system/secrets/v4-0-config-system-ocp-branding-template/login.html",
@@ -59,10 +61,10 @@
                     "minTLSVersion": "VersionTLS12",
                     "namedCertificates": [
                         {
-                            "certFile": "/var/config/system/secrets/v4-0-config-system-router-certs/apps.tremes.lab.upshift.rdu2.redhat.com",
-                            "keyFile": "/var/config/system/secrets/v4-0-config-system-router-certs/apps.tremes.lab.upshift.rdu2.redhat.com",
+                            "certFile": "/var/config/system/secrets/v4-0-config-system-router-certs/apps.ci-ln-qwj5ixk-f76d1.origin-ci-int-gce.dev.openshift.com",
+                            "keyFile": "/var/config/system/secrets/v4-0-config-system-router-certs/apps.ci-ln-qwj5ixk-f76d1.origin-ci-int-gce.dev.openshift.com",
                             "names": [
-                                "*.apps.tremes.lab.upshift.rdu2.redhat.com"
+                                "*.apps.ci-ln-qwj5ixk-f76d1.origin-ci-int-gce.dev.openshift.com"
                             ]
                         }
                     ]
@@ -73,8 +75,6 @@
             }
         },
         "operatorLogLevel": "Normal",
-        "unsupportedConfigOverrides": {
-            "useUnsupportedUnsafeNonHANonProductionUnstableOAuthServer": true
-        }
+        "unsupportedConfigOverrides": null
     }
 }

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubeapiserver/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubeapiserver/cluster.json
@@ -31,6 +31,12 @@
                 "audit-policy-file": [
                     "/etc/kubernetes/static-pod-resources/configmaps/kube-apiserver-audit-policies/default.yaml"
                 ],
+                "authentication-token-webhook-config-file": [
+                    "/etc/kubernetes/static-pod-resources/secrets/webhook-authenticator/kubeConfig"
+                ],
+                "authentication-token-webhook-version": [
+                    "v1"
+                ],
                 "cloud-config": [
                     "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/config"
                 ],
@@ -38,8 +44,10 @@
                     "gce"
                 ],
                 "etcd-servers": [
-                    "xxxxxxxxxxxxxxxxxxxxxxx",
-                    "xxxxxxxxxxxxxxxxxxxxxx"
+                    "https://10.0.0.3:2379",
+                    "https://10.0.0.4:2379",
+                    "https://10.0.0.5:2379",
+                    "https://localhost:2379"
                 ],
                 "feature-gates": [
                     "APIPriorityAndFairness=true",
@@ -47,8 +55,11 @@
                     "SupportPodPidsLimit=true",
                     "NodeDisruptionExclusion=true",
                     "ServiceNodeExclusion=true",
-                    "SCTPSupport=true",
+                    "DownwardAPIHugePages=true",
                     "LegacyNodeRoleBehavior=false"
+                ],
+                "service-account-jwks-uri": [
+                    "https://api-int.ci-ln-qwj5ixk-f76d1.origin-ci-int-gce.dev.openshift.com:6443/openid/v1/jwks"
                 ]
             },
             "authConfig": {

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/openshiftapiserver/cluster.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/openshiftapiserver/cluster.json
@@ -18,7 +18,7 @@
                 "projectRequestMessage": ""
             },
             "routingConfig": {
-                "subdomain": "apps.tremes.lab.upshift.rdu2.redhat.com"
+                "subdomain": "apps.ci-ln-qwj5ixk-f76d1.origin-ci-int-gce.dev.openshift.com"
             },
             "servingInfo": {
                 "cipherSuites": [
@@ -33,7 +33,9 @@
             },
             "storageConfig": {
                 "urls": [
-                    "xxxxxxxxxxxxxxxxxxxxxxx"
+                    "https://10.0.0.3:2379",
+                    "https://10.0.0.4:2379",
+                    "https://10.0.0.5:2379"
                 ]
             }
         },

--- a/pkg/gather/clusterconfig/infrastructures.go
+++ b/pkg/gather/clusterconfig/infrastructures.go
@@ -44,7 +44,6 @@ func gatherClusterInfrastructure(ctx context.Context, configClient configv1clien
 }
 
 func anonymizeInfrastructure(config *configv1.Infrastructure) *configv1.Infrastructure {
-	config.Status.EtcdDiscoveryDomain = anonymize.AnonymizeURL(config.Status.EtcdDiscoveryDomain)
 	config.Status.InfrastructureName = anonymize.AnonymizeURL(config.Status.InfrastructureName)
 	return config
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This removes legacy URL anonymization in the clusteroperator resources. This will be obfuscated when user enables the global obfuscation in 4.8.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->
Sample archive udpated in:

- `insights-operator/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/authentication/cluster.json` 
- `insights-operator/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/kubeapiserver/cluster.json`
- `insights-operator/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/openshiftapiserver/cluster.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
