### PR TITLE
Update the gather functions to collect data from the system namespaces only

### DIFF
--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -18,7 +18,7 @@ var (
 	// logTailLinesLong sets the maximum number of lines to fetch from long pod logs
 	logTailLinesLong = int64(400)
 
-	defaultNamespaces           = []string{"default", "kube-system", "kube-public"}
+	defaultNamespaces           = []string{"default", "kube-system", "kube-public", "openshift"}
 	datahubGroupVersionResource = schema.GroupVersionResource{
 		Group: "installers.datahub.sap.com", Version: "v1alpha1", Resource: "datahubs",
 	}

--- a/pkg/gatherers/clusterconfig/container_images.go
+++ b/pkg/gatherers/clusterconfig/container_images.go
@@ -67,7 +67,7 @@ func gatherContainerImages(ctx context.Context, coreClient corev1client.CoreV1In
 
 		for podIndex, pod := range pods.Items { //nolint:gocritic
 			podPtr := &pods.Items[podIndex]
-			if strings.HasPrefix(pod.Namespace, "openshift") && check.HasContainerInCrashloop(podPtr) {
+			if strings.HasPrefix(pod.Namespace, "openshift-") && check.HasContainerInCrashloop(podPtr) {
 				records = append(records, record.Record{
 					Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name),
 					Item: record.JSONMarshaller{Object: podPtr},

--- a/pkg/gatherers/clusterconfig/install_plans.go
+++ b/pkg/gatherers/clusterconfig/install_plans.go
@@ -63,9 +63,9 @@ func gatherInstallPlans(ctx context.Context,
 	if err != nil {
 		return nil, []error{err}
 	}
-	// collect from all openshift* namespaces
+	// collect from all openshift-* namespaces
 	for i := range config.Items {
-		if !strings.HasPrefix(config.Items[i].Name, "openshift") {
+		if !strings.HasPrefix(config.Items[i].Name, "openshift-") {
 			continue
 		}
 		resInterface := dynamicClient.Resource(opResource).Namespace(config.Items[i].Name)

--- a/pkg/gatherers/clusterconfig/install_plans.go
+++ b/pkg/gatherers/clusterconfig/install_plans.go
@@ -63,9 +63,9 @@ func gatherInstallPlans(ctx context.Context,
 	if err != nil {
 		return nil, []error{err}
 	}
-	// collect from all openshift-* namespaces
+	// collect from openshift and all openshift-* namespaces
 	for i := range config.Items {
-		if !strings.HasPrefix(config.Items[i].Name, "openshift-") {
+		if config.Items[i].Name != "openshift" && !strings.HasPrefix(config.Items[i].Name, "openshift-") {
 			continue
 		}
 		resInterface := dynamicClient.Resource(opResource).Namespace(config.Items[i].Name)

--- a/pkg/gatherers/clusterconfig/service_accounts.go
+++ b/pkg/gatherers/clusterconfig/service_accounts.go
@@ -53,9 +53,9 @@ func gatherServiceAccounts(ctx context.Context, coreClient corev1client.CoreV1In
 	var serviceAccounts []corev1.ServiceAccount
 	var records []record.Record
 	namespaces := defaultNamespaces
-	// collect from all openshift* namespaces + kubernetes defaults
+	// collect from all openshift-* namespaces + kubernetes defaults
 	for i := range config.Items {
-		if strings.HasPrefix(config.Items[i].Name, "openshift") {
+		if strings.HasPrefix(config.Items[i].Name, "openshift-") {
 			namespaces = append(namespaces, config.Items[i].Name)
 		}
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
IIUC, the gather functions (serviceaccount, installplan and container images) want to collect the resources in the system(openshift) namespaces only. So, we will check if the namespace has prefix `openshift`,  but the openshift preserved namespace prefixes are `openshift-, kube-` per doc [1].

[1] https://docs.openshift.com/container-platform/4.7/applications/projects/working-with-projects.html

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [x] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No changes

## Documentation
<!-- Are these changes reflected in documentation? -->

No changes

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No changes

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

No new collected data

## Changelog
No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://docs.openshift.com/container-platform/4.7/applications/projects/working-with-projects.html
