### PR TITLE
[release 4.6] Bug 1953582: GatherClusterOperators and GatherClusterOperatorsPodAndEvents

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -117,10 +117,25 @@ Location in archive: config/oauth/
 See: docs/insights-archive-sample/config/oauth
 
 
+## ClusterOperatorPodsAndEvents
+
+collects all the ClusterOperators degraded Pods
+for degraded cluster operators or that lives at the Cluster Operator's namespace, to collect:
+
+- Pod definitions
+- Previous and current Pod Container logs (when available)
+- Namespace Events
+
+* Location of pods in archive: config/pod/
+* Location of events in archive: events/
+* Id in config: operators_pods_and_events
+
+
 ## ClusterOperators
 
 collects all ClusterOperators and their resource.
 It finds unhealthy Pods for unhealthy operators
+GatherClusterOperators collects all the ClusterOperators definitions and their resources.
 
 The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusteroperator.go#L62
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#clusteroperatorlist-v1config-openshift-io

--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -37,6 +37,7 @@ func (g *Gatherer) Gather(ctx context.Context, recorder record.Interface) error 
 		GatherPodDisruptionBudgets(g),
 		GatherMostRecentMetrics(g),
 		GatherClusterOperators(g),
+		GatherClusterOperatorPodsAndEvents(g),
 		GatherContainerImages(g),
 		GatherNodes(g),
 		GatherConfigMaps(g),

--- a/pkg/gather/clusterconfig/operators.go
+++ b/pkg/gather/clusterconfig/operators.go
@@ -1,33 +1,23 @@
 package clusterconfig
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"regexp"
-	"sort"
 	"strings"
-	"time"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog"
 
 	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/openshift/insights-operator/pkg/record"
