### PR TITLE
[release 4.7] Bug 1955476: Add vsphere_node_hw_version_total metric

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -265,6 +265,7 @@ The GET REST query to URL /federate
 Gathered metrics:
   etcd_object_counts
   cluster_installer
+  vsphere_node_hw_version_total
   namespace CPU and memory usage
   followed by at most 1000 lines of ALERTS metric
 

--- a/docs/insights-archive-sample/config/metrics
+++ b/docs/insights-archive-sample/config/metrics
@@ -2,6 +2,8 @@
 ALERTS{alertname="AlertmanagerReceiversNotConfigured",alertstate="firing",severity="warning",instance="",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-1"} 1 1592829366662
 ALERTS{alertname="ImagePruningDisabled",alertstate="firing",endpoint="60000",instance="10.129.0.33:60000",job="image-registry-operator",namespace="openshift-image-registry",pod="cluster-image-registry-operator-5b4d9c55f-jlrdf",service="image-registry-operator",severity="warning",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-1"} 1 1592829368020
 ALERTS{alertname="Watchdog",alertstate="firing",severity="none",instance="",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-1"} 1 1592829360163
+# TYPE vsphere_node_hw_version_total untyped
+vsphere_node_hw_version_total{container="vsphere-problem-detector-operator",endpoint="vsphere-metrics",hw_version="vmx-13",instance="10.128.0.25:8444",job="vsphere-problem-detector-metrics",namespace="openshift-cluster-storage-operator",pod="vsphere-problem-detector-operator-7f746856d4-78lnn",service="vsphere-problem-detector-metrics",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-0"} 6 1619708403480
 # TYPE cluster_installer untyped
 cluster_installer{endpoint="metrics",instance="10.0.0.4:9099",invoker="openshift-internal-ci/release-openshift-origin-installer-launch-gcp/1275022284997791744",job="cluster-version-operator",namespace="openshift-cluster-version",pod="cluster-version-operator-5f7b8d89b5-t9cdr",service="cluster-version-operator",type="openshift-install",version="v4.4.0",prometheus="openshift-monitoring/k8s",prometheus_replica="prometheus-k8s-1"} 1 1592829361218
 # TYPE etcd_object_counts untyped

--- a/pkg/gather/clusterconfig/recent_metrics.go
+++ b/pkg/gather/clusterconfig/recent_metrics.go
@@ -26,6 +26,7 @@ const (
 // Gathered metrics:
 //   etcd_object_counts
 //   cluster_installer
+//   vsphere_node_hw_version_total
 //   namespace CPU and memory usage
 //   followed by at most 1000 lines of ALERTS metric
 //
@@ -55,6 +56,7 @@ func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) 
 		Param("match[]", "cluster_installer").
 		Param("match[]", "namespace:container_cpu_usage_seconds_total:sum_rate").
 		Param("match[]", "namespace:container_memory_usage_bytes:sum").
+		Param("match[]", "vsphere_node_hw_version_total").
 		DoRaw(ctx)
 	if err != nil {
 		// write metrics errors to the file format as a comment


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Add vsphere_node_hw_version_total metric

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/metrics`  updated

## Documentation
<!-- Are these changes reflected in documentation? -->

- `gahtered-data.md` updated

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4631
