### PR TITLE
Bug 1961067: Collect full pod log for stack traces

### DIFF
--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -21,6 +21,8 @@ var (
 	registryScheme = runtime.NewScheme()
 	// logTailLines sets maximum number of lines to fetch from pod logs
 	logTailLines = int64(100)
+	// logTailLinesLong sets the maximum number of lines to fetch from long pod logs
+	logTailLinesLong = int64(400)
 
 	defaultNamespaces           = []string{"default", "kube-system", "kube-public"}
 	datahubGroupVersionResource = schema.GroupVersionResource{

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events_test.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events_test.go
@@ -121,8 +121,7 @@ func Test_UnhealtyOperators_GetContainerLogs(t *testing.T) {
 				tt.args.client,
 				tt.args.pod,
 				tt.args.isPrevious,
-				tt.args.buf,
-				tt.args.bufferSize); !reflect.DeepEqual(got, tt.want) {
+				tt.args.buf); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getContainerLogs() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR adds the capability to collect full container logs if the partial log contains possible stack traces.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample archive
<!-- Are these changes reflected in sample archive? -->

None.

## Documentation
<!-- Are these changes reflected in documentation? -->

None.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/operators_pods_and_events_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

None.

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4600
https://bugzilla.redhat.com/show_bug.cgi?id=1961067
