### PR TITLE
Bug 1958790: Store translation table in a secret

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -179,7 +179,7 @@ rules:
   verbs:
     - get
     - list
-    - watch 
+    - watch
 - apiGroups:
     - operators.coreos.com
   resources:
@@ -213,6 +213,38 @@ subjects:
 - kind: ServiceAccount
   namespace: openshift-insights
   name: gather
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: insights-operator-obfuscation-secret
+  namespace: openshift-insights
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: insights-operator-obfuscation-secret
+  namespace: openshift-insights
+roleRef:
+  kind: Role
+  name: insights-operator-obfuscation-secret
+subjects:
+- kind: ServiceAccount
+  name: gather
+  namespace: openshift-insights
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/anonymization/anonymizer.go
+++ b/pkg/anonymization/anonymizer.go
@@ -263,8 +263,7 @@ func (anonymizer *Anonymizer) ObfuscateIP(ipStr string) string {
 }
 
 // Stores the translation table in a Secret in the openshift-insights namespace.
-// The actual data is stored in the StringData protion of the Secret.
-// Uses the Apply mechanism so it creates the secret if not present or updates it when present.
+// The actual data is stored in the StringData portion of the Secret.
 func (anonymizer *Anonymizer) StoreTranslationTable() *corev1.Secret {
 	if len(anonymizer.translationTable) == 0 {
 		return nil

--- a/pkg/anonymization/anonymizer.go
+++ b/pkg/anonymization/anonymizer.go
@@ -55,7 +55,7 @@ const (
 )
 
 var (
-	TranslationTableSecretName = "translation"
+	TranslationTableSecretName = "obfuscation-translation-table" //nolint: gosec
 	secretAPIVersion           = "v1"
 	secretKind                 = "Secret"
 )
@@ -288,6 +288,7 @@ func (anonymizer *Anonymizer) StoreTranslationTable() *corev1.Secret {
 	result, err := anonymizer.secretsClient.Apply(context.TODO(), secret, applyOptions)
 	if err != nil {
 		klog.Errorf("Failed to create/update the translation table secret. err: %s", err)
+		return nil
 	}
 	return result
 }

--- a/pkg/anonymization/anonymizer.go
+++ b/pkg/anonymization/anonymizer.go
@@ -54,7 +54,11 @@ const (
 		"some data won't be anonymized(ipv4 and cluster base domain). The error is %v"
 )
 
-var TranslationTableSecretName = "IO-trTable"
+var (
+	TranslationTableSecretName = "translation"
+	secretAPIVersion           = "v1"
+	secretKind                 = "Secret"
+)
 
 type subnetInformation struct {
 	network net.IPNet
@@ -266,6 +270,10 @@ func (anonymizer *Anonymizer) StoreTranslationTable() *corev1.Secret {
 	defer anonymizer.ResetTranslationTable()
 
 	secret := &applycorev1.SecretApplyConfiguration{
+		TypeMetaApplyConfiguration: applymetav1.TypeMetaApplyConfiguration{
+			Kind:       &secretKind,
+			APIVersion: &secretAPIVersion,
+		},
 		ObjectMetaApplyConfiguration: &applymetav1.ObjectMetaApplyConfiguration{
 			Name: &TranslationTableSecretName,
 		},

--- a/pkg/anonymization/anonymizer_test.go
+++ b/pkg/anonymization/anonymizer_test.go
@@ -1,12 +1,18 @@
 package anonymization
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/stretchr/testify/assert"
 	kubefake "k8s.io/client-go/kubernetes/fake"
+	corefake "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	clienttesting "k8s.io/client-go/testing"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )
@@ -108,8 +114,7 @@ func getAnonymizer(t *testing.T) *Anonymizer {
 		"127.0.0.0/8",
 		"192.168.0.0/16",
 	}
-
-	anonymizer, err := NewAnonymizer(clusterBaseDomain, networks, kubefake.NewSimpleClientset().CoreV1().Secrets("test"))
+	anonymizer, err := NewAnonymizer(clusterBaseDomain, networks, kubefake.NewSimpleClientset().CoreV1().Secrets(secretNamespace))
 	assert.NoError(t, err)
 
 	return anonymizer
@@ -191,4 +196,50 @@ func Test_Anonymizer_TranslationTableTest(t *testing.T) {
 	}).Data)
 
 	assert.Equal(t, "192.168.1.1", obfuscatedData)
+
+	assert.Equal(t, 257, len(anonymizer.translationTable))
+	anonymizer.ResetTranslationTable()
+	assert.Equal(t, 0, len(anonymizer.translationTable))
+}
+
+func Test_Anonymizer_StoreTranslationTable(t *testing.T) {
+	anonymizer := getAnonymizer(t)
+
+	// Empty translation table == No call made to
+	assert.Nil(t, anonymizer.StoreTranslationTable())
+
+	// Mock the client to react/check Apply calls
+	kube := kubefake.Clientset{}
+	client := kube.CoreV1().Secrets(secretNamespace)
+	client.(*corefake.FakeSecrets).Fake.AddReactor("patch", "secrets",
+		func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+			if patchAction, ok := action.(clienttesting.PatchAction); ok {
+				assert.Equal(t, secretNamespace, patchAction.GetNamespace())
+				assert.Contains(t, patchAction.GetPatchType(), "apply")
+				assert.Equal(t, secretAPIVersion, patchAction.GetResource().Version)
+				var secret corev1.Secret
+				err := json.Unmarshal(patchAction.GetPatch(), &secret)
+				if err != nil {
+					t.Errorf("Failed to unmarshal sent Secret, err: %s", err)
+				}
+				return true, &secret, nil
+			}
+			t.Errorf("Incorrect action, expected patch got %s", action)
+			return false, nil, nil
+		})
+	anonymizer.secretsClient = client
+
+	// Fill translation table
+	for i := 0; i < 10; i++ {
+		obfuscatedData := string(anonymizer.AnonymizeMemoryRecord(&record.MemoryRecord{
+			Data: []byte(fmt.Sprintf("192.168.0.%v", 255-i)),
+		}).Data)
+
+		assert.Equal(t, fmt.Sprintf("192.168.0.%v", i+1), obfuscatedData)
+	}
+	// Store translation table, then check
+	secret := anonymizer.StoreTranslationTable()
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, secret.StringData[fmt.Sprintf("192.168.0.%v", 255-i)], fmt.Sprintf("192.168.0.%v", i+1))
+	}
 }

