### PR TITLE
Bug 1961701: Use configured interval as the event time limit & check series if

### DIFF
--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -81,7 +81,7 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	defer rec.Flush()
 
 	gatherers := gather.CreateAllGatherers(
-		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, d.Controller,
+		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, &d.Controller,
 	)
 
 	allFunctionReports := make(map[string]gather.GathererFunctionReport)

--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -81,7 +81,7 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	defer rec.Flush()
 
 	gatherers := gather.CreateAllGatherers(
-		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer,
+		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, d.Controller,
 	)
 
 	allFunctionReports := make(map[string]gather.GathererFunctionReport)

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -122,7 +122,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	// the gatherers are periodically called to collect the data from the cluster
 	// and provide the results for the recorder
 	gatherers := gather.CreateAllGatherers(
-		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer,
+		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, s.Controller,
 	)
 	periodicGather := periodic.New(configObserver, rec, gatherers, anonymizer)
 	statusReporter.AddSources(periodicGather.Sources()...)

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -122,7 +122,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	// the gatherers are periodically called to collect the data from the cluster
 	// and provide the results for the recorder
 	gatherers := gather.CreateAllGatherers(
-		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, s.Controller,
+		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, &s.Controller,
 	)
 	periodicGather := periodic.New(configObserver, rec, gatherers, anonymizer)
 	statusReporter.AddSources(periodicGather.Sources()...)

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -54,7 +54,7 @@ type ArchiveMetadata struct {
 // CreateAllGatherers creates all the gatherers
 func CreateAllGatherers(
 	gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig *rest.Config,
-	anonymizer *anonymization.Anonymizer, controller config.Controller,
+	anonymizer *anonymization.Anonymizer, controller *config.Controller,
 ) []gatherers.Interface {
 	clusterConfigGatherer := clusterconfig.New(
 		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, controller.Interval,

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/insights-operator/pkg/anonymization"
+	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
 	"github.com/openshift/insights-operator/pkg/gatherers"
 	"github.com/openshift/insights-operator/pkg/gatherers/clusterconfig"
@@ -53,10 +54,10 @@ type ArchiveMetadata struct {
 // CreateAllGatherers creates all the gatherers
 func CreateAllGatherers(
 	gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig *rest.Config,
-	anonymizer *anonymization.Anonymizer,
+	anonymizer *anonymization.Anonymizer, controller config.Controller,
 ) []gatherers.Interface {
 	clusterConfigGatherer := clusterconfig.New(
-		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer,
+		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, controller.Interval,
 	)
 	workloadsGatherer := workloads.New(gatherProtoKubeConfig)
 

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -2,6 +2,7 @@ package clusterconfig
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/client-go/rest"
 
@@ -16,6 +17,7 @@ type Gatherer struct {
 	gatherProtoKubeConfig   *rest.Config
 	metricsGatherKubeConfig *rest.Config
 	anonymizer              *anonymization.Anonymizer
+	interval                time.Duration
 }
 
 // gathererFuncPtr is a type for pointers to functions of Gatherer
@@ -85,13 +87,14 @@ var gatheringFunctions = map[string]gatheringFunction{
 
 func New(
 	gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig *rest.Config,
-	anonymizer *anonymization.Anonymizer,
+	anonymizer *anonymization.Anonymizer, interval time.Duration,
 ) *Gatherer {
 	return &Gatherer{
 		gatherKubeConfig:        gatherKubeConfig,
 		gatherProtoKubeConfig:   gatherProtoKubeConfig,
 		metricsGatherKubeConfig: metricsGatherKubeConfig,
 		anonymizer:              anonymizer,
+		interval:                interval,
 	}
 }
 

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer_test.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer_test.go
@@ -2,6 +2,7 @@ package clusterconfig_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -10,7 +11,7 @@ import (
 )
 
 func Test_Gatherer_Basic(t *testing.T) {
-	gatherer := clusterconfig.New(nil, nil, nil, nil)
+	gatherer := clusterconfig.New(nil, nil, nil, nil, 1*time.Minute)
 	assert.Equal(t, "clusterconfig", gatherer.GetName())
 	gatheringFunctions := gatherer.GetGatheringFunctions()
 	assert.Greater(t, len(gatheringFunctions), 0)

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -1,8 +1,6 @@
 package clusterconfig
 
 import (
-	"time"
-
 	registryv1 "github.com/openshift/api/imageregistry/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -10,10 +8,6 @@ import (
 )
 
 const (
-	// maxEventTimeInterval represents the "only keep events that are maximum 1h old"
-	// TODO: make this dynamic like the reporting window based on configured interval
-	maxEventTimeInterval = 1 * time.Hour
-
 	jsonExtension = "json"
 )
 

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events_test.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
@@ -28,7 +29,7 @@ func Test_UnhealtyOperators_GatherClusterOperatorPodsAndEvents(t *testing.T) {
 		t.Fatal("unable to create fake clusteroperator", err)
 	}
 
-	_, err = gatherClusterOperatorPodsAndEvents(context.Background(), cfg.ConfigV1(), kubefake.NewSimpleClientset().CoreV1())
+	_, err = gatherClusterOperatorPodsAndEvents(context.Background(), cfg.ConfigV1(), kubefake.NewSimpleClientset().CoreV1(), 1*time.Minute)
 	if err != nil {
 		t.Errorf("unexpected errors: %#v", err)
 		return
@@ -155,7 +156,7 @@ func Test_UnhealtyOperators_UnhealthyClusterOperator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2 := unhealthyClusterOperator(tt.args.ctx, tt.args.items, tt.args.coreClient)
+			got, got1, got2 := unhealthyClusterOperator(tt.args.ctx, tt.args.items, tt.args.coreClient, 1*time.Minute)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("unhealthyClusterOperator() got = %v, want %v", got, tt.want)
 			}
@@ -231,7 +232,7 @@ func Test_UnhealtyOperators_GatherNamespaceEvents(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := gatherNamespaceEvents(tt.args.ctx, tt.args.coreClient, tt.args.namespace)
+			got, err := gatherNamespaceEvents(tt.args.ctx, tt.args.coreClient, tt.args.namespace, 1*time.Minute)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("gatherNamespaceEvents() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/gatherers/clusterconfig/version.go
+++ b/pkg/gatherers/clusterconfig/version.go
@@ -43,12 +43,13 @@ func (g *Gatherer) GatherClusterVersion(ctx context.Context) ([]record.Record, [
 		return nil, []error{err}
 	}
 
-	return getClusterVersion(ctx, gatherConfigClient, gatherKubeClient.CoreV1())
+	return getClusterVersion(ctx, gatherConfigClient, gatherKubeClient.CoreV1(), g.interval)
 }
 
 func getClusterVersion(ctx context.Context,
 	configClient configv1client.ConfigV1Interface,
-	coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
+	coreClient corev1client.CoreV1Interface,
+	interval time.Duration) ([]record.Record, []error) {
 	config, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
@@ -99,7 +100,7 @@ func getClusterVersion(ctx context.Context,
 	}
 	klog.V(2).Infof("Found %d unhealthy pods in %s", len(unhealthyPods), namespace)
 
-	namespaceRecords, err := gatherNamespaceEvents(ctx, coreClient, namespace)
+	namespaceRecords, err := gatherNamespaceEvents(ctx, coreClient, namespace, interval)
 	if err != nil {
 		klog.V(2).Infof("Unable to collect events for namespace %q: %#v", namespace, err)
 	}


### PR DESCRIPTION
lastTimeStamp is zero

<!-- Short description of the PR. What does it do? -->
This PR updates the logic of events gathering to use the gathering interval to get the oldest event time and also looks at event series time in case of `lastTimeStamp` being zero.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
