### PR TITLE
Bug 1955102: Add vsphere_node_hw_version_total metric to the collected metrics

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -306,6 +306,7 @@ The GET REST query to URL /federate
 Gathered metrics:
   etcd_object_counts
   cluster_installer
+  vsphere_node_hw_version_total
   namespace CPU and memory usage
   followed by at most 1000 lines of ALERTS metric
 

--- a/docs/insights-archive-sample/config/metrics
+++ b/docs/insights-archive-sample/config/metrics
@@ -436,6 +436,8 @@ namespace:container_memory_usage_bytes:sum{namespace="openshift-network-operator
 namespace:container_memory_usage_bytes:sum{namespace="openshift-config-operator",instance="",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-1"} 5.3141504e+07 1612793316662
 namespace:container_memory_usage_bytes:sum{namespace="openshift-controller-manager",instance="",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-1"} 1.24739584e+08 1612793316662
 namespace:container_memory_usage_bytes:sum{namespace="openshift-etcd-operator",instance="",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-1"} 1.19230464e+08 1612793316662
+# TYPE vsphere_node_hw_version_total untyped
+vsphere_node_hw_version_total{container="vsphere-problem-detector-operator",endpoint="vsphere-metrics",hw_version="vmx-13",instance="10.128.0.25:8444",job="vsphere-problem-detector-metrics",namespace="openshift-cluster-storage-operator",pod="vsphere-problem-detector-operator-7f746856d4-78lnn",service="vsphere-problem-detector-metrics",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-0"} 6 1619708403480
 # ALERTS 16/1000
 # TYPE ALERTS untyped
 ALERTS{alertname="Watchdog",alertstate="firing",severity="none",instance="",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-1"} 1 1612793310163

--- a/pkg/gather/clusterconfig/recent_metrics.go
+++ b/pkg/gather/clusterconfig/recent_metrics.go
@@ -57,6 +57,7 @@ func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) 
 		Param("match[]", "cluster_installer").
 		Param("match[]", "namespace:container_cpu_usage_seconds_total:sum_rate").
 		Param("match[]", "namespace:container_memory_usage_bytes:sum").
+		Param("match[]", "vsphere_node_hw_version_total").
 		DoRaw(ctx)
 	if err != nil {
 		klog.Errorf("Unable to retrieve most recent metrics: %v", err)

--- a/pkg/gather/clusterconfig/recent_metrics.go
+++ b/pkg/gather/clusterconfig/recent_metrics.go
@@ -28,6 +28,7 @@ const (
 // Gathered metrics:
 //   etcd_object_counts
 //   cluster_installer
+//   vsphere_node_hw_version_total
 //   namespace CPU and memory usage
 //   followed by at most 1000 lines of ALERTS metric
 //


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Add vsphere_node_hw_version_total metric to the collected metrics

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/metrics` was updated

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md` was updated

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- not necessary

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4623