-	"github.com/openshift/insights-operator/pkg/record/diskrecorder"
 )
 
 const (
@@ -44,14 +34,9 @@ type clusterOperatorResource struct {
 	Spec       interface{}
 }
 
-// ClusterOperatorAnonymizer implements serialization of ClusterOperator without change
-type ClusterOperatorAnonymizer struct{ *configv1.ClusterOperator }
-
-// ClusterOperatorResourceAnonymizer implements serialization of clusterOperatorResource
-type ClusterOperatorResourceAnonymizer struct{ resource clusterOperatorResource }
-
 // GatherClusterOperators collects all ClusterOperators and their resource.
 // It finds unhealthy Pods for unhealthy operators
+// GatherClusterOperators collects all the ClusterOperators definitions and their resources.
 //
 // The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusteroperator.go#L62
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#clusteroperatorlist-v1config-openshift-io
@@ -65,10 +50,6 @@ func GatherClusterOperators(g *Gatherer) func() ([]record.Record, []error) {
 		if err != nil {
 			return nil, []error{err}
 		}
-		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-		if err != nil {
-			return nil, []error{err}
-		}
 		discoveryClient, err := discovery.NewDiscoveryClientForConfig(g.gatherKubeConfig)
 		if err != nil {
 			return nil, []error{err}
@@ -77,11 +58,12 @@ func GatherClusterOperators(g *Gatherer) func() ([]record.Record, []error) {
 		if err != nil {
 			return nil, []error{err}
 		}
-		return gatherClusterOperators(g.ctx, gatherConfigClient, gatherKubeClient.CoreV1(), discoveryClient, dynamicClient)
+		return gatherClusterOperators(g.ctx, gatherConfigClient, discoveryClient, dynamicClient)
 	}
 }
 
-func gatherClusterOperators(ctx context.Context, configClient configv1client.ConfigV1Interface, coreClient corev1client.CoreV1Interface, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+// gatherClusterOperators collects cluster operators
+func gatherClusterOperators(ctx context.Context, configClient configv1client.ConfigV1Interface, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface) ([]record.Record, []error) {
 	config, err := configClient.ClusterOperators().List(ctx, metav1.ListOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
@@ -89,13 +71,26 @@ func gatherClusterOperators(ctx context.Context, configClient configv1client.Con
 	if err != nil {
 		return nil, []error{err}
 	}
+
+	// collect the cluster operators reports
+	records := clusterOperatorsRecords(ctx, config.Items, dynamicClient, discoveryClient)
+	return records, nil
+}
+
+// clusterOperatorsRecords generates the cluster operator records
+func clusterOperatorsRecords(ctx context.Context, items []configv1.ClusterOperator, dynamicClient dynamic.Interface, discoveryClient discovery.DiscoveryInterface) []record.Record {
 	resVer, _ := getOperatorResourcesVersions(discoveryClient)
-	records := make([]record.Record, 0, len(config.Items))
-	for index, co := range config.Items {
-		records = append(records, record.Record{Name: fmt.Sprintf("config/clusteroperator/%s", config.Items[index].Name), Item: ClusterOperatorAnonymizer{&config.Items[index]}})
+	records := make([]record.Record, 0, len(items))
+
+	for idx, co := range items {
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("config/clusteroperator/%s", items[idx].Name),
+			Item: record.JSONMarshaller{Object: &items[idx]},
+		})
 		if resVer == nil {
 			continue
 		}
+
 		relRes := collectClusterOperatorResources(ctx, dynamicClient, co, resVer)
 		for _, rr := range relRes {
 			// imageregistry resources (config, pruner) are gathered in image_registries.go, image_pruners.go
@@ -112,133 +107,11 @@ func gatherClusterOperators(ctx context.Context, configClient configv1client.Con
 			})
 		}
 	}
-	namespaceEventsCollected := sets.NewString()
-	now := time.Now()
-	unhealthyPods := []*corev1.Pod{}
-	for _, item := range config.Items {
-		if isHealthyOperator(&item) {
-			continue
-		}
-		for _, namespace := range namespacesForOperator(&item) {
-			pods, err := coreClient.Pods(namespace).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				klog.V(2).Infof("Unable to find pods in namespace %s for failing operator %s", namespace, item.Name)
-				continue
-			}
-			for j := range pods.Items {
-				pod := &pods.Items[j]
-				if isHealthyPod(pod, now) {
-					continue
-				}
-				records = append(records, record.Record{Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name), Item: PodAnonymizer{pod}})
-				unhealthyPods = append(unhealthyPods, pod)
-			}
-			if namespaceEventsCollected.Has(namespace) {
-				continue
-			}
-			namespaceRecords, errs := gatherNamespaceEvents(ctx, coreClient, namespace)
-			if len(errs) > 0 {
-				klog.V(2).Infof("Unable to collect events for namespace %q: %#v", namespace, errs)
-				continue
-			}
-			records = append(records, namespaceRecords...)
-			namespaceEventsCollected.Insert(namespace)
-		}
-	}
 
-	// Exit early if no unhealthy pods found
-	if len(unhealthyPods) == 0 {
-		return records, nil
-	}
-
-	// Fetch a list of containers in unhealthy pods and calculate a log size quota
-	// Total log size must not exceed maxLogsSize multiplied by logCompressionRatio
-	klog.V(2).Infof("Found %d unhealthy pods", len(unhealthyPods))
-	totalUnhealthyContainers := 0
-	for _, pod := range unhealthyPods {
-		totalUnhealthyContainers += len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
-	}
-	bufferSize := int64(diskrecorder.MaxLogSize * logCompressionRatio / totalUnhealthyContainers / 2)
-	klog.V(2).Infof("Maximum buffer size: %v bytes", bufferSize)
-	buf := bytes.NewBuffer(make([]byte, 0, bufferSize))
-
-	// Fetch previous and current container logs
-	for _, isPrevious := range []bool{true, false} {
-		for _, pod := range unhealthyPods {
-			allContainers := pod.Spec.InitContainers
-			allContainers = append(allContainers, pod.Spec.Containers...)
-			for _, c := range allContainers {
-				logName := fmt.Sprintf("%s_current.log", c.Name)
-				if isPrevious {
-					logName = fmt.Sprintf("%s_previous.log", c.Name)
-				}
-				buf.Reset()
-				klog.V(2).Infof("Fetching logs for %s container %s pod in namespace %s (previous: %v): %v", c.Name, pod.Name, pod.Namespace, isPrevious, err)
-				// Collect container logs and continue on error
-				err = collectContainerLogs(ctx, coreClient, pod, buf, c.Name, isPrevious, &bufferSize)
-				if err != nil {
-					klog.V(2).Infof("Error: %q", err)
-					continue
-				}
-				records = append(records, record.Record{Name: fmt.Sprintf("config/pod/%s/logs/%s/%s", pod.Namespace, pod.Name, logName), Item: Raw{buf.String()}})
-			}
-		}
-	}
-
-	return records, nil
-}
-func gatherNamespaceEvents(ctx context.Context, coreClient corev1client.CoreV1Interface, namespace string) ([]record.Record, []error) {
-	// do not accidentally collect events for non-openshift namespace
-	if !strings.HasPrefix(namespace, "openshift-") {
-		return []record.Record{}, nil
-	}
-	events, err := coreClient.Events(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, []error{err}
-	}
-	// filter the event list to only recent events
-	oldestEventTime := time.Now().Add(-maxEventTimeInterval)
-	var filteredEventIndex []int
-	for i := range events.Items {
-		if events.Items[i].LastTimestamp.Time.Before(oldestEventTime) {
-			continue
-		}
-		filteredEventIndex = append(filteredEventIndex, i)
-	}
-	compactedEvents := CompactedEventList{Items: make([]CompactedEvent, len(filteredEventIndex))}
-	for i, index := range filteredEventIndex {
-		compactedEvents.Items[i] = CompactedEvent{
-			Namespace:     events.Items[index].Namespace,
-			LastTimestamp: events.Items[index].LastTimestamp.Time,
-			Reason:        events.Items[index].Reason,
-			Message:       events.Items[index].Message,
-		}
-	}
-	sort.Slice(compactedEvents.Items, func(i, j int) bool {
-		return compactedEvents.Items[i].LastTimestamp.Before(compactedEvents.Items[j].LastTimestamp)
-	})
-	return []record.Record{{Name: fmt.Sprintf("events/%s", namespace), Item: EventAnonymizer{&compactedEvents}}}, nil
+	return records
 }
 
-// collectContainerLogs fetches log lines from the pod
-func collectContainerLogs(ctx context.Context, coreClient corev1client.CoreV1Interface, pod *corev1.Pod, buf *bytes.Buffer, containerName string, isPrevious bool, maxBytes *int64) error {
-	req := coreClient.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Previous: isPrevious, Container: containerName, LimitBytes: maxBytes, TailLines: &logTailLines})
-	readCloser, err := req.Stream(ctx)
-	if err != nil {
-		klog.V(2).Infof("Failed to fetch log for %s pod in namespace %s for failing operator %s (previous: %v): %q", pod.Name, pod.Namespace, containerName, isPrevious, err)
-		return err
-	}
-
-	defer readCloser.Close()
-
-	_, err = io.Copy(buf, readCloser)
-	if err != nil && err != io.ErrShortBuffer {
-		klog.V(2).Infof("Failed to write log for %s pod in namespace %s for failing operator %s (previous: %v): %q", pod.Name, pod.Namespace, containerName, isPrevious, err)
-		return err
-	}
-	return nil
-}
-
+// collectClusterOperatorResources list all cluster operator resources
 func collectClusterOperatorResources(ctx context.Context, dynamicClient dynamic.Interface, co configv1.ClusterOperator, resVer map[string][]string) []clusterOperatorResource {
 	var relObj []configv1.ObjectReference
 	for _, ro := range co.Status.RelatedObjects {
@@ -281,6 +154,7 @@ func collectClusterOperatorResources(ctx context.Context, dynamicClient dynamic.
 	return res
 }
 
+// getOperatorResourcesVersions get all the operator resource versions
 func getOperatorResourcesVersions(discoveryClient discovery.DiscoveryInterface) (map[string][]string, error) {
 	resources, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
@@ -295,48 +169,20 @@ func getOperatorResourcesVersions(discoveryClient discovery.DiscoveryInterface) 
 			}
 			for _, ar := range v.APIResources {
 				key := fmt.Sprintf("%s-%s", gv.Group, ar.Name)
-				r, ok := resourceVersionMap[key]
+				_, ok := resourceVersionMap[key]
 				if !ok {
 					resourceVersionMap[key] = []string{gv.Version}
-				} else {
-					resourceVersionMap[key] = append(r, gv.Version)
+					continue
 				}
+				resourceVersionMap[key] = append(resourceVersionMap[key], gv.Version)
 			}
 		}
 	}
 	return resourceVersionMap, nil
 }
 
