### PR TITLE
MemoryRecord name can be obfuscated & fix case of duplicate records

### DIFF
--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -169,14 +169,6 @@ func (r *Recorder) copy() record.MemoryRecords {
 func (r *Recorder) clear(records record.MemoryRecords) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	size := int64(0)
-	for _, record := range records {
-		existing, ok := r.records[record.Name]
-		if !ok || existing.Data == nil || existing.At != record.At || existing.Fingerprint != record.Fingerprint {
-			continue
-		}
-		size += int64(len(existing.Data))
-		existing.Data = nil
-	}
-	r.size -= size
+	r.records = make(map[string]*record.MemoryRecord, len(records))
+	r.size = 0
 }

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -85,7 +85,7 @@ func (r *Recorder) Record(rec record.Record) error {
 		return fmt.Errorf("record %s(size=%d) exceeds the archive size limit %d and will not be included in the archive",
 			recordName, recordSize, r.maxArchiveSize)
 	}
-	r.records[recordName] = memoryRecord
+	r.records[memoryRecord.Name] = memoryRecord
 	r.size += recordSize
 	return nil
 }
@@ -146,7 +146,7 @@ func (r *Recorder) PeriodicallyPrune(ctx context.Context, reported alreadyReport
 func (r *Recorder) has(re record.Record) bool {
 	existing, ok := r.records[re.Filename()]
 	if ok {
-		if len(re.Fingerprint) > 0 && re.Fingerprint == existing.Fingerprint {
+		if re.Fingerprint == existing.Fingerprint {
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
`MemoryRecord` name can be partially obfuscated as well (when includes cluster base domain i.e node names, hostsubnet names could contain `<CLUSTER_BASE_DOMAIN>` string). This means that such record couldn't be found in https://github.com/openshift/insights-operator/blob/master/pkg/recorder/recorder.go#L171 and the size was growing....and now we have enforced the size limit -> basically empty archives after some time when obfuscation is enabled, because the size limit was exceeded. 

Also do not check the length of the data fingerprint (since it will be always 0 because we don't use fingerprints) -> fix the size counting in case of same duplicate records (yes it can happen as I found out).

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
