### PR TITLE
Bug 1967833: Adds tasks pool to tasks_processing

### DIFF
--- a/pkg/gather/tasks_processing.go
+++ b/pkg/gather/tasks_processing.go
@@ -36,9 +36,14 @@ func HandleTasksConcurrently(ctx context.Context, tasks []Task) chan GatheringFu
 	// run all the tasks in the background and close the channel when they are finished
 	go func() {
 		var wg sync.WaitGroup
-		workerNum := 4 * runtime.NumCPU()
-		klog.V(4).Infof("number of workers: %d", workerNum)
 		tasksChan := make(chan Task)
+
+		// set number of workers according to the CPU, 1 worker per task max
+		workerNum := 4 * runtime.NumCPU()
+		if len(tasks) < workerNum {
+			workerNum = len(tasks)
+		}
+		klog.V(4).Infof("number of workers: %d", workerNum)
 
 		// create workers
 		for i := 0; i < workerNum; i++ {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Adds a task pool in the task_processing.go so that the resource usage doesn't grow linearly with the number of added gatherers.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->
