### PR TITLE
Bug 1957889: Improves documentation of GatherClusterOperatorPodsAndEvents

### DIFF
--- a/pkg/gather/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gather/clusterconfig/operators_pods_and_events.go
@@ -37,14 +37,19 @@ type CompactedEventList struct {
 	Items []CompactedEvent `json:"items"`
 }
 
-// GatherClusterOperatorPodsAndEvents collects all the ClusterOperators degraded Pods
-// for degraded cluster operators or that lives at the Cluster Operator's namespace, to collect:
+// GatherClusterOperatorPodsAndEvents collects information about all pods
+// and events from namespaces of degraded cluster operators. The collected
+// information includes:
 //
 // - Pod definitions
-// - Previous and current Pod Container logs (when available)
-// - Namespace Events
+// - Previous and current logs of pod containers (when available)
+// - Namespace events
 //
-// * Location of pods in archive: config/pod/
+// * Location of pod definitions: config/pod/{namespace}/{pod}.json
+// * Location of pod container current logs:
+//   config/pod/{namespace}/logs/{pod}/{container}_current.log
+// * Location of pod container previous logs:
+//   config/pod/{namespace}/logs/{pod}/{container}_previous.log
 // * Location of events in archive: events/
 // * Id in config: operators_pods_and_events
 func GatherClusterOperatorPodsAndEvents(g *Gatherer, c chan<- gatherResult) {


### PR DESCRIPTION

<!-- Short description of the PR. What does it do? -->
This PR improves documentation of GatherClusterOperatorPodsAndEvents:
- Improves wording to make it clear what is collected and when.
- Lists locations of individual data points so that users know where to
  look for the data even if they don't have a sample archive with the
  data (e.g. when starting an extraction notebook).


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

I need your help here. Is it preferred to update `gathered-data.md` with this type of changes or you do it once in a while? I didn't include an updated version of `gathered-data.md` because it included changes that I didn't do...

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

N/A

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

No.

## References
<!-- What are related references for this PR? -->

https://coreos.slack.com/archives/CLABA9CHY/p1620223118250600?thread_ts=1620212876.245500&cid=CLABA9CHY
