### PR TITLE
Bug 1991860: Don't try to record an empty Record if gatherClusterConfigV1 fails

### DIFF
--- a/pkg/gatherers/clusterconfig/cluster_config_v1_config_map.go
+++ b/pkg/gatherers/clusterconfig/cluster_config_v1_config_map.go
@@ -18,7 +18,7 @@ import (
 func gatherClusterConfigV1(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
 	configMap, err := coreClient.ConfigMaps("kube-system").Get(ctx, "cluster-config-v1", metav1.GetOptions{})
 	if err != nil {
-		return record.Record{}, []error{err}
+		return nil, []error{err}
 	}
 
 	newData := make(map[string]string)
@@ -27,14 +27,14 @@ func gatherClusterConfigV1(ctx context.Context, coreClient corev1client.CoreV1In
 		installConfig := &installertypes.InstallConfig{}
 		err := yaml.Unmarshal([]byte(installConfigStr), installConfig)
 		if err != nil {
-			return record.Record{}, []error{err}
+			return nil, []error{err}
 		}
 
 		installConfig = anonymizeInstallConfig(installConfig)
 
 		installConfigBytes, err := yaml.Marshal(installConfig)
 		if err != nil {
-			return record.Record{}, []error{err}
+			return nil, []error{err}
 		}
 
 		newData["install-config"] = string(installConfigBytes)

--- a/pkg/gatherers/clusterconfig/cluster_config_v1_config_map.go
+++ b/pkg/gatherers/clusterconfig/cluster_config_v1_config_map.go
@@ -15,7 +15,7 @@ import (
 
 // gatherClusterConfigV1 gathers "cluster-config-v1" from "kube-system" namespace leaving only "install-config" from data.
 // "install-config" is anonymized.
-func gatherClusterConfigV1(ctx context.Context, coreClient corev1client.CoreV1Interface) (record.Record, []error) {
+func gatherClusterConfigV1(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
 	configMap, err := coreClient.ConfigMaps("kube-system").Get(ctx, "cluster-config-v1", metav1.GetOptions{})
 	if err != nil {
 		return record.Record{}, []error{err}
@@ -42,10 +42,10 @@ func gatherClusterConfigV1(ctx context.Context, coreClient corev1client.CoreV1In
 
 	configMap.Data = newData
 
-	return record.Record{
+	return []record.Record{{
 		Name: fmt.Sprintf("config/configmaps/%s/%s", configMap.Namespace, configMap.Name),
 		Item: record.JSONMarshaller{Object: configMap},
-	}, nil
+	}}, nil
 }
 
 func anonymizeInstallConfig(installConfig *installertypes.InstallConfig) *installertypes.InstallConfig {

--- a/pkg/gatherers/clusterconfig/config_maps.go
+++ b/pkg/gatherers/clusterconfig/config_maps.go
@@ -54,7 +54,7 @@ func (g *Gatherer) GatherConfigMaps(ctx context.Context) ([]record.Record, []err
 	errs = append(errs, monitoringErrs...)
 
 	clusterConfigV1Rec, clusterConfigV1Errs := gatherClusterConfigV1(ctx, coreClient)
-	records = append(records, clusterConfigV1Rec)
+	records = append(records, clusterConfigV1Rec...)
 	errs = append(errs, clusterConfigV1Errs...)
 
 	return records, errs

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -53,6 +53,9 @@ func (r *Recorder) Record(rec record.Record) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 	klog.V(4).Infof("Recording %s with fingerprint=%s", rec.Name, rec.Fingerprint)
+	if rec.Item == nil {
+		return fmt.Errorf("empty %s record data. Nothing will be recorded", rec.Name)
+	}
 	if r.has(rec) {
 		return nil
 	}

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -189,3 +189,13 @@ func Test_ObfuscatedRecord_NameCorrect(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, rec.size, int64(0))
 }
+
+func Test_EmptyItemRecord(t *testing.T) {
+	rec := newRecorder(MaxArchiveSize, "")
+
+	testRec := record.Record{
+		Name: "test/empty",
+	}
+	err := rec.Record(testRec)
+	assert.Equal(t, err, fmt.Errorf("empty %s record data. Nothing will be recorded", testRec.Name))
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

- do not return an empty `Record` in the `gatherClusterConfigV1`
- check if the empty `record.Item` is not empty before actual recording + basic test

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
Test added in:
- `pkg/recorder/recorder_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=1991860
https://access.redhat.com/solutions/???
