### PR TITLE
Bug 1991860: Don't try to record an empty Record if gatherClusterConfigV1 fails

### DIFF
--- a/pkg/gatherers/clusterconfig/config_maps.go
+++ b/pkg/gatherers/clusterconfig/config_maps.go
@@ -54,7 +54,7 @@ func (g *Gatherer) GatherConfigMaps(ctx context.Context) ([]record.Record, []err
 	errs = append(errs, monitoringErrs...)
 
 	clusterConfigV1Rec, clusterConfigV1Errs := gatherClusterConfigV1(ctx, coreClient)
-	records = append(records, clusterConfigV1Rec)
+	records = append(records, clusterConfigV1Rec...)
 	errs = append(errs, clusterConfigV1Errs...)
 
 	return records, errs


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Currently, `gatherClusterConfigV1` returns `(Record{}, error)` on failure, and its caller appends the empty `Record` into its results; that later crashes in `Record.Filename()` because `Record.Item` is `nil`.

Instead, be more similar to the sibling function and return a `[]Record{}`, which allows `gatherClusterConfigV1` to return no records.

## Categories
- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
See https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/2695/pull-ci-openshift-machine-config-operator-master-e2e-aws-disruptive/1421081909886193664

## Documentation

## Unit Tests
N/A, the existing code doesn’t have unit tests of this nature.

## Privacy
N/A, no newly collected information.

## Changelog
?

## Breaking Changes
No

## References
None