### PR TITLE
Bug 1969525: Replace golint with revive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,8 +27,6 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: github.com/golangci/golangci-lint
-  golint:
-    min-confidence: 0
   gomnd:
     settings:
       mnd:
@@ -79,7 +77,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - goprintffuncname
     - gosec
     - gosimple
@@ -126,6 +124,7 @@ issues:
       source: "^// "
 
 run:
+  timeout: 5m
   skip-dirs:
     - tests/integration
     - pkg/insights

--- a/.openshiftci/install-golangci-lint.sh
+++ b/.openshiftci/install-golangci-lint.sh
@@ -6,10 +6,9 @@ if [ -z "${GOPATH:-}" ]; then
     eval "$(go env | grep GOPATH)"
 fi
 
-OUTPUT=bin/golangci-lint
-VERSION=v1.39.0
+export OUTPUT=bin/golangci-lint
 
 if [ ! -f "$OUTPUT" ]
 then
-    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin $(VERSION)
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin
 fi

--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 )
 
+// norevive
 const (
 	BUGFIX      = "Bugfix"
 	ENHANCEMENT = "Enhancement"

--- a/pkg/anonymization/anonymizer.go
+++ b/pkg/anonymization/anonymizer.go
@@ -43,6 +43,7 @@ import (
 	"github.com/openshift/insights-operator/pkg/utils"
 )
 
+// norevive
 const (
 	Ipv4Regex                            = `((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)`
 	Ipv4NetworkRegex                     = Ipv4Regex + "/([0-9]{1,2})"
@@ -53,6 +54,7 @@ const (
 )
 
 var (
+	// TranslationTableSecretName defines the secret name to store the translation table
 	TranslationTableSecretName = "obfuscation-translation-table" //nolint: gosec
 	secretAPIVersion           = "v1"
 	secretKind                 = "Secret"
@@ -262,7 +264,7 @@ func (anonymizer *Anonymizer) ObfuscateIP(ipStr string) string {
 	return "::"
 }
 
-// Stores the translation table in a Secret in the openshift-insights namespace.
+// StoreTranslationTable stores the translation table in a Secret in the openshift-insights namespace.
 // The actual data is stored in the StringData portion of the Secret.
 func (anonymizer *Anonymizer) StoreTranslationTable() *corev1.Secret {
 	if len(anonymizer.translationTable) == 0 {
@@ -299,7 +301,7 @@ func (anonymizer *Anonymizer) StoreTranslationTable() *corev1.Secret {
 	return result
 }
 
-// Resets the translation table, so that the translation table of multiple gathers wont mix toghater.
+// ResetTranslationTable resets the translation table, so that the translation table of multiple gathers wont mix toghater.
 func (anonymizer *Anonymizer) ResetTranslationTable() {
 	anonymizer.translationTable = make(map[string]string)
 }

--- a/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
+++ b/pkg/authorizer/clusterauthorizer/clusterauthorizer.go
@@ -21,7 +21,7 @@ type Authorizer struct {
 	proxyFromEnvironment func(*http.Request) (*url.URL, error)
 }
 
-// Creates a new Authorizer, whose purpose is to auth requests for outgoing traffic.
+// New creates a new Authorizer, whose purpose is to auth requests for outgoing traffic.
 func New(configurator Configurator) *Authorizer {
 	return &Authorizer{
 		configurator:         configurator,
@@ -29,7 +29,7 @@ func New(configurator Configurator) *Authorizer {
 	}
 }
 
-// Adds the necessary auth header to the request, depending on the config. (BasicAuth/Token)
+// Authorize adds the necessary auth header to the request, depending on the config. (BasicAuth/Token)
 func (a *Authorizer) Authorize(req *http.Request) error {
 	cfg := a.configurator.Config()
 	if len(cfg.Username) > 0 || len(cfg.Password) > 0 {
@@ -53,7 +53,7 @@ func (a *Authorizer) Authorize(req *http.Request) error {
 	return nil
 }
 
-// Creates the proxy URL based on the config. (specific/default proxy)
+// NewSystemOrConfiguredProxy creates the proxy URL based on the config. (specific/default proxy)
 func (a *Authorizer) NewSystemOrConfiguredProxy() func(*http.Request) (*url.URL, error) {
 	// using specific proxy settings
 	if c := a.configurator.Config(); c != nil {

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -22,7 +22,7 @@ import (
 
 const serviceCACertPath = "/var/run/configmaps/service-ca-bundle/service-ca.crt"
 
-// Create the commad for running the Insights Operator.
+// NewOperator create the commad for running the Insights Operator.
 func NewOperator() *cobra.Command {
 	operator := &controller.Operator{
 		Controller: config.Controller{
@@ -46,7 +46,7 @@ func NewOperator() *cobra.Command {
 	return cmd
 }
 
-// Create the commad for running the a single gather.
+// NewGather create the commad for running the a single gather.
 func NewGather() *cobra.Command {
 	operator := &controller.GatherJob{
 		Controller: config.Controller{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,7 +67,7 @@ type HTTPConfig struct {
 
 type Converter func(s *Serialized, cfg *Controller) (*Controller, error)
 
-// Returns the important fields of the config in a string form
+// ToString returns the important fields of the config in a string form
 func (c *Controller) ToString() string {
 	return fmt.Sprintf("enabled=%t "+
 		"endpoint=%s "+
@@ -89,7 +89,7 @@ func (c *Controller) ToString() string {
 		c.ReportPullingTimeout)
 }
 
-// Creates/updates a config Controller according to the Serialized config.
+// ToController creates/updates a config Controller according to the Serialized config.
 // Makes sure that the config is correct.
 func ToController(s *Serialized, cfg *Controller) (*Controller, error) { // nolint: gocyclo
 	if cfg == nil {
@@ -162,7 +162,7 @@ func ToController(s *Serialized, cfg *Controller) (*Controller, error) { // noli
 	return cfg, nil
 }
 
-// Creates/updates a config Controller according to the Serialized config.
+// ToDisconnectedController creates/updates a config Controller according to the Serialized config.
 // Makes sure that the config is correct, but only checks fields necessary for disconnected operation.
 func ToDisconnectedController(s *Serialized, cfg *Controller) (*Controller, error) {
 	if cfg == nil {

--- a/pkg/config/configobserver/configobserver.go
+++ b/pkg/config/configobserver/configobserver.go
@@ -27,7 +27,7 @@ type Configurator interface {
 	ConfigChanged() (<-chan struct{}, func())
 }
 
-// Responsible for periodically checking and (if necessary) updating the local configs/tokens
+// Controller is responsible for periodically checking and (if necessary) updating the local configs/tokens
 // according to the configs/tokens present on the cluster.
 type Controller struct {
 	kubeClient kubernetes.Interface
@@ -41,7 +41,7 @@ type Controller struct {
 	listeners     []chan struct{}
 }
 
-// Creates a new configobsever, the configs/tokens are updated from the configs/tokens present in the cluster if possible.
+// New creates a new configobsever, the configs/tokens are updated from the configs/tokens present in the cluster if possible.
 func New(defaultConfig config.Controller, kubeClient kubernetes.Interface) *Controller { //nolint: gocritic
 	c := &Controller{
 		kubeClient:    kubeClient,
@@ -210,14 +210,14 @@ func (c *Controller) retrieveConfig(ctx context.Context) error { //nolint: gocyc
 	return nil
 }
 
-// Provides the config in a thread-safe way.
+// Config provides the config in a thread-safe way.
 func (c *Controller) Config() *config.Controller {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	return c.config
 }
 
-// Subscribe for config changes
+// ConfigChanged subscribe for config changes
 // 1.Param: A channel where the listener is notified that the config has changed.
 // 2.Param: A func which can be used to unsubscribe from the config changes.
 func (c *Controller) ConfigChanged() (configCh <-chan struct{}, closeFn func()) {

--- a/pkg/config/mock_configurator.go
+++ b/pkg/config/mock_configurator.go
@@ -9,7 +9,6 @@ func (mc *MockConfigurator) Config() *Controller {
 	return mc.Conf
 }
 
-// nolint: gocritic
-func (mc *MockConfigurator) ConfigChanged() (<-chan struct{}, func()) {
+func (mc *MockConfigurator) ConfigChanged() (c <-chan struct{}, f func()) {
 	return nil, nil
 }

--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -20,12 +20,12 @@ import (
 	"github.com/openshift/insights-operator/pkg/recorder/diskrecorder"
 )
 
-// Object responsible for controlling a non-periodic Gather execution
+// GatherJob is the type responsible for controlling a non-periodic Gather execution
 type GatherJob struct {
 	config.Controller
 }
 
-// Runs a single gather and stores the generated archive, without uploading it.
+// Gather runs a single gather and stores the generated archive, without uploading it.
 // 1. Creates the necessary configs/clients
 // 2. Creates the configobserver to get more configs
 // 3. Initiates the recorder

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -33,12 +33,12 @@ import (
 	"github.com/openshift/insights-operator/pkg/recorder/diskrecorder"
 )
 
-// Object responsible for controlling the start up of the Insights Operator
+// Operator is the type responsible for controlling the start up of the Insights Operator
 type Operator struct {
 	config.Controller
 }
 
-// Starts the Insights Operator:
+// Run starts the Insights Operator:
 // 1. Gets/Creates the necessary configs/clients
 // 2. Starts the configobserver and status reporter
 // 3. Initiates the recorder and starts the periodic record pruneing

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -87,7 +87,7 @@ func (c *Controller) Run(stopCh <-chan struct{}, initialDelay time.Duration) {
 	<-stopCh
 }
 
-// Runs the gatherers one after the other.
+// Gather Runs the gatherers one after the other.
 // Currently their is only 1 gatherer (clusterconfig) and no new gatherer is on the horizon.
 // Running the gatherers in parallel should be a future improvement when a new gatherer is introduced.
 func (c *Controller) Gather() {

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -28,7 +28,7 @@ import (
 // as UploadDegraded
 const uploadFailuresCountThreshold = 5
 
-// How many gatherings can fail in a row before we report Degraded
+// GatherFailuresCountThreshold defines how many gatherings can fail in a row before we report Degraded
 const GatherFailuresCountThreshold = 5
 
 type Reported struct {
@@ -39,7 +39,7 @@ type Configurator interface {
 	Config() *config.Controller
 }
 
-// Responsible for managing the status of the operator according to the status of the sources.
+// Controller is the type responsible for managing the status of the operator according to the status of the sources.
 // Sources come from different major parts of the codebase, for the purpose of communicating their status with the controller.
 type Controller struct {
 	name         string
@@ -55,7 +55,7 @@ type Controller struct {
 	start    time.Time
 }
 
-// Creates a status controller, responsible for monitoring the operators status and updating the it's cluster status accordingly.
+// NewController creates a status controller, responsible for monitoring the operators status and updating the it's cluster status accordingly.
 func NewController(client configv1client.ConfigV1Interface,
 	coreClient corev1client.CoreV1Interface,
 	configurator Configurator, namespace string) *Controller {
@@ -86,14 +86,14 @@ func (c *Controller) controllerStartTime() time.Time {
 	return c.start
 }
 
-// Provides the last reported time in a thread-safe way.
+// LastReportedTime provides the last reported time in a thread-safe way.
 func (c *Controller) LastReportedTime() time.Time {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	return c.reported.LastReportTime.Time
 }
 
-// Sets the last reported time in a thread-safe way.
+// SetLastReportedTime sets the last reported time in a thread-safe way.
 func (c *Controller) SetLastReportedTime(at time.Time) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -104,7 +104,7 @@ func (c *Controller) SetLastReportedTime(at time.Time) {
 	c.triggerStatusUpdate()
 }
 
-// Adds sources in a thread-safe way.
+// AddSources adds sources in a thread-safe way.
 // A source is used to monitor parts of the operator.
 func (c *Controller) AddSources(sources ...controllerstatus.Interface) {
 	c.lock.Lock()
@@ -112,7 +112,7 @@ func (c *Controller) AddSources(sources ...controllerstatus.Interface) {
 	c.sources = append(c.sources, sources...)
 }
 
-// Provides the sources in a thread-safe way.
+// Sources provides the sources in a thread-safe way.
 // A source is used to monitor parts of the operator.
 func (c *Controller) Sources() []controllerstatus.Interface {
 	c.lock.Lock()
@@ -360,7 +360,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 	return existing
 }
 
-// Starts the periodic checking of sources.
+// Start starts the periodic checking of sources.
 func (c *Controller) Start(ctx context.Context) error {
 	if err := c.updateStatus(ctx, true); err != nil {
 		return err
@@ -432,10 +432,10 @@ func (c *Controller) updateStatus(ctx context.Context, initial bool) error {
 	return err
 }
 
-// OperatorDisabled reports when the primary function of the operator has been disabled.
+// OperatorDisabled defines the condition type when the operator's primary funcion has been disabled
 const OperatorDisabled configv1.ClusterStatusConditionType = "Disabled"
 
-// Uploading reports true when the operator is successfully uploading
+// UploadDegraded defines the condition type when a report is successfully uploaded
 const UploadDegraded configv1.ClusterStatusConditionType = "UploadDegraded"
 
 func isNotAuthorizedReason(reason string) bool {

--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -22,7 +22,7 @@ const (
 	GatheringReport Operation = "GatheringReport"
 )
 
-// Represents the status summary of an Operation
+// Summary represents the status summary of an Operation
 type Summary struct {
 	Operation          Operation
 	Healthy            bool
@@ -32,7 +32,7 @@ type Summary struct {
 	Count              int
 }
 
-// Represents the status of a given part of the operator
+// Simple represents the status of a given part of the operator
 type Simple struct {
 	Name string
 
@@ -40,7 +40,7 @@ type Simple struct {
 	summary Summary
 }
 
-// Updates the status, keeps track how long a status have been in effect
+// UpdateStatus updates the status, keeps track how long a status have been in effect
 func (s *Simple) UpdateStatus(summary Summary) { //nolint: gocritic
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -68,7 +68,7 @@ func (s *Simple) UpdateStatus(summary Summary) { //nolint: gocritic
 	}
 }
 
-// Retrives the status summary in a thread-safe way
+// CurrentStatus retrives the status summary in a thread-safe way
 func (s *Simple) CurrentStatus() (Summary, bool) {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/insights-operator/pkg/utils"
 )
 
+// norevive
 const (
 	AllGatherersConst = "ALL"
 )
@@ -62,8 +63,7 @@ func CreateAllGatherers(
 	return []gatherers.Interface{clusterConfigGatherer, workloadsGatherer}
 }
 
-// CollectAndRecord gathers enabled functions of the provided gatherer and records the results to the recorder
-// collectAndRecordGatherer gathers enabled functions of the provided gatherer, records the results to the recorder
+// CollectAndRecordGatherer gathers enabled functions of the provided gatherer and records the results to the recorder
 // and returns info about the recorded data. Panics are just logged and written
 // to the resulting array (to the archive metadata)
 func CollectAndRecordGatherer(

--- a/pkg/gatherers/clusterconfig/container_images_test.go
+++ b/pkg/gatherers/clusterconfig/container_images_test.go
@@ -92,7 +92,7 @@ func Test_ContainerImages_Gather(t *testing.T) { //nolint: funlen,gocyclo
 		return
 	}
 
-	var containerInfo *ContainerInfo = nil
+	var containerInfo *ContainerInfo
 	for _, rec := range records {
 		if rec.Name != "config/running_containers" {
 			continue

--- a/pkg/gatherers/interface.go
+++ b/pkg/gatherers/interface.go
@@ -16,7 +16,7 @@ type Interface interface {
 	GetGatheringFunctions() map[string]GatheringClosure
 }
 
-// CustomPeriodGatherer. Gatherers implementing this interface may not get to each archive
+// CustomPeriodGatherer gatherers implementing this interface may not get to each archive
 // and their period can be different from interval in the config(equal or higher, but never lower)
 type CustomPeriodGatherer interface {
 	Interface

--- a/pkg/record/memory.go
+++ b/pkg/record/memory.go
@@ -2,7 +2,7 @@ package record
 
 import "time"
 
-// Represents records stored in memory
+// MemoryRecord Represents records stored in memory
 type MemoryRecord struct {
 	Name        string
 	Fingerprint string

--- a/pkg/record/record.go
+++ b/pkg/record/record.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// Represents a record that will be stored as a file.
+// Record represents a record that will be stored as a file.
 type Record struct {
 	Name     string
 	Captured time.Time

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -17,7 +17,7 @@ import (
 // MaxArchiveSize defines maximum allowed tarball size
 const MaxArchiveSize = 8 * 1024 * 1024
 
-// Metadata record name
+// MetadataRecordName defines the metadata record name
 const MetadataRecordName = "insights-operator/gathers"
 
 type alreadyReported interface {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR replaces `golint` with `revive`, since `golint` is deprecated and `revive` is 6x faster than `golint`. Also, this PR fixes some linting issues pointed by `revive`.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in the sample archive? -->

No.

## Documentation
<!-- Are these changes reflected in documentation? -->

No.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/container_images_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

N/A

## Changelog
<!-- Was changelog updated? -->

N/A

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No.

## References
<!-- What are related references for this PR? -->

https://bugzilla.redhat.com/show_bug.cgi?id=1969525
