### PR TITLE
Bug 1982170: Set also the summary operation when updating status

### DIFF
--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -64,6 +64,7 @@ func (s *Simple) UpdateStatus(summary Summary) { //nolint: gocritic
 		klog.V(2).Infof("name=%s healthy=%t reason=%s message=%s", s.Name, summary.Healthy, summary.Reason, summary.Message)
 		s.summary.Reason = summary.Reason
 		s.summary.Message = summary.Message
+		s.summary.Operation = summary.Operation
 		return
 	}
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Set also to operation so it can be distinguished in `status.go`. See the messy code here https://github.com/openshift/insights-operator/blob/master/pkg/controller/status/status.go#L156. We should probably set `degradingFailure` to false by default. There's already issue to refactor this method. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new test but we should think about some integration test if possible. 

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=1982170
https://access.redhat.com/solutions/???
