### PR TITLE
[release-4.8] Bug 2001457: Gather installed PSP names (#489)

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -521,6 +521,19 @@ Response see https://docs.okd.io/latest/rest_api/policy_apis/poddisruptionbudget
   * 4.6+
 
 
+## PodSecurityPolicies
+
+gathers the names of installed PodSecurityPolicies
+
+The Kubernetes API https://github.com/kubernetes/client-go/blob/v12.0.0/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go#L76
+
+* Location in archive: config/psp_names.json
+* See: docs/insights-archive-sample/config/psp_names.json
+* Id in config: psps
+* Since versions:
+  * 4.10+
+
+
 ## SAPConfig
 
 collects selected security context constraints

--- a/docs/insights-archive-sample/config/psp_names.json
+++ b/docs/insights-archive-sample/config/psp_names.json
@@ -1,0 +1,4 @@
+[
+    "100-psp",
+    "next-psp-name"
+]

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -85,6 +85,7 @@ var gatheringFunctions = map[string]gatheringFunction{
 	"olm_operators":                     failableFunc((*Gatherer).GatherOLMOperators),
 	"pod_network_connectivity_checks":   failableFunc((*Gatherer).GatherPNCC),
 	"machine_autoscalers":               failableFunc((*Gatherer).GatherMachineAutoscalers),
+	"psps":                              failableFunc((*Gatherer).GatherPodSecurityPolicies),
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/pod_security_policies.go
+++ b/pkg/gatherers/clusterconfig/pod_security_policies.go
@@ -1,0 +1,43 @@
+package clusterconfig
+
+import (
+	"context"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
+)
+
+// GatherPodSecurityPolicies gathers the names of installed PodSecurityPolicies
+//
+// The Kubernetes API https://github.com/kubernetes/client-go/blob/v12.0.0/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go#L76
+//
+// * Location in archive: config/psp_names.json
+// * See: docs/insights-archive-sample/config/psp_names.json
+// * Id in config: psps
+// * Since versions:
+//   * 4.10+
+func (g *Gatherer) GatherPodSecurityPolicies(ctx context.Context) ([]record.Record, []error) {
+	gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherPodSecurityPolicies(ctx, gatherPolicyClient)
+}
+
+func gatherPodSecurityPolicies(ctx context.Context, policyClient policyclient.PolicyV1beta1Interface) ([]record.Record, []error) {
+	psps, err := policyClient.PodSecurityPolicies().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, []error{err}
+	}
+	pspNames := make([]string, 0, len(psps.Items))
+	for i := range psps.Items {
+		psp := psps.Items[i]
+		pspNames = append(pspNames, psp.Name)
+	}
+	return []record.Record{{
+		Name: "config/psp_names",
+		Item: record.JSONMarshaller{Object: pspNames},
+	}}, nil
+}

--- a/pkg/gatherers/clusterconfig/pod_security_policies_test.go
+++ b/pkg/gatherers/clusterconfig/pod_security_policies_test.go
@@ -1,0 +1,47 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+var (
+	psp1 *policyv1beta1.PodSecurityPolicy = &policyv1beta1.PodSecurityPolicy{
+		ObjectMeta: v1.ObjectMeta{Name: "psp-1"},
+	}
+	psp2 *policyv1beta1.PodSecurityPolicy = &policyv1beta1.PodSecurityPolicy{
+		ObjectMeta: v1.ObjectMeta{Name: "psp-2"},
+	}
+)
+
+func Test_PodSecurityPolicies_Gather(t *testing.T) {
+	coreClient := kubefake.NewSimpleClientset()
+	ctx := context.Background()
+	records, errs := gatherPodSecurityPolicies(ctx, coreClient.PolicyV1beta1())
+	assert.Empty(t, errs, "Unexpected errors: %#v", errs)
+	assert.Len(t, records, 1)
+	s, ok := records[0].Item.(record.JSONMarshaller).Object.([]string)
+	assert.True(t, ok, "Unexpected data format. Expecting an array of strings")
+	assert.Equal(t, s, []string{}, "Expecting an empty array")
+
+	// create some psps
+	_, err := coreClient.PolicyV1beta1().PodSecurityPolicies().Create(ctx, psp1, v1.CreateOptions{})
+	assert.NoError(t, err, "Unexpected error when creating test PodSecurityPolicy")
+	_, err = coreClient.PolicyV1beta1().PodSecurityPolicies().Create(ctx, psp2, v1.CreateOptions{})
+	assert.NoError(t, err, "Unexpected error when creating test PodSecurityPolicy")
+
+	// check that the created PSPs are actually gathered
+	records, errs = gatherPodSecurityPolicies(ctx, coreClient.PolicyV1beta1())
+	assert.Empty(t, errs, "Unexpected errors: %#v", errs)
+	assert.Len(t, records, 1)
+
+	s, ok = records[0].Item.(record.JSONMarshaller).Object.([]string)
+	assert.True(t, ok, "Unexpected data format. Expecting an array of strings")
+	assert.Equal(t, s, []string{"psp-1", "psp-2"}, "Expecting an empty array")
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This adds new gatherer for PodSecurityPolicies names installed in a cluster. There are no psps by default in a cluster so you have to create one (see the example below) to test this.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

Updated
- `docs/insights-archive-sample/config/psp_names.json `

## Documentation
<!-- Are these changes reflected in documentation? -->

Updated
- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Added
- ` pkg/gatherers/clusterconfig/pod_security_policies_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->
https://issues.redhat.com/browse/INSIGHTOCP-433
https://bugzilla.redhat.com/show_bug.cgi?id=2001457
https://access.redhat.com/solutions/5622051
