### PR TITLE
Bug 1988349: Insightsreport set corresponding clusteroperator condition correctly

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -163,6 +163,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	go uploader.Run(ctx)
 
 	reportGatherer := insightsreport.New(insightsClient, configObserver, uploader)
+	statusReporter.AddSources(reportGatherer)
 	go reportGatherer.Run(ctx)
 
 	klog.Warning("started")


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR registers the `insightsreport` status controller so that the operation can be distinguished and new condition (called `InsightsDownloadDegraded`) introduced 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

I will work on new integration test.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