--- a/pkg/anonymization/anonymizer_test.go
+++ b/pkg/anonymization/anonymizer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openshift/insights-operator/pkg/record"
 )
@@ -108,7 +109,7 @@ func getAnonymizer(t *testing.T) *Anonymizer {
 		"192.168.0.0/16",
 	}
 
-	anonymizer, err := NewAnonymizer(clusterBaseDomain, networks)
+	anonymizer, err := NewAnonymizer(clusterBaseDomain, networks, kubefake.NewSimpleClientset().CoreV1().Secrets("test"))
 	assert.NoError(t, err)
 
 	return anonymizer

--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -184,7 +184,7 @@ func Test_StartGatheringConcurrently(t *testing.T) {
 		},
 	})
 
-	resultsChan, _ = startGatheringConcurrently(context.Background(), gatherer, []string{
+	resultsChan, err = startGatheringConcurrently(context.Background(), gatherer, []string{
 		"mock_gatherer/name",
 		"mock_gatherer/3_records",
 	})

--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -184,7 +184,7 @@ func Test_StartGatheringConcurrently(t *testing.T) {
 		},
 	})
 
-	resultsChan, err = startGatheringConcurrently(context.Background(), gatherer, []string{
+	resultsChan, _ = startGatheringConcurrently(context.Background(), gatherer, []string{
 		"mock_gatherer/name",
 		"mock_gatherer/3_records",
 	})
@@ -251,7 +251,7 @@ func Test_CollectAndRecord(t *testing.T) {
 		Gather:                  []string{AllGatherersConst},
 		EnableGlobalObfuscation: true,
 	}}
-	anonymizer, err := anonymization.NewAnonymizer("", nil)
+	anonymizer, err := anonymization.NewAnonymizer("", nil, nil)
 	assert.NoError(t, err)
 
 	functionReports, err := CollectAndRecordGatherer(context.Background(), gatherer, mockRecorder, mockConfigurator)

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -92,6 +92,9 @@ func (r *Recorder) Record(rec record.Record) error {
 
 // Flush and save the reports using recorder driver
 func (r *Recorder) Flush() error {
+	if r.anonymizer != nil {
+		defer r.anonymizer.StoreTranslationTable()
+	}
 	records := r.copy()
 	if len(records) == 0 {
 		return nil

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -62,7 +62,7 @@ func newRecorder(maxArchiveSize int64) Recorder {
 	driver := driverMock{}
 	driver.On("Save").Return(nil, nil)
 
-	anonymizer, _ := anonymization.NewAnonymizer("", nil)
+	anonymizer, _ := anonymization.NewAnonymizer("", nil, nil)
 
 	interval, _ := time.ParseDuration("1m")
 	return Recorder{


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
The anonymizer has a translation-table about the obfuscated IP addresses. As of right now its inaccessible, so this change would store the  translation-table in a `Secret` in the `openshift-insights` namespace.
On the Web UI you can easily find the secrets under `Workloads` -> `Secrets`, the name of the secret is `obfuscation-translation-table`.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

- no

## Documentation
<!-- Are these changes reflected in documentation? -->

- Added docstrings, user facing documentation is a separate task.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- Added new unit tests to `pkg/anonymization/anonymizer_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->


## References
<!-- What are related references for this PR? -->