-// Marshal serializes ClusterOperator
-func (a ClusterOperatorAnonymizer) Marshal(_ context.Context) ([]byte, error) {
-	return runtime.Encode(openshiftSerializer, a.ClusterOperator)
-}
-
-// GetExtension returns extension for anonymized cluster operator objects
-func (a ClusterOperatorAnonymizer) GetExtension() string {
-	return "json"
-}
-
-func isHealthyOperator(operator *configv1.ClusterOperator) bool {
-	for _, condition := range operator.Status.Conditions {
-		switch {
-		case condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue,
-			condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse:
-			return false
-		}
-	}
-	return true
-}
-
-func namespacesForOperator(operator *configv1.ClusterOperator) []string {
-	var ns []string
-	for _, ref := range operator.Status.RelatedObjects {
-		if ref.Resource == "namespaces" {
-			ns = append(ns, ref.Name)
-		}
-	}
-	return ns
-}
+// ClusterOperatorResourceAnonymizer implements serialization of clusterOperatorResource
+type ClusterOperatorResourceAnonymizer struct{ resource clusterOperatorResource }
 
 // Marshal serializes clusterOperatorResource with IP address anonymization
 func (a ClusterOperatorResourceAnonymizer) Marshal(_ context.Context) ([]byte, error) {

--- a/pkg/gather/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gather/clusterconfig/operators_pods_and_events.go
@@ -1,0 +1,317 @@
+package clusterconfig
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/record/diskrecorder"
+	"github.com/openshift/insights-operator/pkg/utils/check"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog"
+)
+
+// CompactedEvent holds one Namespace Event
+type CompactedEvent struct {
+	Namespace     string    `json:"namespace"`
+	LastTimestamp time.Time `json:"lastTimestamp"`
+	Reason        string    `json:"reason"`
+	Message       string    `json:"message"`
+}
+
+// CompactedEventList is collection of events
+type CompactedEventList struct {
+	Items []CompactedEvent `json:"items"`
+}
+
+// GatherClusterOperatorPodsAndEvents collects all the ClusterOperators degraded Pods
+// for degraded cluster operators or that lives at the Cluster Operator's namespace, to collect:
+//
+// - Pod definitions
+// - Previous and current Pod Container logs (when available)
+// - Namespace Events
+//
+// * Location of pods in archive: config/pod/
+// * Location of events in archive: events/
+// * Id in config: operators_pods_and_events
+func GatherClusterOperatorPodsAndEvents(g *Gatherer) func() ([]record.Record, []error) {
+	return func() ([]record.Record, []error) {
+		gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
+		if err != nil {
+			return nil, []error{err}
+		}
+		gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+		if err != nil {
+			return nil, []error{err}
+		}
+
+		return gatherClusterOperatorPodsAndEvents(g.ctx, gatherConfigClient, gatherKubeClient.CoreV1())
+	}
+}
+
+func gatherClusterOperatorPodsAndEvents(ctx context.Context, configClient configv1client.ConfigV1Interface, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
+	config, err := configClient.ClusterOperators().List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	// gather pods from unhealthy operators
+	pods, records, totalContainers := unhealthyClusterOperator(ctx, config.Items, coreClient)
+	// Exit early if no pods found
+	klog.V(2).Infof("Found %d pods with %d containers", len(pods), totalContainers)
+	if len(pods) == 0 || totalContainers <= 0 {
+		return records, nil
+	}
+
+	// gather pods containers logs
+	bufferSize := int64(diskrecorder.MaxLogSize * logCompressionRatio / totalContainers / 2)
+	clogs, err := gatherPodContainersLogs(ctx, coreClient, pods, bufferSize)
+	if err != nil {
+		klog.V(2).Infof("Unable to gather pod containers logs: %v", err)
+		return records, nil
+	}
+	if len(clogs) > 0 {
+		records = append(records, clogs...)
+	}
+
+	return records, nil
+}
+
+// unhealthyClusterOperator collects unhealthy cluster operator resources
+func unhealthyClusterOperator(ctx context.Context, items []configv1.ClusterOperator, coreClient corev1client.CoreV1Interface) ([]*corev1.Pod, []record.Record, int) {
+	var records []record.Record
+
+	namespaceEventsCollected := sets.NewString()
+	pods := []*corev1.Pod{}
+	totalContainers := 0
+
+	for _, item := range items {
+		if isHealthyOperator(&item) {
+			continue
+		}
+
+		for _, namespace := range namespacesForOperator(&item) {
+			podList, err := coreClient.Pods(namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				klog.V(2).Infof("Unable to find pods in namespace %s for failing operator %s", namespace, item.Name)
+				continue
+			}
+
+			uhPods, uhRecords, uhTotal := gatherUnhealthyPods(podList.Items)
+			pods = append(pods, uhPods...)
+			records = append(records, uhRecords...)
+			totalContainers += uhTotal
+
+			if namespaceEventsCollected.Has(namespace) {
+				continue
+			}
+
+			namespaceRecords, err := gatherNamespaceEvents(ctx, coreClient, namespace)
+			if err != nil {
+				klog.V(2).Infof("Unable to collect events for namespace %q: %#v", namespace, err)
+				continue
+			}
+
+			records = append(records, namespaceRecords...)
+			namespaceEventsCollected.Insert(namespace)
+		}
+	}
+
+	return pods, records, totalContainers
+}
+
+// gatherUnhealthyPods collects cluster operator unhealthy pods
+func gatherUnhealthyPods(pods []corev1.Pod) ([]*corev1.Pod, []record.Record, int) {
+	var records []record.Record
+	var podList []*corev1.Pod
+	total := 0
+	now := time.Now()
+
+	for j := range pods {
+		pod := &pods[j]
+		if check.IsHealthyPod(pod, now) {
+			continue
+		}
+		records = append(records, record.Record{Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name), Item: record.JSONMarshaller{Object: pod}})
+		podList = append(podList, pod)
+		total += len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
+	}
+
+	return podList, records, total
+}
+
+// gatherNamespaceEvents gather all namespace events
+func gatherNamespaceEvents(ctx context.Context, coreClient corev1client.CoreV1Interface, namespace string) ([]record.Record, error) {
+	// do not accidentally collect events for non-openshift namespace
+	if !strings.HasPrefix(namespace, "openshift-") {
+		return []record.Record{}, nil
+	}
+	events, err := coreClient.Events(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	// filter the event list to only recent events
+	oldestEventTime := time.Now().Add(-maxEventTimeInterval)
+	var filteredEventIndex []int
+	for i := range events.Items {
+		if events.Items[i].LastTimestamp.Time.Before(oldestEventTime) {
+			continue
+		}
+		filteredEventIndex = append(filteredEventIndex, i)
+
+	}
+	compactedEvents := CompactedEventList{Items: make([]CompactedEvent, len(filteredEventIndex))}
+	for i, index := range filteredEventIndex {
+		compactedEvents.Items[i] = CompactedEvent{
+			Namespace:     events.Items[index].Namespace,
+			LastTimestamp: events.Items[index].LastTimestamp.Time,
+			Reason:        events.Items[index].Reason,
+			Message:       events.Items[index].Message,
+		}
+	}
+	sort.Slice(compactedEvents.Items, func(i, j int) bool {
+		return compactedEvents.Items[i].LastTimestamp.Before(compactedEvents.Items[j].LastTimestamp)
+	})
+	return []record.Record{{Name: fmt.Sprintf("events/%s", namespace), Item: record.JSONMarshaller{Object: &compactedEvents}}}, nil
+}
+
+// gatherPodContainersLogs collect the pod current and previous containers logs
+func gatherPodContainersLogs(ctx context.Context, client corev1client.CoreV1Interface, pods []*corev1.Pod, bufferSize int64) ([]record.Record, error) {
+	if bufferSize <= 0 {
+		return nil, fmt.Errorf("invalid buffer size %d", bufferSize)
+	}
+
+	// Fetch a list of containers in pods and calculate a log size quota
+	// Total log size must not exceed maxLogsSize multiplied by logCompressionRatio
+	klog.V(2).Infof("Maximum buffer size: %v bytes", bufferSize)
+	buf := bytes.NewBuffer(make([]byte, 0, bufferSize))
+
+	// Fetch previous and current container logs
+	var records []record.Record
+	for _, isPrevious := range []bool{true, false} {
+		for _, pod := range pods {
+			clog := getContainerLogs(ctx, client, pod, isPrevious, buf, bufferSize)
+			if len(clog) > 0 {
+				records = append(records, clog...)
+			}
+		}
+	}
+
+	return records, nil
+}
+
+// getContainerLogs get previous and current log reports for pod containers using the k8s API response
+func getContainerLogs(ctx context.Context, client corev1client.CoreV1Interface, pod *corev1.Pod, isPrevious bool, buf *bytes.Buffer, bufferSize int64) []record.Record {
+	var records []record.Record
+
+	allContainers := append(pod.Spec.InitContainers, pod.Spec.Containers...)
+	for _, c := range allContainers {
+		// only grab previous log if the pod is restarted
+		if isPrevious && !isPodRestarted(pod) {
+			continue
+		}
+
+		logName := fmt.Sprintf("%s_current.log", c.Name)
+		if isPrevious {
+			logName = fmt.Sprintf("%s_previous.log", c.Name)
+		}
+
+		buf.Reset()
+		klog.V(2).Infof("Fetching logs for %s container %s pod in namespace %s (previous: %v).", c.Name, pod.Name, pod.Namespace, isPrevious)
+		// Fetch container logs and continue on error
+		err := fetchPodContainerLog(ctx, client, pod, buf, c.Name, isPrevious, &bufferSize)
+		if err != nil {
+			klog.V(2).Infof("Error: %q", err)
+			continue
+		}
+
+		// Do not record empty records
+		if buf.Len() == 0 {
+			continue
+		}
+		records = append(records, record.Record{Name: fmt.Sprintf("config/pod/%s/logs/%s/%s", pod.Namespace, pod.Name, logName), Item: Raw{buf.String()}})
+	}
+
+	return records
+}
+
+// fetchPodContainerLog fetches log lines from the pod
+func fetchPodContainerLog(ctx context.Context, coreClient corev1client.CoreV1Interface, pod *corev1.Pod, buf *bytes.Buffer, containerName string, isPrevious bool, maxBytes *int64) error {
+	req := coreClient.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{Previous: isPrevious, Container: containerName, LimitBytes: maxBytes, TailLines: &logTailLines})
+	readCloser, err := req.Stream(ctx)
+	if err != nil {
+		klog.V(2).Infof("Failed to fetch log for %s pod in namespace %s for failing operator %s (previous: %v): %q", pod.Name, pod.Namespace, containerName, isPrevious, err)
+		return err
+	}
+
+	defer readCloser.Close()
+
+	_, err = io.Copy(buf, readCloser)
+	if err != nil && err != io.ErrShortBuffer {
+		klog.V(2).Infof("Failed to write log for %s pod in namespace %s for failing operator %s (previous: %v): %q", pod.Name, pod.Namespace, containerName, isPrevious, err)
+		return err
+	}
+	return nil
+}
+
+// isPodRestarted checks if pod was restarted by testing its container's restart count status is bigger than zero
+func isPodRestarted(pod *corev1.Pod) bool {
+	// pods that have containers that have terminated with non-zero exit codes are considered failure
+	for _, status := range pod.Status.InitContainerStatuses {
+		if status.RestartCount > 0 {
+			return true
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.RestartCount > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// isHealthyOperator checks if operator ins't degraded or unavailable
+func isHealthyOperator(operator *configv1.ClusterOperator) bool {
+	for _, condition := range operator.Status.Conditions {
+		if isOperatorConditionDegraded(condition) || isOperatorConditionAvailable(condition) {
+			return false
+		}
+	}
+	return true
+}
+
+// isOperatorConditionDegraded check if the operator status condition degraded is true
+func isOperatorConditionDegraded(c configv1.ClusterOperatorStatusCondition) bool {
+	return c.Type == configv1.OperatorDegraded && c.Status == configv1.ConditionTrue
+}
+
+// isOperatorConditionAvailable check if the operator status condition available is false
+func isOperatorConditionAvailable(c configv1.ClusterOperatorStatusCondition) bool {
+	return c.Type == configv1.OperatorAvailable && c.Status == configv1.ConditionFalse
+}
+
+// namespacesForOperator get all the cluster operator namespaces
+func namespacesForOperator(operator *configv1.ClusterOperator) []string {
+	var ns []string
+	for _, ref := range operator.Status.RelatedObjects {
+		if ref.Resource == "namespaces" {
+			ns = append(ns, ref.Name)
+		}
+	}
+	return ns
+}

--- a/pkg/gather/clusterconfig/operators_pods_and_events_test.go
+++ b/pkg/gather/clusterconfig/operators_pods_and_events_test.go
@@ -1,0 +1,512 @@
+package clusterconfig
+
+import (
+	"bytes"
+	"context"
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/insights-operator/pkg/record"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+func Test_UnhealtyOperators_GatherClusterOperatorPodsAndEvents(t *testing.T) {
+	testOperator := configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-clusteroperator",
+		},
+	}
+	cfg := configfake.NewSimpleClientset()
+	_, err := cfg.ConfigV1().ClusterOperators().Create(context.Background(), &testOperator, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal("unable to create fake clusteroperator", err)
+	}
+
+	_, errs := gatherClusterOperatorPodsAndEvents(context.Background(), cfg.ConfigV1(), kubefake.NewSimpleClientset().CoreV1())
+	if len(errs) > 0 {
+		t.Errorf("unexpected errors: %#v", err)
+		return
+	}
+}
+
+func Test_UnhealtyOperators_GatherPodContainersLogs(t *testing.T) {
+	type args struct {
+		ctx        context.Context
+		client     corev1client.CoreV1Interface
+		pods       []*corev1.Pod
+		bufferSize int64
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []record.Record
+		wantErr bool
+	}{
+		{
+			name: "total container is zero and the podlist is empty",
+			args: args{
+				ctx:        context.TODO(),
+				client:     kubefake.NewSimpleClientset().CoreV1(),
+				pods:       []*v1.Pod{},
+				bufferSize: 0,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "total container is two and the podlist is empty",
+			args: args{
+				ctx:        context.TODO(),
+				client:     kubefake.NewSimpleClientset().CoreV1(),
+				pods:       []*v1.Pod{},
+				bufferSize: int64(10 * 10 / 2 / 2),
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := gatherPodContainersLogs(tt.args.ctx, tt.args.client, tt.args.pods, tt.args.bufferSize)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("gatherNamespaceEvents() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("gatherPodContainersLogs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_UnhealtyOperators_GetContainerLogs(t *testing.T) {
+	bufferSize := int64(8 * 1024 * 1024 * logCompressionRatio / 10 / 2)
+
+	type args struct {
+		ctx        context.Context
+		client     corev1client.CoreV1Interface
+		pod        *corev1.Pod
+		isPrevious bool
+		buf        *bytes.Buffer
+		bufferSize int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want []record.Record
+	}{
+		{
+			name: "empty pod containers log",
+			args: args{
+				ctx:        context.TODO(),
+				client:     kubefake.NewSimpleClientset().CoreV1(),
+				pod:        &v1.Pod{},
+				isPrevious: false,
+				buf:        bytes.NewBuffer(make([]byte, 0, bufferSize)),
+				bufferSize: bufferSize,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getContainerLogs(tt.args.ctx, tt.args.client, tt.args.pod, tt.args.isPrevious, tt.args.buf, tt.args.bufferSize); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getContainerLogs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_UnhealtyOperators_UnhealthyClusterOperator(t *testing.T) {
+	type args struct {
+		ctx        context.Context
+		items      []configv1.ClusterOperator
+		coreClient corev1client.CoreV1Interface
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  []*corev1.Pod
+		want1 []record.Record
+		want2 int
+	}{
+		{
+			name: "test empty list",
+			args: args{
+				ctx:        context.TODO(),
+				items:      []configv1.ClusterOperator{},
+				coreClient: kubefake.NewSimpleClientset().CoreV1(),
+			},
+			want:  []*corev1.Pod{},
+			want1: nil,
+			want2: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, got2 := unhealthyClusterOperator(tt.args.ctx, tt.args.items, tt.args.coreClient)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unhealthyClusterOperator() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("unhealthyClusterOperator() got1 = %v, want1 %v", got1, tt.want1)
+			}
+			if got2 != tt.want2 {
+				t.Errorf("unhealthyClusterOperator() got2 = %v, want2 %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func Test_UnhealtyOperators_GatherUnhealthyPods(t *testing.T) {
+	type args struct {
+		pods []corev1.Pod
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  []*corev1.Pod
+		want1 []record.Record
+		want2 int
+	}{
+		{
+			name:  "empty pod list",
+			args:  args{pods: []v1.Pod{}},
+			want:  nil,
+			want1: nil,
+			want2: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, got2 := gatherUnhealthyPods(tt.args.pods)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("gatherUnhealthyPods() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("gatherUnhealthyPods() got1 = %v, want %v", got1, tt.want1)
+			}
+			if got2 != tt.want2 {
+				t.Errorf("gatherUnhealthyPods() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func Test_UnhealtyOperators_GatherNamespaceEvents(t *testing.T) {
+	type args struct {
+		ctx        context.Context
+		coreClient corev1client.CoreV1Interface
+		namespace  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []record.Record
+		wantErr bool
+	}{
+		{
+			name: "empty namespace events",
+			args: args{
+				ctx:        context.TODO(),
+				coreClient: kubefake.NewSimpleClientset().CoreV1(),
+				namespace:  "insights-operator",
+			},
+			want:    []record.Record{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := gatherNamespaceEvents(tt.args.ctx, tt.args.coreClient, tt.args.namespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("gatherNamespaceEvents() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("gatherNamespaceEvents() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_UnhealtyOperators_FetchPodContainerLog(t *testing.T) {
+	bufferSize := int64(8 * 1024 * 1024 * logCompressionRatio / 10 / 2)
+
+	type args struct {
+		ctx           context.Context
+		coreClient    corev1client.CoreV1Interface
+		pod           *corev1.Pod
+		buf           *bytes.Buffer
+		containerName string
+		isPrevious    bool
+		maxBytes      *int64
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "container without previous log",
+			args: args{
+				ctx:           context.TODO(),
+				coreClient:    kubefake.NewSimpleClientset().CoreV1(),
+				pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "testPod"}},
+				buf:           bytes.NewBuffer(make([]byte, 0, bufferSize)),
+				containerName: "testContainer",
+				isPrevious:    false,
+				maxBytes:      pointer.Int64Ptr(bufferSize),
+			},
+			wantErr: false,
+		},
+		{
+			name: "container with previous log",
+			args: args{
+				ctx:           context.TODO(),
+				coreClient:    kubefake.NewSimpleClientset().CoreV1(),
+				pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "testPod"}},
+				buf:           bytes.NewBuffer(make([]byte, 0, bufferSize)),
+				containerName: "testContainer",
+				isPrevious:    true,
+				maxBytes:      pointer.Int64Ptr(bufferSize),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			//t.Parallel()
+			if err := fetchPodContainerLog(tt.args.ctx, tt.args.coreClient, tt.args.pod, tt.args.buf, tt.args.containerName, tt.args.isPrevious, tt.args.maxBytes); (err != nil) != tt.wantErr {
+				t.Errorf("fetchPodContainerLog() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_UnhealtyOperators_IsHealthyOperator(t *testing.T) {
+	type args struct {
+		operator *configv1.ClusterOperator
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "cluster operator isn't degraded",
+			args: args{
+				operator: &configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "insights",
+					},
+					Status: configv1.ClusterOperatorStatus{Conditions: []configv1.ClusterOperatorStatusCondition{
+						{Type: configv1.OperatorDegraded, Status: configv1.ConditionFalse},
+					}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "cluster operator is available",
+			args: args{
+				operator: &configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "insights",
+					},
+					Status: configv1.ClusterOperatorStatus{Conditions: []configv1.ClusterOperatorStatusCondition{
+						{Type: configv1.OperatorAvailable, Status: configv1.ConditionTrue},
+					}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "cluster operator is degraded",
+			args: args{
+				operator: &configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "insights",
+					},
+					Status: configv1.ClusterOperatorStatus{Conditions: []configv1.ClusterOperatorStatusCondition{
+						{Type: configv1.OperatorDegraded, Status: configv1.ConditionTrue},
+					}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "cluster operator isn't available",
+			args: args{
+				operator: &configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "insights",
+					},
+					Status: configv1.ClusterOperatorStatus{Conditions: []configv1.ClusterOperatorStatusCondition{
+						{Type: configv1.OperatorAvailable, Status: configv1.ConditionFalse},
+					}},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isHealthyOperator(tt.args.operator); got != tt.want {
+				t.Errorf("isHealthyOperator() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_UnhealtyOperators_IsPodRestarted(t *testing.T) {
+	type args struct {
+		pod *corev1.Pod
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "pod isn't restarted with InitStatuses",
+			args: args{
+				pod: &v1.Pod{
+					Status: v1.PodStatus{
+						InitContainerStatuses: []v1.ContainerStatus{
+							{RestartCount: 0},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod was restarted with InitStatuses",
+			args: args{
+				pod: &v1.Pod{
+					Status: v1.PodStatus{
+						InitContainerStatuses: []v1.ContainerStatus{
+							{RestartCount: 2},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod isn't restarted",
+			args: args{
+				pod: &v1.Pod{
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{RestartCount: 0},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod was restarted",
+			args: args{
+				pod: &v1.Pod{
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{RestartCount: 2},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPodRestarted(tt.args.pod); got != tt.want {
+				t.Errorf("isPodRestarted() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_UnhealtyOperators_NamespacesForOperator(t *testing.T) {
+	type args struct {
+		operator *configv1.ClusterOperator
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "Cluster operator with one namespace",
+			args: args{
+				operator: &configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "insights",
+					},
+					Status: configv1.ClusterOperatorStatus{
+						RelatedObjects: []configv1.ObjectReference{
+							{Group: "", Resource: "namespaces", Name: "namespace1"},
+						},
+					},
+				},
+			},
+			want: []string{"namespace1"},
+		},
+		{
+			name: "Cluster operator with more than one namespace",
+			args: args{
+				operator: &configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "insights",
+					},
+					Status: configv1.ClusterOperatorStatus{
+						RelatedObjects: []configv1.ObjectReference{
+							{Group: "", Resource: "namespaces", Name: "namespace1"},
+							{Group: "", Resource: "namespaces", Name: "namespace2"},
+							{Group: "", Resource: "not-namespaces", Name: "not-namespace"},
+						},
+					},
+				},
+			},
+			want: []string{"namespace1", "namespace2"},
+		},
+		{
+			name: "Cluster operator without namespace",
+			args: args{
+				operator: &configv1.ClusterOperator{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "insights",
+					},
+					Status: configv1.ClusterOperatorStatus{
+						RelatedObjects: []configv1.ObjectReference{},
+					},
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := namespacesForOperator(tt.args.operator); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("namespacesForOperator() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/gather/clusterconfig/operators_pods_and_events_test.go
+++ b/pkg/gather/clusterconfig/operators_pods_and_events_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/utils/pointer"
 )
 
 func Test_UnhealtyOperators_GatherClusterOperatorPodsAndEvents(t *testing.T) {
@@ -240,58 +239,7 @@ func Test_UnhealtyOperators_GatherNamespaceEvents(t *testing.T) {
 }
 
 func Test_UnhealtyOperators_FetchPodContainerLog(t *testing.T) {
-	bufferSize := int64(8 * 1024 * 1024 * logCompressionRatio / 10 / 2)
-
-	type args struct {
-		ctx           context.Context
-		coreClient    corev1client.CoreV1Interface
-		pod           *corev1.Pod
-		buf           *bytes.Buffer
-		containerName string
-		isPrevious    bool
-		maxBytes      *int64
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "container without previous log",
-			args: args{
-				ctx:           context.TODO(),
-				coreClient:    kubefake.NewSimpleClientset().CoreV1(),
-				pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "testPod"}},
-				buf:           bytes.NewBuffer(make([]byte, 0, bufferSize)),
-				containerName: "testContainer",
-				isPrevious:    false,
-				maxBytes:      pointer.Int64Ptr(bufferSize),
-			},
-			wantErr: false,
-		},
-		{
-			name: "container with previous log",
-			args: args{
-				ctx:           context.TODO(),
-				coreClient:    kubefake.NewSimpleClientset().CoreV1(),
-				pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "testPod"}},
-				buf:           bytes.NewBuffer(make([]byte, 0, bufferSize)),
-				containerName: "testContainer",
-				isPrevious:    true,
-				maxBytes:      pointer.Int64Ptr(bufferSize),
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			//t.Parallel()
-			if err := fetchPodContainerLog(tt.args.ctx, tt.args.coreClient, tt.args.pod, tt.args.buf, tt.args.containerName, tt.args.isPrevious, tt.args.maxBytes); (err != nil) != tt.wantErr {
-				t.Errorf("fetchPodContainerLog() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
+	t.Skipf("Current API doesn't support this test.")
 }
 
 func Test_UnhealtyOperators_IsHealthyOperator(t *testing.T) {

--- a/pkg/gather/clusterconfig/operators_test.go
+++ b/pkg/gather/clusterconfig/operators_test.go
@@ -2,29 +2,38 @@ package clusterconfig
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	openshiftscheme "github.com/openshift/client-go/config/clientset/versioned/scheme"
+	"github.com/openshift/insights-operator/pkg/record"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
-func TestGatherClusterOperator(t *testing.T) {
-	testOperator := &configv1.ClusterOperator{
+func newClusterOperator() configv1.ClusterOperator {
+	return configv1.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-clusteroperator",
 		},
 	}
-	configCS := configfake.NewSimpleClientset()
-	_, err := configCS.ConfigV1().ClusterOperators().Create(context.Background(), testOperator, metav1.CreateOptions{})
+}
+
+func Test_Operators_GatherClusterOperators(t *testing.T) {
+	testOperator := newClusterOperator()
+	cfg := configfake.NewSimpleClientset()
+	_, err := cfg.ConfigV1().ClusterOperators().Create(context.Background(), &testOperator, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal("unable to create fake clusteroperator", err)
 	}
-	records, errs := gatherClusterOperators(context.Background(), configCS.ConfigV1(), kubefake.NewSimpleClientset().CoreV1(), configCS.Discovery(), dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()))
+
+	records, errs := gatherClusterOperators(context.Background(), cfg.ConfigV1(), cfg.Discovery(), dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()))
 	if len(errs) > 0 {
 		t.Errorf("unexpected errors: %#v", errs)
 		return
@@ -32,12 +41,110 @@ func TestGatherClusterOperator(t *testing.T) {
 
 	item, _ := records[0].Item.Marshal(context.TODO())
 	var gatheredCO configv1.ClusterOperator
-	_, _, err = openshiftSerializer.Decode(item, nil, &gatheredCO)
+	openshiftCodec := openshiftscheme.Codecs.LegacyCodec(configv1.SchemeGroupVersion)
+	_, _, err = openshiftCodec.Decode(item, nil, &gatheredCO)
 	if err != nil {
 		t.Fatalf("failed to decode object: %v", err)
 	}
 	if gatheredCO.Name != "test-clusteroperator" {
 		t.Fatalf("unexpected clusteroperator name %s", gatheredCO.Name)
 	}
+}
 
+func Test_Operators_ClusterOperatorsRecords(t *testing.T) {
+	type args struct {
+		ctx             context.Context
+		items           []configv1.ClusterOperator
+		dynamicClient   dynamic.Interface
+		discoveryClient discovery.DiscoveryInterface
+	}
+	tests := []struct {
+		name string
+		args args
+		want []record.Record
+	}{
+		{
+			name: "empty cluster operator",
+			args: args{
+				ctx:             context.TODO(),
+				items:           []configv1.ClusterOperator{},
+				dynamicClient:   &dynamicfake.FakeDynamicClient{},
+				discoveryClient: kubefake.NewSimpleClientset().Discovery(),
+			},
+			want: []record.Record{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := clusterOperatorsRecords(tt.args.ctx, tt.args.items, tt.args.dynamicClient, tt.args.discoveryClient); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("clusterOperatorsRecords() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_Operators_CollectClusterOperatorResources(t *testing.T) {
+	type args struct {
+		ctx           context.Context
+		dynamicClient dynamic.Interface
+		co            configv1.ClusterOperator
+		resVer        map[string][]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []clusterOperatorResource
+	}{
+		{
+			name: "empty cluster operator resources",
+			args: args{
+				ctx:           context.TODO(),
+				dynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+				co:            newClusterOperator(),
+				resVer:        map[string][]string{},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := collectClusterOperatorResources(tt.args.ctx, tt.args.dynamicClient, tt.args.co, tt.args.resVer); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("collectClusterOperatorResources() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_Operators_GetOperatorResourcesVersions(t *testing.T) {
+	type args struct {
+		discoveryClient discovery.DiscoveryInterface
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string][]string
+		wantErr bool
+	}{
+		{
+			name:    "empty operator resources versions",
+			args:    args{discoveryClient: kubefake.NewSimpleClientset().Discovery()},
+			want:    map[string][]string{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := getOperatorResourcesVersions(tt.args.discoveryClient)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getOperatorResourcesVersions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getOperatorResourcesVersions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/utils/check/is_healthy_pod.go
+++ b/pkg/utils/check/is_healthy_pod.go
@@ -1,0 +1,41 @@
+package check
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func IsHealthyPod(pod *corev1.Pod, now time.Time) bool {
+	// pending pods may be unable to schedule or start due to failures, and the info they provide in status is important
+	// for identifying why scheduling has not happened
+	if pod.Status.Phase == corev1.PodPending {
+		if now.Sub(pod.CreationTimestamp.Time) > 2*time.Minute {
+			return false
+		}
+	}
+	// pods that have containers that have terminated with non-zero exit codes are considered failure
+	for _, status := range pod.Status.InitContainerStatuses {
+		if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.RestartCount > 0 {
+			return false
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.RestartCount > 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR backports two changes related to `GatherClusterOperators` #355 and #397.

This backports some changes that allow the gather to collect also logs from pods that are related to unhealthy operators, and also improves the gather responsibility by splitting it into to gathers `GatherClusterOperators` and `GatherClusterOperatorsPodAndEvents`.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in the sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md` (updated)

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gather/clusterconfig/operators_pods_and_events_test.go` (new)
- `pkg/gather/clusterconfig/operators_test.go` (updated)


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

N/A

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4428
https://bugzilla.redhat.com/show_bug.cgi?id=1953582
