### PR TITLE
Bugzilla 1975542: Add delete annotation to stale resources

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -224,6 +224,42 @@ subjects:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: insights-operator-obfuscation-secret
+  namespace: openshift-insights
+  annotations:
+    release.openshift.io/delete: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: insights-operator-obfuscation-secret
+  namespace: openshift-insights
+  annotations:
+    release.openshift.io/delete: "true"
+roleRef:
+  kind: Role
+  name: insights-operator-obfuscation-secret
+subjects:
+- kind: ServiceAccount
+  name: gather
+  namespace: openshift-insights
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: insights-operator-gather-reader


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
I found out that we need to keep these resource definitions and add this new delete annotation so that CVO can remove them after upgrading from 4.8 to 4.9.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=1975542
https://access.redhat.com/solutions/???
