### PR TITLE
[release-4.9] Bug 2004816: Fix the error logic in the OCM controller & degrade only…

### DIFF
--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -413,9 +413,6 @@ func responseBody(r *http.Response) string {
 func ocmErrorMessage(url *url.URL, r *http.Response) error {
 	errMessage := fmt.Sprintf("OCM API %s returned HTTP %d: %s", url, r.StatusCode, responseBody(r))
 	err := fmt.Errorf(errMessage)
-	if r.StatusCode == http.StatusUnauthorized || r.StatusCode == http.StatusForbidden {
-		return authorizer.Error{Err: err}
-	}
 	return HttpError{
 		Err:        err,
 		StatusCode: r.StatusCode,


### PR DESCRIPTION
… in HTTP error (#494)

>= 500

<!-- Short description of the PR. What does it do? -->
This fixes the logic in the exponential backoff and corresponding error handling in the OCM controller. Previously the IO was never marked as degraded because when there was an HTTP (or other) error then the data was `nil` so the status of the controller was always marked as healthy.

Now the `wait.ExponentialBackoff` always returns some error if there's no consequent repeat. The error should be now handled correctly. I think it makes sense to degrade the operator only when the HTTP response code is >= 500, because other 40x errors can mean various problems with the account permissions/settings (The organization didn't allow this functionality etc.)

**How to reproduce**
You will need latest 4.9 cluster (from cluster-bot). You have to to update the `FeatureGate` to allow the TP functionality (see https://docs.openshift.com/container-platform/4.8/nodes/clusters/nodes-cluster-enabling-features.html) and you can play with settings for the IO in `support` secret (in the `openshift-config` namespace):

- you can shorthen the period by setting e.g ocmInterval to 1m
- you can simulate OCM API errors by setting e.g ocmEndpoint to https://httpstat.us/500

The IO should be marked as degraded (when the exp.backoff ends) only in case of HTTP error >=500

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2004816
https://access.redhat.com/solutions/???
