### PR TITLE
Better pod log gathering with offset for stacktrace messages

### DIFF
--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -14,9 +14,11 @@ const (
 var (
 	registryScheme = runtime.NewScheme()
 	// logMaxLines sets maximum number of lines of the log file
-	logMaxLines = int64(100)
+	logMaxTailLines = int64(100)
+	// logMaxLongTailLines sets maximum number of lines of the long log file
+	logMaxLongTailLines = int64(200)
 	// logLinesOffset sets the maximum offset if a stacktrace message was found in the logs
-	logLinesOffset = int64(20)
+	logLinesOffset = int64(10)
 
 	defaultNamespaces           = []string{"default", "kube-system", "kube-public"}
 	datahubGroupVersionResource = schema.GroupVersionResource{

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -16,9 +16,9 @@ var (
 	// logMaxLines sets maximum number of lines of the log file
 	logMaxTailLines = int64(100)
 	// logMaxLongTailLines sets maximum number of lines of the long log file
-	logMaxLongTailLines = int64(200)
+	logMaxLongTailLines = int64(2000)
 	// logLinesOffset sets the maximum offset if a stacktrace message was found in the logs
-	logLinesOffset = int64(10)
+	logLinesOffset = int64(20)
 
 	defaultNamespaces           = []string{"default", "kube-system", "kube-public"}
 	datahubGroupVersionResource = schema.GroupVersionResource{

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -14,9 +14,9 @@ const (
 var (
 	registryScheme = runtime.NewScheme()
 	// logTailLines sets maximum number of lines to fetch from pod logs
-	logTailLines = int64(100)
-	// logTailLinesLong sets the maximum number of lines to fetch from long pod logs
-	logTailLinesLong = int64(400)
+	logTailLines = int64(4000)
+	// logLinesOffset sets the maximum offset if a stacktrace message was found in the logs
+	logLinesOffset = int64(100)
 
 	defaultNamespaces           = []string{"default", "kube-system", "kube-public"}
 	datahubGroupVersionResource = schema.GroupVersionResource{

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -18,7 +18,7 @@ var (
 	// logMaxLongTailLines sets maximum number of lines of the long log file
 	logMaxLongTailLines = int64(2000)
 	// logLinesOffset sets the maximum offset if a stacktrace message was found in the logs
-	logLinesOffset = int64(20)
+	logLinesOffset = 20
 
 	defaultNamespaces           = []string{"default", "kube-system", "kube-public"}
 	datahubGroupVersionResource = schema.GroupVersionResource{

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -13,10 +13,10 @@ const (
 
 var (
 	registryScheme = runtime.NewScheme()
-	// logTailLines sets maximum number of lines to fetch from pod logs
-	logTailLines = int64(4000)
+	// logMaxLines sets maximum number of lines of the log file
+	logMaxLines = int64(100)
 	// logLinesOffset sets the maximum offset if a stacktrace message was found in the logs
-	logLinesOffset = int64(100)
+	logLinesOffset = int64(20)
 
 	defaultNamespaces           = []string{"default", "kube-system", "kube-public"}
 	datahubGroupVersionResource = schema.GroupVersionResource{

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -316,21 +316,18 @@ func getContainerLogs(ctx context.Context,
 
 // getLogWithStacktracing search for the first stack trace line and offset it by logLinesOffset
 func getLogWithStacktracing(logArray []string) string {
-	var log []string
-	var found bool
-
+	var limit int
 	for idx := range logArray {
 		line := logArray[idx]
-		log = append(log, line)
-		if !found {
-			if len(log) > logLinesOffset {
-				log = log[1:]
+		if found := stackTraceRegex.MatchString(line); found {
+			limit = idx - logLinesOffset
+			if limit < 0 {
+				limit = 0
 			}
-			found = stackTraceRegex.MatchString(line)
+			break
 		}
 	}
-
-	return strings.Join(log, "\n")
+	return strings.Join(logArray[limit:], "\n")
 }
 
 // getContainerLogString fetch the container log from API and return it as String

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -41,7 +41,7 @@ type CompactedEventList struct {
 }
 
 // Used to detect the possible stack trace on logs
-var stackTraceRegex = regexp.MustCompile(`.*/[^/]*:\d+.*0[xX][0-9a-fA-F]+`)
+var stackTraceRegex = regexp.MustCompile(`\.go:[0-9]+\s\+0x`)
 
 // GatherClusterOperatorPodsAndEvents collects information about all pods
 // and events from namespaces of degraded cluster operators. The collected

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -40,7 +40,7 @@ type CompactedEventList struct {
 }
 
 // Used to detect the possible stack trace on logs
-var stackTraceRegex = regexp.MustCompile(`\.go:[0-9]+\s\+0x`)
+var stackTraceRegex = regexp.MustCompile(`\.go:\d+\s\+0x`)
 
 // GatherClusterOperatorPodsAndEvents collects information about all pods
 // and events from namespaces of degraded cluster operators. The collected

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -321,21 +321,12 @@ func getLogWithStacktracing(logArray []string) string {
 
 	for idx := range logArray {
 		line := logArray[idx]
-		// if it already found the stack we just want to keep add the log till the end
-		if found {
-			log = append(log, line)
-			continue
-		}
-		// tries to find the stack message at the given line and add it to the log
-		if found = stackTraceRegex.MatchString(line); found {
-			log = append(log, line)
-			continue
-		}
-		// if it didn't find the line yet, keep add it as offset limiting by the arbitrary
-		// offset limit value
 		log = append(log, line)
-		if len(log) > logLinesOffset {
-			log = log[1:]
+		if !found {
+			if len(log) > logLinesOffset {
+				log = log[1:]
+			}
+			found = stackTraceRegex.MatchString(line)
 		}
 	}
 

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -335,8 +335,6 @@ func getLogWithStacktracing(logArray []string) string {
 		// offset limit value
 		log = append(log, line)
 		if len(log) > logLinesOffset {
-			// to avoid memory leaks (https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order)
-			log[0] = ""
 			log = log[1:]
 		}
 	}

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -334,7 +334,7 @@ func getLogWithStacktracing(logArray []string) string {
 		// if it didn't find the line yet, keep add it as offset limiting by the arbitrary
 		// offset limit value
 		log = append(log, line)
-		if len(log) > int(logLinesOffset) {
+		if len(log) > logLinesOffset {
 			// to avoid memory leaks (https://github.com/golang/go/wiki/SliceTricks#delete-without-preserving-order)
 			log[0] = ""
 			log = log[1:]


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a better way to gather the pod container logs by using an offset limit based on the line where the first stack trace message is found.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in the sample archive? -->

No.

## Documentation
<!-- Are these changes reflected in documentation? -->

No.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

No.

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using the operator's data. -->

No.

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-4600
