### PR TITLE
insightsclient - close response body

### DIFF
--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -111,11 +111,16 @@ func (c *Controller) PullSmartProxy() (bool, error) {
 		})
 		return true, err
 	}
+	defer func() {
+		if err := reportBody.Close(); err != nil {
+			klog.Warningf("Failed to close response body: %v", err)
+		}
+	}()
 
 	klog.V(4).Info("Report retrieved")
 	reportResponse := Response{}
 
-	if err = json.NewDecoder(*reportBody).Decode(&reportResponse); err != nil {
+	if err = json.NewDecoder(reportBody).Decode(&reportResponse); err != nil {
 		klog.Error("The report response cannot be parsed")
 		return true, err
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
The functions `RecvReport` and `RecvSCACerts` don't close the response body. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
