### PR TITLE
Bug 1995913: Degraded status in the OCM controller

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -180,7 +180,8 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			downloadReason = summary.Reason
 			downloadMessage = summary.Message
 		} else if summary.Operation == controllerstatus.PullingSCACerts {
-			// summary.Count
+			klog.V(4).Infof("Failed to download the SCA certs within the threshold %d with exponential backoff. Marking as degraded.",
+				uploadFailuresCountThreshold)
 			degradingFailure = true
 			ocmErrorMsg = summary.Message
 			ocmErrorReason = summary.Reason

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -181,7 +181,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			downloadMessage = summary.Message
 		} else if summary.Operation == controllerstatus.PullingSCACerts {
 			klog.V(4).Infof("Failed to download the SCA certs within the threshold %d with exponential backoff. Marking as degraded.",
-				uploadFailuresCountThreshold)
+				OCMAPIFailureCountThreshold)
 			degradingFailure = true
 			ocmErrorMsg = summary.Message
 			ocmErrorReason = summary.Reason

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -36,6 +36,9 @@ const (
 	uploadFailuresCountThreshold = 5
 	// GatherFailuresCountThreshold defines how many gatherings can fail in a row before we report Degraded
 	GatherFailuresCountThreshold = 5
+	// OCMAPIFailureCountThreshold defines how many unsuccessful responses from the OCM API in a row is tolerated
+	// before the operator is marked as Degraded
+	OCMAPIFailureCountThreshold = 5
 )
 
 type Reported struct {

--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -20,6 +20,8 @@ const (
 	Uploading Operation = "Uploading"
 	// GatheringReport specific for gathering the report from the cluster
 	GatheringReport Operation = "GatheringReport"
+	// PullingSCACerts is specific operation for pulling the SCA certs data from the OCM API
+	PullingSCACerts Operation = "PullingSCACerts"
 )
 
 // Summary represents the status summary of an Operation

--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -93,9 +93,9 @@ func (c *Controller) PullSmartProxy() (bool, error) {
 	} else if err == insightsclient.ErrWaitingForVersion {
 		klog.Error(err)
 		return false, err
-	} else if insightsclient.IsInsightsError(err) {
+	} else if insightsclient.IsHttpError(err) {
 
-		ie := err.(insightsclient.InsightsError)
+		ie := err.(insightsclient.HttpError)
 		klog.Errorf("Unexpected error retrieving the report: %s", ie)
 		// if there's a 404 response then retry
 		if ie.StatusCode == http.StatusNotFound {

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -190,7 +190,7 @@ func (c *Controller) updateSecret(s *v1.Secret, ocmData *ScaResponse) (*v1.Secre
 // Data return value still can be an empty array in case of HTTP 404 error.
 func (c *Controller) requestSCAWithExpBackoff(endpoint string) ([]byte, error) {
 	bo := wait.Backoff{
-		Duration: 10 * time.Minute,
+		Duration: c.configurator.Config().OCMConfig.Interval / 32, // 15 min by default
 		Factor:   2,
 		Jitter:   0,
 		Steps:    status.OCMAPIFailureCountThreshold,

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -8,11 +8,13 @@ import (
 	"time"
 
 	"github.com/openshift/insights-operator/pkg/config"
+	"github.com/openshift/insights-operator/pkg/controller/status"
 	"github.com/openshift/insights-operator/pkg/controllerstatus"
 	"github.com/openshift/insights-operator/pkg/insights/insightsclient"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 )
@@ -84,22 +86,25 @@ func (c *Controller) Run() {
 }
 
 func (c *Controller) requestDataAndCheckSecret(endpoint string) {
-	data, err := c.client.RecvSCACerts(c.ctx, endpoint)
+	data, err := c.requestSCAWithExpBackoff(endpoint)
 	if err != nil {
-		if insightsclient.IsHttpError(err) {
-			httpErr := err.(insightsclient.HttpError)
-			// we don't want to update the status when there's HTTP 404 response from the OCM API, because it means
-			// the SCA certs are not allowed for the given organization
-			if httpErr.StatusCode != http.StatusNotFound {
-				c.Simple.UpdateStatus(controllerstatus.Summary{
-					Operation: controllerstatus.PullingSCACerts,
-					Reason:    "FailedToPullSCACerts",
-					Message:   fmt.Sprintf("Failed to pull SCA certs from %s: %v", endpoint, err),
-				})
-				return
-			}
-		}
-		klog.Errorf("Failed to retrieve data: %v", err)
+		// in case of any error other than 404 mark the operator as degraded
+		c.Simple.UpdateStatus(controllerstatus.Summary{
+			Operation: controllerstatus.PullingSCACerts,
+			Reason:    "FailedToPullSCACerts",
+			Message:   fmt.Sprintf("Failed to pull SCA certs from %s: %v", endpoint, err),
+		})
+		return
+	}
+	// handle the case with HTTP 404
+	if len(data) == 0 {
+		msg := fmt.Sprintf("Received no SCA certs from the %s. Please check if it's enabled for your organization.", endpoint)
+		klog.Info(msg)
+		c.Simple.UpdateStatus(controllerstatus.Summary{
+			Operation: controllerstatus.PullingSCACerts,
+			Message:   msg,
+			Healthy:   true,
+		})
 		return
 	}
 	var ocmRes ScaResponse
@@ -178,4 +183,38 @@ func (c *Controller) updateSecret(s *v1.Secret, ocmData *ScaResponse) (*v1.Secre
 		return nil, err
 	}
 	return s, nil
+}
+
+// requestSCAWithExpBackoff queries OCM API with exponential backoff and returns
+// an error only in case of an HTTP error other than 404 received from the OCM API.
+// Data return value still can be an empty array in case of HTTP 404 error.
+func (c *Controller) requestSCAWithExpBackoff(endpoint string) ([]byte, error) {
+	bo := wait.Backoff{
+		Duration: 5 * time.Minute,
+		Factor:   2,
+		Jitter:   0,
+		Steps:    status.OCMAPIFailureCountThreshold,
+	}
+	var data []byte
+	err := wait.ExponentialBackoff(bo, func() (bool, error) {
+		var err error
+		data, err = c.client.RecvSCACerts(c.ctx, endpoint)
+		if err != nil {
+			if !insightsclient.IsHttpError(err) {
+				return false, nil
+			}
+			httpErr := err.(insightsclient.HttpError)
+			// don't try again in case of 404
+			if httpErr.StatusCode == http.StatusNotFound {
+				return true, nil
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	// exp. backoff timeouted -> error
+	if err != nil {
+		return nil, fmt.Errorf("timed out waiting for the successful response from %s", endpoint)
+	}
+	return data, nil
 }

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -190,10 +190,11 @@ func (c *Controller) updateSecret(s *v1.Secret, ocmData *ScaResponse) (*v1.Secre
 // Data return value still can be an empty array in case of HTTP 404 error.
 func (c *Controller) requestSCAWithExpBackoff(endpoint string) ([]byte, error) {
 	bo := wait.Backoff{
-		Duration: 5 * time.Minute,
+		Duration: 10 * time.Minute,
 		Factor:   2,
 		Jitter:   0,
 		Steps:    status.OCMAPIFailureCountThreshold,
+		Cap:      c.configurator.Config().OCMConfig.Interval,
 	}
 	var data []byte
 	err := wait.ExponentialBackoff(bo, func() (bool, error) {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This adds status checking to the OCM controller. If the response from the OCM API is an HTTP error other than 404 (which means that SCA certs are not allowed for the given organization) then try again with exponential backoff and after few attempts mark the operator as degraded.  
At the same time, the status doesn't have to be changed to degraded in a disconnected environment. This means that any non-HTTP error is not considered as a reason for marking the operator as degraded.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No documentation update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=1995913
https://access.redhat.com/solutions/???
