### PR TITLE
Bug 1984047: Do not use klog.Fatal

### DIFF
--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -69,15 +69,15 @@ func NewGather() *cobra.Command {
 func runGather(operator *controller.GatherJob, cfg *controllercmd.ControllerCommandConfig) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if configArg := cmd.Flags().Lookup("config").Value.String(); len(configArg) == 0 {
-			klog.Error("error: --config is required")
+			klog.Exit("error: --config is required")
 		}
 		unstructured, _, _, err := cfg.Config()
 		if err != nil {
-			klog.Error(err)
+			klog.Exit(err)
 		}
 		cont, err := config.LoadConfig(operator.Controller, unstructured.Object, config.ToDisconnectedController)
 		if err != nil {
-			klog.Error(err)
+			klog.Exit(err)
 		}
 		operator.Controller = cont
 
@@ -85,20 +85,20 @@ func runGather(operator *controller.GatherJob, cfg *controllercmd.ControllerComm
 		if kubeConfigPath := cmd.Flags().Lookup("kubeconfig").Value.String(); len(kubeConfigPath) > 0 {
 			kubeConfigBytes, err := ioutil.ReadFile(kubeConfigPath) //nolint: govet
 			if err != nil {
-				klog.Error(err)
+				klog.Exit(err)
 			}
 			kubeConfig, err := clientcmd.NewClientConfigFromBytes(kubeConfigBytes)
 			if err != nil {
-				klog.Error(err)
+				klog.Exit(err)
 			}
 			clientConfig, err = kubeConfig.ClientConfig()
 			if err != nil {
-				klog.Error(err)
+				klog.Exit(err)
 			}
 		} else {
 			clientConfig, err = rest.InClusterConfig()
 			if err != nil {
-				klog.Error(err)
+				klog.Exit(err)
 			}
 		}
 		protoConfig := rest.CopyConfig(clientConfig)
@@ -125,17 +125,17 @@ func runOperator(operator *controller.Operator, cfg *controllercmd.ControllerCom
 		serviceability.StartProfiler()
 
 		if configArg := cmd.Flags().Lookup("config").Value.String(); len(configArg) == 0 {
-			klog.Error("error: --config is required")
+			klog.Exit("error: --config is required")
 		}
 
 		unstructured, operatorConfig, configBytes, err := cfg.Config()
 		if err != nil {
-			klog.Error(err)
+			klog.Exit(err)
 		}
 
 		startingFileContent, observedFiles, err := cfg.AddDefaultRotationToConfig(operatorConfig, configBytes)
 		if err != nil {
-			klog.Error(err)
+			klog.Exit(err)
 		}
 
 		// if the service CA is rotated, we want to restart

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -69,15 +69,15 @@ func NewGather() *cobra.Command {
 func runGather(operator *controller.GatherJob, cfg *controllercmd.ControllerCommandConfig) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		if configArg := cmd.Flags().Lookup("config").Value.String(); len(configArg) == 0 {
-			klog.Fatalf("error: --config is required")
+			klog.Error("error: --config is required")
 		}
 		unstructured, _, _, err := cfg.Config()
 		if err != nil {
-			klog.Fatal(err)
+			klog.Error(err)
 		}
 		cont, err := config.LoadConfig(operator.Controller, unstructured.Object, config.ToDisconnectedController)
 		if err != nil {
-			klog.Fatal(err)
+			klog.Error(err)
 		}
 		operator.Controller = cont
 
@@ -85,20 +85,20 @@ func runGather(operator *controller.GatherJob, cfg *controllercmd.ControllerComm
 		if kubeConfigPath := cmd.Flags().Lookup("kubeconfig").Value.String(); len(kubeConfigPath) > 0 {
 			kubeConfigBytes, err := ioutil.ReadFile(kubeConfigPath) //nolint: govet
 			if err != nil {
-				klog.Fatal(err)
+				klog.Error(err)
 			}
 			kubeConfig, err := clientcmd.NewClientConfigFromBytes(kubeConfigBytes)
 			if err != nil {
-				klog.Fatal(err)
+				klog.Error(err)
 			}
 			clientConfig, err = kubeConfig.ClientConfig()
 			if err != nil {
-				klog.Fatal(err)
+				klog.Error(err)
 			}
 		} else {
 			clientConfig, err = rest.InClusterConfig()
 			if err != nil {
-				klog.Fatal(err)
+				klog.Error(err)
 			}
 		}
 		protoConfig := rest.CopyConfig(clientConfig)
@@ -108,7 +108,7 @@ func runGather(operator *controller.GatherJob, cfg *controllercmd.ControllerComm
 		ctx, cancel := context.WithTimeout(context.Background(), operator.Interval)
 		err = operator.Gather(ctx, clientConfig, protoConfig)
 		if err != nil {
-			klog.Fatal(err)
+			klog.Error(err)
 		}
 		cancel()
 		os.Exit(0)
@@ -125,17 +125,17 @@ func runOperator(operator *controller.Operator, cfg *controllercmd.ControllerCom
 		serviceability.StartProfiler()
 
 		if configArg := cmd.Flags().Lookup("config").Value.String(); len(configArg) == 0 {
-			klog.Fatalf("error: --config is required")
+			klog.Error("error: --config is required")
 		}
 
 		unstructured, operatorConfig, configBytes, err := cfg.Config()
 		if err != nil {
-			klog.Fatal(err)
+			klog.Error(err)
 		}
 
 		startingFileContent, observedFiles, err := cfg.AddDefaultRotationToConfig(operatorConfig, configBytes)
 		if err != nil {
-			klog.Fatal(err)
+			klog.Error(err)
 		}
 
 		// if the service CA is rotated, we want to restart
@@ -164,7 +164,7 @@ func runOperator(operator *controller.Operator, cfg *controllercmd.ControllerCom
 			WithServer(operatorConfig.ServingInfo, operatorConfig.Authentication, operatorConfig.Authorization).
 			WithRestartOnChange(exitOnChangeReactorCh, startingFileContent, observedFiles...)
 		if err := builder.Run(ctx2, unstructured); err != nil {
-			klog.Fatal(err)
+			klog.Error(err)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
`klog.Fatal` dumps goroutines stack traces and calls `os.Exit(255)`. This is not desired.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No documentation update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=1984047
https://access.redhat.com/solutions/???
