### PR TITLE
Bug 1962095: Replace gather-job image without FQDN

### DIFF
--- a/docs/gather-job.yaml
+++ b/docs/gather-job.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: insights-operator
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   ttlSecondsAfterFinished: 600
   template:
     spec:
@@ -56,7 +56,7 @@ spec:
         - --config=/etc/insights-operator/server.yaml
       containers:
         - name: sleepy
-          image: busybox
+          image: quay.io/openshift/origin-base:latest
           args:
             - /bin/sh
             - -c


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR replaces the previous image without FQDN used by the gather-job.
If you need to test it, the instructions for it can be found [here](https://github.com/openshift/insights-operator/pull/389).

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

N/A

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

N/A

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

N/A

## Changelog
<!-- Was changelog updated? -->

N/A

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4861
https://bugzilla.redhat.com/show_bug.cgi?id=1962095
