### PR TITLE
Bug 1967595: Fixes the remaining lint issues

### DIFF
--- a/.golangci.precommit.yml
+++ b/.golangci.precommit.yml
@@ -66,10 +66,9 @@ linters:
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    # https://github.com/go-critic/go-critic/issues/926
     - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
+        - lll      
+      source: "^// "
 
 run:
   skip-dirs:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,10 +121,9 @@ linters:
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    # https://github.com/go-critic/go-critic/issues/926
     - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
+        - lll      
+      source: "^// "
 
 run:
   skip-dirs:

--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -24,7 +25,7 @@ const (
 
 var (
 	squashRegexp       = regexp.MustCompile(`(.*)-(\d+)`)
-	mergeRequestRegexp = regexp.MustCompile(`Merge-pull-request-([\d]+)`)
+	mergeRequestRegexp = regexp.MustCompile(`Merge-pull-request-(\d+)`)
 	prefixRegexp       = regexp.MustCompile(`^.+: (.+)`)
 	releaseRegexp      = regexp.MustCompile(`(release-\d\.\d)`)
 	latestHashRegexp   = regexp.MustCompile(`<!--Latest hash: (.+)-->`)
@@ -53,10 +54,10 @@ const gitHubRepoOwner = "openshift"
 const gitHubPath = "https://github.com/openshift/insights-operator"
 
 // API reference: https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
-const gitHubAPIFormat = "https://api.github.com/repos/%s/%s/pulls/%s" //owner, repo, pull-number
+const gitHubAPIFormat = "https://api.github.com/repos/%s/%s/pulls/%s" // owner, repo, pull-number
 
 type Change struct {
-	pullId      string
+	pullID      string
 	hash        string
 	title       string
 	description string
@@ -64,8 +65,8 @@ type Change struct {
 	release     string
 }
 
-func (c Change) toMarkdown() string {
-	return fmt.Sprintf("- [#%s](%s) %s\n", c.pullId, createPullRequestLink(c.pullId), c.title)
+func (c *Change) toMarkdown() string {
+	return fmt.Sprintf("- [#%s](%s) %s\n", c.pullID, createPullRequestLink(c.pullID), c.title)
 }
 
 func createPullRequestLink(id string) string {
@@ -75,7 +76,9 @@ func createPullRequestLink(id string) string {
 func main() {
 	log.SetFlags(0)
 	if len(os.Args) != 1 && len(os.Args) != 3 {
-		log.Fatalf("Either specify two date arguments, AFTER and UNTIL, to create a brand new CHANGELOG, or call it without arguments to update the current one with new changes.")
+		log.Fatalf(`Either specify two date arguments, AFTER and UNTIL, 
+		to create a brand new CHANGELOG, or call it without arguments to 
+		update the current one with new changes.`)
 	}
 	gitHubToken = os.Getenv("GITHUB_TOKEN")
 	if len(gitHubToken) == 0 {
@@ -177,7 +180,8 @@ func updateToMarkdownReleaseBlock(releaseBlocks map[string]MarkdownReleaseBlock,
 func createCHANGELOG(releaseBlocks map[string]MarkdownReleaseBlock) {
 	file, _ := os.Create("CHANGELOG.md")
 	defer file.Close()
-	_, _ = file.WriteString("# Note: This CHANGELOG is only for the changes in insights operator. Please see OpenShift release notes for official changes\n")
+	_, _ = file.WriteString(`# Note: This CHANGELOG is only for the changes in insights operator. 
+	Please see OpenShift release notes for official changes\n`)
 	_, _ = file.WriteString(fmt.Sprintf("<!--Latest hash: %s-->\n", latestHash))
 	var releases []string
 	for k := range releaseBlocks {
@@ -204,14 +208,14 @@ func createCHANGELOG(releaseBlocks map[string]MarkdownReleaseBlock) {
 	}
 }
 
-func createReleaseBlock(file *os.File, release string, title string) {
+func createReleaseBlock(file *os.File, release, title string) {
 	if len(release) > 0 {
 		_, _ = file.WriteString(fmt.Sprintf("### %s\n", title))
 		_, _ = file.WriteString(fmt.Sprintf("%s\n", release))
 	}
 }
 
-func getChanges(pullRequestIds []string, pullRequestHashes []string) []Change {
+func getChanges(pullRequestIds, pullRequestHashes []string) []Change {
 	var changes []Change
 	for i, id := range pullRequestIds {
 		change := getPullRequestFromGitHub(id)
@@ -226,7 +230,7 @@ func getPullRequestFromGitHub(id string) Change {
 	// There is a limit for the GitHub API, if you use auth then its 5000/hour
 	var bearer = "token " + gitHubToken
 
-	req, err := http.NewRequest("GET", fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id), nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id), nil)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
@@ -236,6 +240,7 @@ func getPullRequestFromGitHub(id string) Change {
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalf(err.Error())
@@ -244,7 +249,7 @@ func getPullRequestFromGitHub(id string) Change {
 	_ = json.Unmarshal(body, &jsonMap)
 
 	var ch Change
-	ch.pullId = id
+	ch.pullID = id
 	_ = json.Unmarshal(jsonMap["title"], &ch.title)
 	// Remove nosy prefix
 	if match := prefixRegexp.FindStringSubmatch(ch.title); len(match) > 0 {
@@ -307,8 +312,16 @@ func findEarliestRelease(releases []string) string {
 	return minStr
 }
 
-func timeFrameReverseGitLog(after string, until string) []string {
-	out, err := exec.Command("git", "log", "--topo-order", "--pretty=tformat:%f|%H", "--reverse", fmt.Sprintf("--after=%s", after), fmt.Sprintf("--until=%s", until)).CombinedOutput()
+func timeFrameReverseGitLog(after, until string) []string {
+	// nolint: gosec
+	out, err := exec.Command(
+		"git",
+		"log",
+		"--topo-order",
+		"--pretty=tformat:%f|%H",
+		"--reverse",
+		fmt.Sprintf("--after=%s", after),
+		fmt.Sprintf("--until=%s", until)).CombinedOutput()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -316,14 +329,21 @@ func timeFrameReverseGitLog(after string, until string) []string {
 }
 
 func sinceHashReverseGitLog(hash string) []string {
-	out, err := exec.Command("git", "log", "--topo-order", "--pretty=tformat:%f|%H", "--reverse", fmt.Sprintf("%s..HEAD", hash)).CombinedOutput()
+	// nolint: gosec
+	out, err := exec.Command(
+		"git",
+		"log",
+		"--topo-order",
+		"--pretty=tformat:%f|%H",
+		"--reverse",
+		fmt.Sprintf("%s..HEAD", hash)).CombinedOutput()
 	if err != nil {
 		log.Fatal(err)
 	}
 	return strings.Split(string(out), "\n")
 }
 
-func getPullRequestInfo(gitLog []string) ([]string, []string) {
+func getPullRequestInfo(gitLog []string) (ids, hashes []string) {
 	var pullRequestIds []string
 	var pullRequestHashes []string
 	for _, line := range gitLog {

--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -195,7 +195,7 @@ func findGoMod(pkgFilePath string) (goModPath, relPkgPath string, err error) {
 	dirPath := absPkgFilePath
 	for {
 		goModPath = filepath.Join(dirPath, "go.mod")
-		if _, err := os.Stat(goModPath); os.IsNotExist(err) {
+		if _, err = os.Stat(goModPath); os.IsNotExist(err) {
 			// This directory does not contain a go.mod file. Go to the parent directory.
 			parentDir := filepath.Dir(dirPath)
 			if parentDir == dirPath {
@@ -281,7 +281,7 @@ func execExampleMethod(methodFullPackage, methodPackage, methodName string) (str
 	}
 
 	defer func() {
-		err := os.Remove(f)
+		err = os.Remove(f)
 		if err != nil {
 			fmt.Print(err)
 		}

--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -27,17 +27,15 @@ var (
 	reExample  = regexp.MustCompile(`^(Example)(.*)`)
 )
 
-func init() {
-	flag.StringVar(&inPath, "in", "gatherers", "Package where to find Gather methods")
-	flag.StringVar(&outPath, "out", "gathered-data.md", "File to which MD doc will be generated")
-}
-
 type DocBlock struct {
 	Doc      string
 	Examples map[string]string
 }
 
 func main() {
+	flag.StringVar(&inPath, "in", "gatherers", "Package where to find Gather methods")
+	flag.StringVar(&outPath, "out", "gathered-data.md", "File to which MD doc will be generated")
+
 	flag.Parse()
 	var err error
 	mdf, err = os.Create(outPath)
@@ -100,6 +98,7 @@ func main() {
 	fmt.Println("Done")
 }
 
+// nolint: gocyclo
 func walkDir(cleanRoot string, md map[string]*DocBlock) error {
 	expPath := ""
 	fset := token.NewFileSet() // positions are relative to fset

--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -80,7 +80,7 @@ func main() {
 			for _, e := range md[k].Examples {
 				size = len(e)
 			}
-			size = size / len(md[k].Examples)
+			size /= len(md[k].Examples)
 			_, err := mdf.WriteString(fmt.Sprintf(
 				"Output raw size: %d\n\n"+
 					"### Examples\n\n", size))
@@ -199,7 +199,7 @@ func findGoMod(pkgFilePath string) (goModPath, relPkgPath string, err error) {
 			// This directory does not contain a go.mod file. Go to the parent directory.
 			parentDir := filepath.Dir(dirPath)
 			if parentDir == dirPath {
-				return "", "", fmt.Errorf("There is no go.mod file in the directory tree of %q", pkgFilePath)
+				return "", "", fmt.Errorf("there is no go.mod file in the directory tree of %q", pkgFilePath)
 			}
 			dirPath = parentDir
 			continue
@@ -224,19 +224,15 @@ func getModuleNameFromGoMod(goModPath string) (string, error) {
 		return "", err
 	}
 
-	re, err := regexp.Compile(`module (\S+)`)
-	if err != nil {
-		return "", err
-	}
-
+	re := regexp.MustCompile(`module (\S+)`)
 	matches := re.FindAllSubmatch(goModBytes, -1)
 	if len(matches) != 1 {
-		return "", fmt.Errorf("Invalid go.mod format; contains %d module names instead of 1", len(matches))
+		return "", fmt.Errorf("invalid go.mod format; contains %d module names instead of 1", len(matches))
 	}
 
 	firstMatch := matches[0]
 	if len(firstMatch) != 2 {
-		return "", fmt.Errorf("Unexpected number of groups captured by regular expression: %d (expected 2)", len(firstMatch))
+		return "", fmt.Errorf("unexpected number of groups captured by regular expression: %d (expected 2)", len(firstMatch))
 	}
 
 	return string(firstMatch[1]), nil
@@ -304,6 +300,7 @@ func execExampleMethod(methodFullPackage, methodPackage, methodName string) (str
 		fmt.Print(err)
 	}
 
+	// nolint: gosec
 	cmd := exec.Command("go", "run", "./"+f)
 	output, err := cmd.CombinedOutput()
 

--- a/cmd/insights-operator/main.go
+++ b/cmd/insights-operator/main.go
@@ -28,7 +28,7 @@ func main() {
 	command := NewOperatorCommand()
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		defer os.Exit(1)
 	}
 }
 

--- a/pkg/config/mock_configurator.go
+++ b/pkg/config/mock_configurator.go
@@ -8,6 +8,8 @@ type MockConfigurator struct {
 func (mc *MockConfigurator) Config() *Controller {
 	return mc.Conf
 }
+
+// nolint: gocritic
 func (mc *MockConfigurator) ConfigChanged() (<-chan struct{}, func()) {
 	return nil, nil
 }

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -34,12 +34,12 @@ type Controller struct {
 func New(
 	configurator configobserver.Configurator,
 	rec recorder.FlushInterface,
-	gatherers []gatherers.Interface,
+	listGatherers []gatherers.Interface,
 	anonymizer *anonymization.Anonymizer,
 ) *Controller {
 	statuses := make(map[string]*controllerstatus.Simple)
 
-	for _, gatherer := range gatherers {
+	for _, gatherer := range listGatherers {
 		gathererName := gatherer.GetName()
 		statuses[gathererName] = &controllerstatus.Simple{Name: fmt.Sprintf("periodic-%s", gathererName)}
 	}
@@ -47,7 +47,7 @@ func New(
 	return &Controller{
 		configurator: configurator,
 		recorder:     rec,
-		gatherers:    gatherers,
+		gatherers:    listGatherers,
 		statuses:     statuses,
 		anonymizer:   anonymizer,
 	}

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -65,7 +65,7 @@ func Test_Controller_CustomPeriodGathererNoPeriod(t *testing.T) {
 	mockRecorder.Reset()
 }
 
-//Test_Controller_FailingGatherer tests that metadata file doesn't grow with failing gatherer functions
+// Test_Controller_FailingGatherer tests that metadata file doesn't grow with failing gatherer functions
 func Test_Controller_FailingGatherer(t *testing.T) {
 	c, mockRecorder := getMocksForPeriodicTest([]gatherers.Interface{
 		&gather.MockFailingGatherer{},
@@ -77,16 +77,17 @@ func Test_Controller_FailingGatherer(t *testing.T) {
 	assert.Len(t, mockRecorder.Records, 6)
 	for i := range mockRecorder.Records {
 		// find metadata record
-		if mockRecorder.Records[i].Name == recorder.MetadataRecordName {
-			metadataFound = true
-			b, err := mockRecorder.Records[i].Item.Marshal(context.Background())
-			assert.NoError(t, err)
-			metaData := make(map[string]interface{})
-			err = json.Unmarshal(b, &metaData)
-			assert.NoError(t, err)
-			assert.Len(t, metaData["status_reports"].([]interface{}), 1,
-				fmt.Sprintf("Only one fucntion for %s expected ", c.gatherers[0].GetName()))
+		if mockRecorder.Records[i].Name != recorder.MetadataRecordName {
+			continue
 		}
+		metadataFound = true
+		b, err := mockRecorder.Records[i].Item.Marshal(context.Background())
+		assert.NoError(t, err)
+		metaData := make(map[string]interface{})
+		err = json.Unmarshal(b, &metaData)
+		assert.NoError(t, err)
+		assert.Len(t, metaData["status_reports"].([]interface{}), 1,
+			fmt.Sprintf("Only one function for %s expected ", c.gatherers[0].GetName()))
 	}
 	assert.Truef(t, metadataFound, fmt.Sprintf("%s not found in records", recorder.MetadataRecordName))
 	mockRecorder.Reset()
@@ -94,7 +95,7 @@ func Test_Controller_FailingGatherer(t *testing.T) {
 
 // TODO: cover more things
 
-func getMocksForPeriodicTest(gatherers []gatherers.Interface, interval time.Duration) (*Controller, *recorder.MockRecorder) {
+func getMocksForPeriodicTest(listGatherers []gatherers.Interface, interval time.Duration) (*Controller, *recorder.MockRecorder) {
 	mockConfigurator := config.MockConfigurator{Conf: &config.Controller{
 		Report:   true,
 		Interval: interval,
@@ -102,5 +103,5 @@ func getMocksForPeriodicTest(gatherers []gatherers.Interface, interval time.Dura
 	}}
 	mockRecorder := recorder.MockRecorder{}
 
-	return New(&mockConfigurator, &mockRecorder, gatherers, nil), &mockRecorder
+	return New(&mockConfigurator, &mockRecorder, listGatherers, nil), &mockRecorder
 }

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	AllGatherersConst       = "ALL"
-	archiveMetadataFilename = "insights-operator/gathers"
+	AllGatherersConst = "ALL"
 )
 
 var programStartTime time.Time
@@ -201,7 +200,7 @@ func startGatheringConcurrently(
 // } where each item consists of a gatherer name and a function name split by a slash.
 // If there's a string "ALL", we enable everything and return the first parameter as true,
 // otherwise it will be false and the second parameter will contain function names
-func getListOfEnabledFunctionForGatherer(gathererName string, allFunctionsList []string) (bool, []string) {
+func getListOfEnabledFunctionForGatherer(gathererName string, allFunctionsList []string) (ok bool, list []string) {
 	if utils.StringInSlice(AllGatherersConst, allFunctionsList) {
 		return true, nil
 	}

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -26,11 +26,7 @@ const (
 	AllGatherersConst = "ALL"
 )
 
-var programStartTime time.Time
-
-func init() {
-	programStartTime = time.Now()
-}
+var programStartTime = time.Now()
 
 // GathererFunctionReport contains the information about a specific gathering function
 type GathererFunctionReport struct {

--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -97,6 +97,7 @@ func Test_sumErrors(t *testing.T) {
 	assert.EqualError(t, err, "error 1, error 2, error 3, error 5")
 }
 
+// nolint: funlen
 func Test_StartGatheringConcurrently(t *testing.T) {
 	gatherer := &MockGatherer{SomeField: "some_value"}
 
@@ -401,7 +402,7 @@ func assertMetadataOneGatherer(
 	assert.ElementsMatch(t, statusReports, archiveMetadata.StatusReports)
 }
 
-func assertRecordsOneGatherer(t testing.TB, records []record.Record, expectedRecords []record.Record) {
+func assertRecordsOneGatherer(t testing.TB, records, expectedRecords []record.Record) {
 	var recordsWithoutMetadata []record.Record
 	for _, r := range records {
 		if !strings.HasSuffix(r.Name, recorder.MetadataRecordName) {

--- a/pkg/gather/tasks_processing_test.go
+++ b/pkg/gather/tasks_processing_test.go
@@ -38,7 +38,7 @@ func Test_HandleTasksConcurrently(t *testing.T) {
 	}
 
 	results := handleTasksConcurrentlyGatherTasks(tasks)
-	for i, _ := range results {
+	for i := range results {
 		results[i].TimeElapsed = 0
 	}
 
@@ -157,7 +157,7 @@ func Test_HandleTasksConcurrently_CanFail_Panic(t *testing.T) {
 }
 
 // TODO: write a test testing that handleTasksConcurrently is actually concurrent.
-// We can employ some threads syncronization magic which would cause execution to timeout when run sequentially
+// We can employ some threads synchronization magic which would cause execution to timeout when run sequentially
 // and work just fine when run in parallel.
 // TODO: more tests?
 

--- a/pkg/gatherers/clusterconfig/certificate_signing_requests.go
+++ b/pkg/gatherers/clusterconfig/certificate_signing_requests.go
@@ -192,18 +192,18 @@ func anonymizeCSRRequest(r *certificatesv1api.CertificateSigningRequest, c *CSRA
 
 	c.Spec.Request.SignatureAlgorithm = csr.SignatureAlgorithm.String()
 	c.Spec.Request.PublicKeyAlgorithm = csr.PublicKeyAlgorithm.String()
-	c.Spec.Request.DNSNames = Map(csr.DNSNames, anonymize.AnonymizeURL)
-	c.Spec.Request.EmailAddresses = Map(csr.EmailAddresses, anonymize.AnonymizeURL)
+	c.Spec.Request.DNSNames = Map(csr.DNSNames, anonymize.URL)
+	c.Spec.Request.EmailAddresses = Map(csr.EmailAddresses, anonymize.URL)
 	ipsl := make([]string, len(csr.IPAddresses))
 	for i, ip := range csr.IPAddresses {
 		ipsl[i] = ip.String()
 	}
-	c.Spec.Request.IPAddresses = Map(ipsl, anonymize.AnonymizeURL)
+	c.Spec.Request.IPAddresses = Map(ipsl, anonymize.URL)
 	urlsl := make([]string, len(csr.URIs))
 	for i, u := range csr.URIs {
 		urlsl[i] = u.String()
 	}
-	c.Spec.Request.URIs = Map(urlsl, anonymize.AnonymizeURL)
+	c.Spec.Request.URIs = Map(urlsl, anonymize.URL)
 }
 
 func anonymizePkxName(s *pkix.Name) (a pkix.Name) {
@@ -226,9 +226,9 @@ func anonymizePkxName(s *pkix.Name) (a pkix.Name) {
 	for i := range src {
 		switch s := src[i].(type) {
 		case *string:
-			*(dst[i].(*string)) = anonymize.AnonymizeString(*s)
+			*(dst[i].(*string)) = anonymize.String(*s)
 		case *[]string:
-			*(dst[i].(*[]string)) = Map(*s, anonymize.AnonymizeString)
+			*(dst[i].(*[]string)) = Map(*s, anonymize.String)
 		default:
 			panic(fmt.Sprintf("unknown type %T", s))
 		}

--- a/pkg/gatherers/clusterconfig/image_registries.go
+++ b/pkg/gatherers/clusterconfig/image_registries.go
@@ -118,30 +118,30 @@ func findPVByPVCName(ctx context.Context, coreClient corev1client.CoreV1Interfac
 }
 
 func anonymizeImageRegistry(config *registryv1.Config) *registryv1.Config {
-	config.Spec.HTTPSecret = anonymize.AnonymizeString(config.Spec.HTTPSecret)
+	config.Spec.HTTPSecret = anonymize.String(config.Spec.HTTPSecret)
 	if config.Spec.Storage.S3 != nil {
-		config.Spec.Storage.S3.Bucket = anonymize.AnonymizeString(config.Spec.Storage.S3.Bucket)
-		config.Spec.Storage.S3.KeyID = anonymize.AnonymizeString(config.Spec.Storage.S3.KeyID)
-		config.Spec.Storage.S3.RegionEndpoint = anonymize.AnonymizeString(config.Spec.Storage.S3.RegionEndpoint)
-		config.Spec.Storage.S3.Region = anonymize.AnonymizeString(config.Spec.Storage.S3.Region)
+		config.Spec.Storage.S3.Bucket = anonymize.String(config.Spec.Storage.S3.Bucket)
+		config.Spec.Storage.S3.KeyID = anonymize.String(config.Spec.Storage.S3.KeyID)
+		config.Spec.Storage.S3.RegionEndpoint = anonymize.String(config.Spec.Storage.S3.RegionEndpoint)
+		config.Spec.Storage.S3.Region = anonymize.String(config.Spec.Storage.S3.Region)
 	}
 	if config.Spec.Storage.Azure != nil {
-		config.Spec.Storage.Azure.AccountName = anonymize.AnonymizeString(config.Spec.Storage.Azure.AccountName)
-		config.Spec.Storage.Azure.Container = anonymize.AnonymizeString(config.Spec.Storage.Azure.Container)
+		config.Spec.Storage.Azure.AccountName = anonymize.String(config.Spec.Storage.Azure.AccountName)
+		config.Spec.Storage.Azure.Container = anonymize.String(config.Spec.Storage.Azure.Container)
 	}
 	if config.Spec.Storage.GCS != nil {
-		config.Spec.Storage.GCS.Bucket = anonymize.AnonymizeString(config.Spec.Storage.GCS.Bucket)
-		config.Spec.Storage.GCS.ProjectID = anonymize.AnonymizeString(config.Spec.Storage.GCS.ProjectID)
-		config.Spec.Storage.GCS.KeyID = anonymize.AnonymizeString(config.Spec.Storage.GCS.KeyID)
+		config.Spec.Storage.GCS.Bucket = anonymize.String(config.Spec.Storage.GCS.Bucket)
+		config.Spec.Storage.GCS.ProjectID = anonymize.String(config.Spec.Storage.GCS.ProjectID)
+		config.Spec.Storage.GCS.KeyID = anonymize.String(config.Spec.Storage.GCS.KeyID)
 	}
 	if config.Spec.Storage.Swift != nil {
-		config.Spec.Storage.Swift.AuthURL = anonymize.AnonymizeString(config.Spec.Storage.Swift.AuthURL)
-		config.Spec.Storage.Swift.Container = anonymize.AnonymizeString(config.Spec.Storage.Swift.Container)
-		config.Spec.Storage.Swift.Domain = anonymize.AnonymizeString(config.Spec.Storage.Swift.Domain)
-		config.Spec.Storage.Swift.DomainID = anonymize.AnonymizeString(config.Spec.Storage.Swift.DomainID)
-		config.Spec.Storage.Swift.Tenant = anonymize.AnonymizeString(config.Spec.Storage.Swift.Tenant)
-		config.Spec.Storage.Swift.TenantID = anonymize.AnonymizeString(config.Spec.Storage.Swift.TenantID)
-		config.Spec.Storage.Swift.RegionName = anonymize.AnonymizeString(config.Spec.Storage.Swift.RegionName)
+		config.Spec.Storage.Swift.AuthURL = anonymize.String(config.Spec.Storage.Swift.AuthURL)
+		config.Spec.Storage.Swift.Container = anonymize.String(config.Spec.Storage.Swift.Container)
+		config.Spec.Storage.Swift.Domain = anonymize.String(config.Spec.Storage.Swift.Domain)
+		config.Spec.Storage.Swift.DomainID = anonymize.String(config.Spec.Storage.Swift.DomainID)
+		config.Spec.Storage.Swift.Tenant = anonymize.String(config.Spec.Storage.Swift.Tenant)
+		config.Spec.Storage.Swift.TenantID = anonymize.String(config.Spec.Storage.Swift.TenantID)
+		config.Spec.Storage.Swift.RegionName = anonymize.String(config.Spec.Storage.Swift.RegionName)
 	}
 	return config
 }

--- a/pkg/gatherers/clusterconfig/infrastructures.go
+++ b/pkg/gatherers/clusterconfig/infrastructures.go
@@ -41,6 +41,6 @@ func gatherClusterInfrastructure(ctx context.Context, configClient configv1clien
 }
 
 func anonymizeInfrastructure(config *configv1.Infrastructure) *configv1.Infrastructure {
-	config.Status.InfrastructureName = anonymize.AnonymizeURL(config.Status.InfrastructureName)
+	config.Status.InfrastructureName = anonymize.URL(config.Status.InfrastructureName)
 	return config
 }

--- a/pkg/gatherers/clusterconfig/machine_healthcheck.go
+++ b/pkg/gatherers/clusterconfig/machine_healthcheck.go
@@ -49,7 +49,6 @@ func gatherMachineHealthCheck(ctx context.Context, dynamicClient dynamic.Interfa
 			Name: recordName,
 			Item: record.JSONMarshaller{Object: i.Object},
 		})
-
 	}
 
 	return records, nil

--- a/pkg/gatherers/clusterconfig/nodes.go
+++ b/pkg/gatherers/clusterconfig/nodes.go
@@ -54,11 +54,11 @@ func anonymizeNode(node *corev1.Node) *corev1.Node {
 		if isProductNamespacedKey(k) {
 			continue
 		}
-		node.Labels[k] = anonymize.AnonymizeString(v)
+		node.Labels[k] = anonymize.String(v)
 	}
-	node.Status.NodeInfo.BootID = anonymize.AnonymizeString(node.Status.NodeInfo.BootID)
-	node.Status.NodeInfo.SystemUUID = anonymize.AnonymizeString(node.Status.NodeInfo.SystemUUID)
-	node.Status.NodeInfo.MachineID = anonymize.AnonymizeString(node.Status.NodeInfo.MachineID)
+	node.Status.NodeInfo.BootID = anonymize.String(node.Status.NodeInfo.BootID)
+	node.Status.NodeInfo.SystemUUID = anonymize.String(node.Status.NodeInfo.SystemUUID)
+	node.Status.NodeInfo.MachineID = anonymize.String(node.Status.NodeInfo.MachineID)
 	node.Status.Images = nil
 	return node
 }

--- a/pkg/gatherers/clusterconfig/openshift_apiserver_operator_logs.go
+++ b/pkg/gatherers/clusterconfig/openshift_apiserver_operator_logs.go
@@ -19,7 +19,6 @@ import (
 //
 // * Location in archive: config/pod/{namespace-name}/logs/{pod-name}/errors.log
 func (g *Gatherer) GatherOpenShiftAPIServerOperatorLogs(ctx context.Context) ([]record.Record, []error) {
-
 	containersFilter := logContainersFilter{
 		namespace:     "openshift-apiserver-operator",
 		labelSelector: "app=openshift-apiserver-operator",

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -276,7 +276,12 @@ func getContainerLogs(ctx context.Context,
 
 		// check for stack tracer
 		if found := stackTraceRegex.MatchString(logString); found {
-			klog.V(2).Infof("Stack trace found in log for %s container %s pod in namespace %s (previous: %v).", c.Name, pod.Name, pod.Namespace, isPrevious)
+			klog.V(2).Infof(
+				"Stack trace found in log for %s container %s pod in namespace %s (previous: %v).",
+				c.Name,
+				pod.Name,
+				pod.Namespace,
+				isPrevious)
 			logString, err = getContainerLogString(ctx, client, pod, c.Name, isPrevious, buf, &logTailLinesLong)
 			if err != nil {
 				klog.V(2).Infof("Error: %q", err)
@@ -312,7 +317,7 @@ func getContainerLogString(
 	}
 
 	if buf.Len() == 0 {
-		return "", fmt.Errorf("Log buffer is empty")
+		return "", fmt.Errorf("log buffer is empty")
 	}
 
 	return buf.String(), nil
@@ -335,7 +340,6 @@ func fetchPodContainerLog(ctx context.Context,
 	containerName string,
 	isPrevious bool,
 	tailLines *int64) error {
-
 	var limitBytes *int64
 	bufCap := int64(buf.Cap())
 	limitBytes = &bufCap

--- a/pkg/gatherers/clusterconfig/pod_network_connectivity_checks.go
+++ b/pkg/gatherers/clusterconfig/pod_network_connectivity_checks.go
@@ -60,7 +60,8 @@ func gatherPNCC(ctx context.Context, dynamicClient dynamic.Interface) ([]record.
 	}
 
 	unsuccessful := []controlplanev1.LogEntry{}
-	for _, pncc := range pnccListStruct.Items {
+	for idx := range pnccListStruct.Items {
+		pncc := pnccListStruct.Items[idx]
 		unsuccessful = append(unsuccessful, getUnsuccessfulChecks(pncc.Status.Failures)...)
 		for _, outage := range pncc.Status.Outages {
 			unsuccessful = append(unsuccessful, getUnsuccessfulChecks(outage.StartLogs)...)

--- a/pkg/gatherers/clusterconfig/pod_network_connectivity_checks_test.go
+++ b/pkg/gatherers/clusterconfig/pod_network_connectivity_checks_test.go
@@ -15,6 +15,8 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
+const podnetworkconnectivitychecksPath = "config/podnetworkconnectivitychecks"
+
 func Test_PNCC(t *testing.T) {
 	var pnccYAML = `apiVersion: controlplane.operator.openshift.io/v1alpha1
 kind: PodNetworkConnectivityCheck
@@ -49,7 +51,7 @@ status:
 		t.Fatalf("unexpected number or records in the first run: %d", len(records))
 	}
 	rec := records[0]
-	if rec.Name != "config/podnetworkconnectivitychecks" {
+	if rec.Name != podnetworkconnectivitychecksPath {
 		t.Fatalf("unexpected name of record in the first run: %q", rec.Name)
 	}
 	recItem, ok := rec.Item.(record.JSONMarshaller)
@@ -61,7 +63,10 @@ status:
 	}
 
 	// Create the PNCC resource.
-	_, _ = pnccClient.Resource(pnccGroupVersionResource).Namespace("example-namespace").Create(context.Background(), testPNCC, metav1.CreateOptions{})
+	_, _ = pnccClient.
+		Resource(pnccGroupVersionResource).
+		Namespace("example-namespace").
+		Create(context.Background(), testPNCC, metav1.CreateOptions{})
 
 	// Check after creating the PNCC.
 	records, errs = gatherPNCC(context.Background(), pnccClient)
@@ -72,7 +77,7 @@ status:
 		t.Fatalf("unexpected number or records in the second run: %d", len(records))
 	}
 	rec = records[0]
-	if rec.Name != "config/podnetworkconnectivitychecks" {
+	if rec.Name != podnetworkconnectivitychecksPath {
 		t.Fatalf("unexpected name of record in the second run: %q", rec.Name)
 	}
 	recItem, ok = rec.Item.(record.JSONMarshaller)

--- a/pkg/gatherers/clusterconfig/proxies.go
+++ b/pkg/gatherers/clusterconfig/proxies.go
@@ -41,12 +41,12 @@ func gatherClusterProxy(ctx context.Context, configClient configv1client.ConfigV
 }
 
 func anonymizeProxy(proxy *configv1.Proxy) *configv1.Proxy {
-	proxy.Spec.HTTPProxy = anonymize.AnonymizeURLCSV(proxy.Spec.HTTPProxy)
-	proxy.Spec.HTTPSProxy = anonymize.AnonymizeURLCSV(proxy.Spec.HTTPSProxy)
-	proxy.Spec.NoProxy = anonymize.AnonymizeURLCSV(proxy.Spec.NoProxy)
-	proxy.Spec.ReadinessEndpoints = anonymize.AnonymizeURLSlice(proxy.Spec.ReadinessEndpoints)
-	proxy.Status.HTTPProxy = anonymize.AnonymizeURLCSV(proxy.Status.HTTPProxy)
-	proxy.Status.HTTPSProxy = anonymize.AnonymizeURLCSV(proxy.Status.HTTPSProxy)
-	proxy.Status.NoProxy = anonymize.AnonymizeURLCSV(proxy.Status.NoProxy)
+	proxy.Spec.HTTPProxy = anonymize.URLCSV(proxy.Spec.HTTPProxy)
+	proxy.Spec.HTTPSProxy = anonymize.URLCSV(proxy.Spec.HTTPSProxy)
+	proxy.Spec.NoProxy = anonymize.URLCSV(proxy.Spec.NoProxy)
+	proxy.Spec.ReadinessEndpoints = anonymize.URLSlice(proxy.Spec.ReadinessEndpoints)
+	proxy.Status.HTTPProxy = anonymize.URLCSV(proxy.Status.HTTPProxy)
+	proxy.Status.HTTPSProxy = anonymize.URLCSV(proxy.Status.HTTPSProxy)
+	proxy.Status.NoProxy = anonymize.URLCSV(proxy.Status.NoProxy)
 	return proxy
 }

--- a/pkg/gatherers/clusterconfig/sap_machine_configs_test.go
+++ b/pkg/gatherers/clusterconfig/sap_machine_configs_test.go
@@ -9,68 +9,28 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
+func createMockConfigMachine(t *testing.T, c dynamic.Interface, data string) {
+	decUnstructured1 := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	testMachineConfig := &unstructured.Unstructured{}
+	_, _, err := decUnstructured1.Decode([]byte(data), nil, testMachineConfig)
+	if err != nil {
+		t.Fatal("unable to decode MachineConfig YAML", err)
+	}
+
+	_, _ = c.
+		Resource(machineConfigGroupVersionResource).
+		Create(context.Background(), testMachineConfig, metav1.CreateOptions{})
+}
+
 func Test_SAPMachineConfigs(t *testing.T) {
 	// Initialize the fake dynamic client.
-	machineConfigYAML1 := `apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-    name: 75-worker-sap-data-intelligence
-`
-	machineConfigYAML2 := `apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-    name: 75-master-sap-data-intelligence
-`
-	machineConfigYAML3 := `apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-    name: 99-sdi-generated-containerruntime
-    ownerReferences:
-        - kind: ContainerRuntimeConfig
-          name: sdi-pids-limit
-`
-	machineConfigYAML4 := `apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-    name: 00-example-machine-config
-    labels:
-        workload: sap-data-intelligence
-`
-
 	machineConfigClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
 		machineConfigGroupVersionResource: "MachineConfigsList",
 	})
-
-	decUnstructured1 := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	testMachineConfig1 := &unstructured.Unstructured{}
-	_, _, err := decUnstructured1.Decode([]byte(machineConfigYAML1), nil, testMachineConfig1)
-	if err != nil {
-		t.Fatal("unable to decode MachineConfig 1 YAML", err)
-	}
-
-	decUnstructured2 := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	testMachineConfig2 := &unstructured.Unstructured{}
-	_, _, err = decUnstructured2.Decode([]byte(machineConfigYAML2), nil, testMachineConfig2)
-	if err != nil {
-		t.Fatal("unable to decode MachineConfig 2 YAML", err)
-	}
-
-	decUnstructured3 := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	testMachineConfig3 := &unstructured.Unstructured{}
-	_, _, err = decUnstructured3.Decode([]byte(machineConfigYAML3), nil, testMachineConfig3)
-	if err != nil {
-		t.Fatal("unable to decode MachineConfig 3 YAML", err)
-	}
-
-	decUnstructured4 := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-	testMachineConfig4 := &unstructured.Unstructured{}
-	_, _, err = decUnstructured4.Decode([]byte(machineConfigYAML4), nil, testMachineConfig4)
-	if err != nil {
-		t.Fatal("unable to decode MachineConfig 4 YAML", err)
-	}
 
 	records, errs := gatherSAPMachineConfigs(context.Background(), machineConfigClient)
 	if len(errs) > 0 {
@@ -82,10 +42,13 @@ metadata:
 	}
 
 	// Create first MachineConfig resource.
-	_, _ = machineConfigClient.
-		Resource(machineConfigGroupVersionResource).
-		Create(context.Background(), testMachineConfig1, metav1.CreateOptions{})
+	machineConfigYAML1 := `apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+    name: 75-worker-sap-data-intelligence
+`
 
+	createMockConfigMachine(t, machineConfigClient, machineConfigYAML1)
 	records, errs = gatherSAPMachineConfigs(context.Background(), machineConfigClient)
 	if len(errs) > 0 {
 		t.Fatalf("unexpected errors: %#v", errs)
@@ -96,10 +59,13 @@ metadata:
 	}
 
 	// Create second MachineConfig resource.
-	_, _ = machineConfigClient.
-		Resource(machineConfigGroupVersionResource).
-		Create(context.Background(), testMachineConfig2, metav1.CreateOptions{})
+	machineConfigYAML2 := `apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+    name: 75-master-sap-data-intelligence
+`
 
+	createMockConfigMachine(t, machineConfigClient, machineConfigYAML2)
 	records, errs = gatherSAPMachineConfigs(context.Background(), machineConfigClient)
 	if len(errs) > 0 {
 		t.Fatalf("unexpected errors: %#v", errs)
@@ -110,10 +76,16 @@ metadata:
 	}
 
 	// Create third MachineConfig resource.
-	_, _ = machineConfigClient.
-		Resource(machineConfigGroupVersionResource).
-		Create(context.Background(), testMachineConfig3, metav1.CreateOptions{})
+	machineConfigYAML3 := `apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+    name: 99-sdi-generated-containerruntime
+    ownerReferences:
+        - kind: ContainerRuntimeConfig
+          name: sdi-pids-limit
+`
 
+	createMockConfigMachine(t, machineConfigClient, machineConfigYAML3)
 	records, errs = gatherSAPMachineConfigs(context.Background(), machineConfigClient)
 	if len(errs) > 0 {
 		t.Fatalf("unexpected errors: %#v", errs)
@@ -124,10 +96,15 @@ metadata:
 	}
 
 	// Create fourth MachineConfig resource.
-	_, _ = machineConfigClient.
-		Resource(machineConfigGroupVersionResource).
-		Create(context.Background(), testMachineConfig4, metav1.CreateOptions{})
+	machineConfigYAML4 := `apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+    name: 00-example-machine-config
+    labels:
+        workload: sap-data-intelligence
+`
 
+	createMockConfigMachine(t, machineConfigClient, machineConfigYAML4)
 	records, errs = gatherSAPMachineConfigs(context.Background(), machineConfigClient)
 	if len(errs) > 0 {
 		t.Fatalf("unexpected errors: %#v", errs)

--- a/pkg/gatherers/clusterconfig/version.go
+++ b/pkg/gatherers/clusterconfig/version.go
@@ -109,6 +109,6 @@ func getClusterVersion(ctx context.Context,
 }
 
 func anonymizeClusterVersion(version *configv1.ClusterVersion) *configv1.ClusterVersion {
-	version.Spec.Upstream = configv1.URL(anonymize.AnonymizeURL(string(version.Spec.Upstream)))
+	version.Spec.Upstream = configv1.URL(anonymize.URL(string(version.Spec.Upstream)))
 	return version
 }

--- a/pkg/gatherers/workloads/workloads_info_test.go
+++ b/pkg/gatherers/workloads/workloads_info_test.go
@@ -40,7 +40,7 @@ func Test_gatherWorkloadInfo(t *testing.T) {
 		t.Fatal(errs)
 	}
 
-	t.Logf("Gathered in %s", time.Now().Sub(start).Round(time.Second).String())
+	t.Logf("Gathered in %s", time.Since(start).Round(time.Second).String())
 
 	if len(records) != 1 {
 		t.Fatalf("unexpected: %v", records)

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -82,7 +82,7 @@ func (r *Recorder) Record(rec record.Record) error {
 	}
 	// we want to record our metadata file anyway
 	if r.size+recordSize > r.maxArchiveSize && rec.Name != MetadataRecordName {
-		return fmt.Errorf("Record %s(size=%d) exceeds the archive size limit %d and will not be included in the archive",
+		return fmt.Errorf("record %s(size=%d) exceeds the archive size limit %d and will not be included in the archive",
 			recordName, recordSize, r.maxArchiveSize)
 	}
 	r.records[recordName] = memoryRecord

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -139,5 +139,12 @@ func Test_Record_ArchiveSizeExceeded(t *testing.T) {
 			Data: data,
 		},
 	})
-	assert.Equal(t, err, fmt.Errorf("Record %s(size=%d) exceeds the archive size limit %d and will not be included in the archive", mock1Name, len([]byte(data)), maxArchiveSize))
+	assert.Equal(
+		t,
+		err,
+		fmt.Errorf(
+			"record %s(size=%d) exceeds the archive size limit %d and will not be included in the archive",
+			mock1Name,
+			len([]byte(data)),
+			maxArchiveSize))
 }

--- a/pkg/utils/anonymize/string.go
+++ b/pkg/utils/anonymize/string.go
@@ -2,6 +2,6 @@ package anonymize
 
 import "strings"
 
-func AnonymizeString(s string) string {
+func String(s string) string {
 	return strings.Repeat("x", len(s))
 }

--- a/pkg/utils/anonymize/url.go
+++ b/pkg/utils/anonymize/url.go
@@ -5,20 +5,20 @@ import (
 	"strings"
 )
 
-func AnonymizeURLCSV(s string) string {
+func URLCSV(s string) string {
 	strs := strings.Split(s, ",")
-	outSlice := AnonymizeURLSlice(strs)
+	outSlice := URLSlice(strs)
 	return strings.Join(outSlice, ",")
 }
 
-func AnonymizeURLSlice(in []string) []string {
+func URLSlice(in []string) []string {
 	var outSlice []string
 	for _, str := range in {
-		outSlice = append(outSlice, AnonymizeURL(str))
+		outSlice = append(outSlice, URL(str))
 	}
 	return outSlice
 }
 
-var reURL = regexp.MustCompile(`[^\.\-/\:]`)
+var reURL = regexp.MustCompile(`[^.\-/:]`)
 
-func AnonymizeURL(s string) string { return reURL.ReplaceAllString(s, "x") }
+func URL(s string) string { return reURL.ReplaceAllString(s, "x") }

--- a/pkg/utils/check/has_container_in_crashloop.go
+++ b/pkg/utils/check/has_container_in_crashloop.go
@@ -10,13 +10,13 @@ func IsContainerInCrashloop(status *corev1.ContainerStatus) bool {
 }
 
 func HasContainerInCrashloop(pod *corev1.Pod) bool {
-	for _, status := range pod.Status.InitContainerStatuses {
-		if IsContainerInCrashloop(&status) {
+	for idx := range pod.Status.InitContainerStatuses {
+		if IsContainerInCrashloop(&pod.Status.InitContainerStatuses[idx]) {
 			return true
 		}
 	}
-	for _, status := range pod.Status.ContainerStatuses {
-		if IsContainerInCrashloop(&status) {
+	for idx := range pod.Status.ContainerStatuses {
+		if IsContainerInCrashloop(&pod.Status.ContainerStatuses[idx]) {
 			return true
 		}
 	}

--- a/pkg/utils/check/has_container_in_crashloop.go
+++ b/pkg/utils/check/has_container_in_crashloop.go
@@ -3,7 +3,10 @@ package check
 import corev1 "k8s.io/api/core/v1"
 
 func IsContainerInCrashloop(status *corev1.ContainerStatus) bool {
-	return status.RestartCount > 0 && ((status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode != 0) || status.LastTerminationState.Waiting != nil)
+	return status.RestartCount > 0 &&
+		((status.LastTerminationState.Terminated != nil &&
+			status.LastTerminationState.Terminated.ExitCode != 0) ||
+			status.LastTerminationState.Waiting != nil)
 }
 
 func HasContainerInCrashloop(pod *corev1.Pod) bool {

--- a/pkg/utils/check/is_healthy_pod.go
+++ b/pkg/utils/check/is_healthy_pod.go
@@ -15,7 +15,8 @@ func IsHealthyPod(pod *corev1.Pod, now time.Time) bool {
 		}
 	}
 	// pods that have containers that have terminated with non-zero exit codes are considered failure
-	for _, status := range pod.Status.InitContainerStatuses {
+	for idx := range pod.Status.InitContainerStatuses {
+		status := pod.Status.InitContainerStatuses[idx]
 		if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode != 0 {
 			return false
 		}
@@ -26,7 +27,8 @@ func IsHealthyPod(pod *corev1.Pod, now time.Time) bool {
 			return false
 		}
 	}
-	for _, status := range pod.Status.ContainerStatuses {
+	for idx := range pod.Status.ContainerStatuses {
+		status := pod.Status.ContainerStatuses[idx]
 		if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode != 0 {
 			return false
 		}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR fixes the remaining lint issues in our codebase. So, we should be all good to have it enabled in the CI. :partying_face: 

Related to: https://github.com/openshift/release/pull/18961

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in the sample archive? -->

No changes.

## Documentation
<!-- Are these changes reflected in documentation? -->

No changes.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/periodic/periodic_test.go`
- `pkg/gather/gather_test.go`
- `pkg/gather/tasks_processing_test.go`
- `pkg/gatherers/clusterconfig/pod_network_connectivity_checks_test.go`
- `pkg/gatherers/clusterconfig/sap_machine_configs_test.go` (biggest changes)
- `pkg/gatherers/workloads/workloads_info_test.go`
- `pkg/recorder/recorder_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using the operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4078
https://bugzilla.redhat.com/show_bug.cgi?id=1967595
