### PR TITLE
Bug 1961701: Change event gathering interval

### DIFF
--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -209,6 +209,10 @@ func gatherNamespaceEvents(ctx context.Context, coreClient corev1client.CoreV1In
 	sort.Slice(compactedEvents.Items, func(i, j int) bool {
 		return compactedEvents.Items[i].LastTimestamp.Before(compactedEvents.Items[j].LastTimestamp)
 	})
+
+	if len(compactedEvents.Items) == 0 {
+		return nil, nil
+	}
 	return []record.Record{{Name: fmt.Sprintf("events/%s", namespace), Item: record.JSONMarshaller{Object: &compactedEvents}}}, nil
 }
 

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -188,12 +188,13 @@ func gatherNamespaceEvents(ctx context.Context, coreClient corev1client.CoreV1In
 		return nil, err
 	}
 	// filter the event list to only recent events
-	oldestEventTime := time.Now().Add(-maxEventTimeInterval)
+	oldestEventTime := time.Now().Add(-maxEventTimeInterval * 2)
 	var filteredEventIndex []int
 	for i := range events.Items {
 		if events.Items[i].LastTimestamp.Time.Before(oldestEventTime) {
 			continue
 		}
+
 		filteredEventIndex = append(filteredEventIndex, i)
 	}
 	compactedEvents := CompactedEventList{Items: make([]CompactedEvent, len(filteredEventIndex))}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR changes the event gathering interval. It is now 2 times the gatherer's interval. It means that it should collect events that happened in the last 2 hours from the gatherer execution.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in the sample archive? -->

No

## Documentation
<!-- Are these changes reflected in documentation? -->

No

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

N/A

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using the operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4621
https://bugzilla.redhat.com/show_bug.cgi?id=1961701