### PR TITLE
Gather jaegers.jaegertracing.io CRs

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -319,6 +319,17 @@ The Operators-Framework api https://github.com/operator-framework/api/blob/maste
   * 4.7+
 
 
+## JaegerCR
+
+collects maximum of 5 jaegers.jaegertracing.io custom resources
+installed in the cluster
+
+* Location in archive: config/jaegertracing.io/
+* Id in config: jaegers
+* Since versions:
+  * 4.10+
+
+
 ## LogsOfNamespace
 
 creates a gathering closure which collects logs from pods in the provided namespace

--- a/docs/insights-archive-sample/config/jaegertracing.io/jaeger1.json
+++ b/docs/insights-archive-sample/config/jaegertracing.io/jaeger1.json
@@ -1,0 +1,108 @@
+{
+    "apiVersion": "jaegertracing.io/v1",
+    "kind": "Jaeger",
+    "metadata": {
+        "creationTimestamp": "2021-09-17T08:38:13Z",
+        "generation": 3,
+        "labels": {
+            "jaegertracing.io/operated-by": "openshift-operators.jaeger-operator"
+        },
+        "name": "jaeger1",
+        "namespace": "openshift-operators",
+        "resourceVersion": "495267",
+        "uid": "46309f18-3fc3-4071-b739-31664ac7becf"
+    },
+    "spec": {
+        "agent": {
+            "config": {},
+            "options": {},
+            "resources": {}
+        },
+        "allInOne": {
+            "config": {},
+            "options": {},
+            "resources": {}
+        },
+        "collector": {
+            "config": {},
+            "options": {},
+            "resources": {}
+        },
+        "ingester": {
+            "config": {},
+            "options": {},
+            "resources": {}
+        },
+        "ingress": {
+            "openshift": {},
+            "options": {},
+            "resources": {},
+            "security": "oauth-proxy"
+        },
+        "query": {
+            "options": {},
+            "resources": {}
+        },
+        "resources": {},
+        "sampling": {
+            "options": {}
+        },
+        "storage": {
+            "cassandraCreateSchema": {},
+            "dependencies": {
+                "resources": {},
+                "schedule": "55 23 * * *"
+            },
+            "elasticsearch": {
+                "nodeCount": 3,
+                "redundancyPolicy": "SingleRedundancy",
+                "resources": {
+                    "limits": {
+                        "memory": "16Gi"
+                    },
+                    "requests": {
+                        "cpu": "1",
+                        "memory": "16Gi"
+                    }
+                },
+                "storage": {}
+            },
+            "esIndexCleaner": {
+                "numberOfDays": 7,
+                "resources": {},
+                "schedule": "55 23 * * *"
+            },
+            "esRollover": {
+                "resources": {},
+                "schedule": "0 0 * * *"
+            },
+            "options": {},
+            "type": "memory"
+        },
+        "strategy": "allinone",
+        "ui": {
+            "options": {
+                "menu": [
+                    {
+                        "items": [
+                            {
+                                "label": "Documentation",
+                                "url": "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/jaeger/index"
+                            }
+                        ],
+                        "label": "About"
+                    },
+                    {
+                        "anchorTarget": "_self",
+                        "label": "Log Out",
+                        "url": "/oauth/sign_in"
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "phase": "Running",
+        "version": "1.24.1"
+    }
+}

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -219,7 +219,15 @@ rules:
     verbs:
       - get
       - list
-      - watch  
+      - watch
+  - apiGroups:
+      - jaegertracing.io
+    resources:
+      - jaegers
+    verbs:
+      - get
+      - list
+      - watch    
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -87,6 +87,7 @@ var gatheringFunctions = map[string]gatheringFunction{
 	"machine_autoscalers":               failableFunc((*Gatherer).GatherMachineAutoscalers),
 	"openshift_logging":                 failableFunc((*Gatherer).GatherOpenshiftLogging),
 	"psps":                              failableFunc((*Gatherer).GatherPodSecurityPolicies),
+	"jaegers":                           failableFunc((*Gatherer).GatherJaegerCR),
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -35,6 +35,10 @@ var (
 	openshiftLoggingResource = schema.GroupVersionResource{
 		Group: "logging.openshift.io", Version: "v1", Resource: "clusterloggings",
 	}
+
+	jaegerResource = schema.GroupVersionResource{
+		Group: "jaegertracing.io", Version: "v1", Resource: "jaegers",
+	}
 )
 
 func init() { //nolint: gochecknoinits

--- a/pkg/gatherers/clusterconfig/jaeger_cr.go
+++ b/pkg/gatherers/clusterconfig/jaeger_cr.go
@@ -1,0 +1,57 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// limit the number of gathered jaegers.jaegertracing.io resources
+var limit = 5
+
+// GatherJaegerCR collects maximum of 5 jaegers.jaegertracing.io custom resources
+// installed in the cluster
+//
+// * Location in archive: config/jaegertracing.io/
+// * Id in config: jaegers
+// * Since versions:
+//   * 4.10+
+func (g *Gatherer) GatherJaegerCR(ctx context.Context) ([]record.Record, []error) {
+	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherJaegerCR(ctx, gatherDynamicClient)
+}
+
+func gatherJaegerCR(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	jaegersList, err := dynamicClient.Resource(jaegerResource).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	var errs []error
+	records := make([]record.Record, 0, limit)
+	for i := range jaegersList.Items {
+		j := jaegersList.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("config/%s/%s", jaegerResource.Group, j.GetName()),
+			Item: record.ResourceMarshaller{Resource: &j},
+		})
+		// limit the gathered records
+		if len(records) == limit {
+			err := fmt.Errorf("limit %d for number of gathered %s resources exceeded", limit, jaegerResource.GroupResource())
+			errs = append(errs, err)
+			break
+		}
+	}
+
+	return records, errs
+}

--- a/pkg/gatherers/clusterconfig/jaeger_cr_test.go
+++ b/pkg/gatherers/clusterconfig/jaeger_cr_test.go
@@ -1,0 +1,40 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func Test_JaegerCR_Gather(t *testing.T) {
+	var jaegerYAML = `
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+    name: testing-jaeger
+`
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		jaegerResource: "JaegersList",
+	})
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+
+	testJaegerCR := &unstructured.Unstructured{}
+
+	_, _, err := decUnstructured.Decode([]byte(jaegerYAML), nil, testJaegerCR)
+	assert.NoError(t, err, "unable to decode jaeger YAML")
+	_, err = client.Resource(jaegerResource).Create(context.Background(), testJaegerCR, metav1.CreateOptions{})
+	assert.NoError(t, err, "unable to create fake jaeger")
+
+	records, errs := gatherJaegerCR(context.Background(), client)
+	if assert.Empty(t, errs, "unexpected errors while gathering Jaeger CRs") {
+		assert.Len(t, records, 1, "unexpected number or records")
+		assert.Equal(t, "config/jaegertracing.io/testing-jaeger", records[0].Name)
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This adds a new gatherer for `jaeger.jaegertracing.io/v1` resources. There's a limit of 5 records for this new gatherer. 

**How to reproduce**
Install the Jaeger operator via OLM. Click on the installed operator and you can create a new instance there. These instances should be gathered. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/jaegertracing.io/jaeger1.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/jaeger_cr_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
