### PR TITLE
Enables godox on precommit

### DIFF
--- a/.golangci.precommit.yml
+++ b/.golangci.precommit.yml
@@ -60,6 +60,8 @@ linters-settings:
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
 
 linters:
+  enable:
+    - godox
   disable:
     - gomnd
 


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR enables the godox linter to checks at the precommit for TODO, FIXME, and BUG comments. To help us to avoid issue tracking. (PS: It doesn't not affect the CI)

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No.

## Documentation
<!-- Are these changes reflected in documentation? -->

No.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

No.

## Changelog
<!-- Was changelog updated? -->

No.

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No.

## References
<!-- What are related references for this PR? -->

No.