### PR TITLE
Bug 2003657:  Respect user defined proxy's CA cert

### DIFF
--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -146,6 +146,8 @@ func (c *Client) clientTransport() http.RoundTripper {
 		if userCAPem != nil {
 			if ok := rootCAs.AppendCertsFromPEM(userCAPem); !ok {
 				klog.Error("failed to parse CA pem data")
+			} else {
+				klog.Infof("Sucecssfully added CA cert referenced in the clusterProxy.Spec.TrustedCA bundle")
 			}
 		}
 	}
@@ -466,8 +468,11 @@ func (c *Client) getUserCABundle() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	data := []byte(cm.Data["ca-bundle.crt"])
-	return data, nil
+	data, ok := cm.Data["ca-bundle.crt"]
+	if !ok {
+		return nil, fmt.Errorf("can't find ca-bundle.crt key in %s config map", cmWithCACert)
+	}
+	return []byte(data), nil
 }
 
 var (

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -436,6 +436,8 @@ func ocmErrorMessage(url *url.URL, r *http.Response) error {
 	}
 }
 
+// isProxySet looks up "HTTP_PROXY" and "HTTPS_PROXY" environment variables
+// and returns true if at least one is set
 func isProxySet() (ok bool) {
 	_, httpProxySet := os.LookupEnv("HTTP_PROXY")
 	_, httpsProxySet := os.LookupEnv("HTTPS_PROXY")
@@ -443,8 +445,10 @@ func isProxySet() (ok bool) {
 	return httpProxySet || httpsProxySet
 }
 
+// getUserCABundle reads "cluster" proxy resource to get a name of config map with
+// "TrustedCA" certificate and then it tries to read the certificate data from "ca-bundle.crt" key
+// Returns the certificate data or an error in case of failed reading
 func (c *Client) getUserCABundle() ([]byte, error) {
-	//look at the Config Map reference
 	configCli, err := configv1client.NewForConfig(c.gatherKubeConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This checks if some proxy is defined for the Insights Operator and if so then:

1.  Looks at the cluster-wide proxy spec `clusterProxy.Spec.TrustedCA.Name` to get the  name of the config map with the CA cert
2.  Gets the corresponding config map from the `openshift-config` namespaces
3. Tries to read the `ca-bundle.crt` key from the config map
4. Adds the CA bundle cert to the CA cert pool used in the `insightsclient`

**How to reproduce**
It's quite easy to reproduce the actual problem (you can set some proxy in the cluster-wide proxy and observe the IO error), but it's a bit difficult to verify that this fix works. You can check the https://access.redhat.com/articles/4740031. In general you need to do the following:

1.  Deploy the mitmproxy to a cluster
2. Extract the `mitmproxy-ca-cert.pem` from the mitmproxy container (see `oc exec -n mitmproxy mitmproxy cat /root/.mitmproxy/mitmproxy-ca-cert.pem > /tmp/mitmproxy-ca-cert.pem` (It happened that the mitmproxy container was sometimes killed in my case. **Note that you have to extract the cert again in such case!**)
3. Create a new config map in `openshift-config` namespace containing the cert (see `oc create cm user-ca-bundle -n openshift-config --from-file=ca-bundle.crt=/tmp/mitmproxy-ca-cert.pem`
3. Patch the cluster-wide proxy `spec.TrustedCA` to point to the new config map (see ` oc patch proxy cluster --type=json -p '[{"op":"add","path":"/spec/trustedCA","value":{"name":"user-ca-bundle"}}]'`)
4. Configure the proxy env vars for the IO container:
```
MY_NO_PROXY=$(oc get network cluster --template '{{(index .status.serviceNetwork 0)}},{{(index .status.clusterNetwork 0).cidr}},localhost')
oc set env deployment/insights-operator HTTP_PROXY=http://mitmproxy.mitmproxy.svc:8080 HTTPS_PROXY=http://mitmproxy.mitmproxy.svc:8080 NO_PROXY=$MY_NO_PROXY
```
The IO upload should work fine and it should be visible in the mitmproxy log. Image containing this fix is available at quay.io/tremes/respect_proxy_ca
 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No test. We can think of some integration tests, but we would probably need to deploy mitmproxy container.

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2003657 (originally reported in https://bugzilla.redhat.com/show_bug.cgi?id=1995937)

