### PR TITLE
[release-4.9] Bug 2005338: OCM controller - change type of the secret (#500)

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -20,8 +20,10 @@ import (
 )
 
 const (
-	targetNamespaceName = "openshift-config-managed"
-	secretName          = "etc-pki-entitlement" //nolint: gosec
+	targetNamespaceName    = "openshift-config-managed"
+	secretName             = "etc-pki-entitlement" //nolint: gosec
+	entitlementAttrName    = "entitlement.pem"
+	entitlementKeyAttrName = "entitlement-key.pem"
 )
 
 // Controller holds all the required resources to be able to communicate with OCM API
@@ -146,6 +148,18 @@ func (c *Controller) checkSecret(ocmData *ScaResponse) error {
 		return err
 	}
 
+	if scaSec.Type == v1.SecretTypeTLS {
+		err = c.coreClient.Secrets(targetNamespaceName).Delete(c.ctx, scaSec.GetName(), metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+		_, err = c.createSecret(ocmData)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	_, err = c.updateSecret(scaSec, ocmData)
 	if err != nil {
 		return err
@@ -160,10 +174,10 @@ func (c *Controller) createSecret(ocmData *ScaResponse) (*v1.Secret, error) {
 			Namespace: targetNamespaceName,
 		},
 		Data: map[string][]byte{
-			v1.TLSCertKey:       []byte(ocmData.Cert),
-			v1.TLSPrivateKeyKey: []byte(ocmData.Key),
+			entitlementAttrName:    []byte(ocmData.Cert),
+			entitlementKeyAttrName: []byte(ocmData.Key),
 		},
-		Type: v1.SecretTypeTLS,
+		Type: v1.SecretTypeOpaque,
 	}
 	cm, err := c.coreClient.Secrets(targetNamespaceName).Create(c.ctx, newSCA, metav1.CreateOptions{})
 	if err != nil {
@@ -175,8 +189,8 @@ func (c *Controller) createSecret(ocmData *ScaResponse) (*v1.Secret, error) {
 // updateSecret updates provided secret with given data
 func (c *Controller) updateSecret(s *v1.Secret, ocmData *ScaResponse) (*v1.Secret, error) {
 	s.Data = map[string][]byte{
-		v1.TLSCertKey:       []byte(ocmData.Cert),
-		v1.TLSPrivateKeyKey: []byte(ocmData.Key),
+		entitlementAttrName:    []byte(ocmData.Cert),
+		entitlementKeyAttrName: []byte(ocmData.Key),
 	}
 	s, err := c.coreClient.Secrets(s.Namespace).Update(c.ctx, s, metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -138,7 +138,7 @@ func (c *Controller) checkSecret(ocmData *ScaResponse) error {
 
 	// if the secret doesn't exist then create one
 	if errors.IsNotFound(err) {
-		_, err = c.createSecret(ocmData)
+		err = c.createSecret(ocmData)
 		if err != nil {
 			return err
 		}
@@ -153,7 +153,7 @@ func (c *Controller) checkSecret(ocmData *ScaResponse) error {
 		if err != nil {
 			return err
 		}
-		_, err = c.createSecret(ocmData)
+		err = c.createSecret(ocmData)
 		if err != nil {
 			return err
 		}
@@ -167,7 +167,7 @@ func (c *Controller) checkSecret(ocmData *ScaResponse) error {
 	return nil
 }
 
-func (c *Controller) createSecret(ocmData *ScaResponse) (*v1.Secret, error) {
+func (c *Controller) createSecret(ocmData *ScaResponse) error {
 	newSCA := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
@@ -179,11 +179,11 @@ func (c *Controller) createSecret(ocmData *ScaResponse) (*v1.Secret, error) {
 		},
 		Type: v1.SecretTypeOpaque,
 	}
-	cm, err := c.coreClient.Secrets(targetNamespaceName).Create(c.ctx, newSCA, metav1.CreateOptions{})
+	_, err := c.coreClient.Secrets(targetNamespaceName).Create(c.ctx, newSCA, metav1.CreateOptions{})
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return cm, nil
+	return nil
 }
 
 // updateSecret updates provided secret with given data

--- a/pkg/ocm/ocm_test.go
+++ b/pkg/ocm/ocm_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	tlsSecretCrt = "tls.crt"
-	tlsSecretKey = "tls.key"
-	secTestData  = "secret testing data"
+	entitlementPem    = "entitlement.pem"
+	entitlementKeyPem = "entitlement-key.pem"
+	secTestData       = "secret testing data"
 )
 
 var testRes = &ScaResponse{
@@ -31,10 +31,10 @@ func Test_OCMController_SecretIsCreated(t *testing.T) {
 
 	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
 	assert.NoError(t, err, "can't get secret")
-	assert.Contains(t, testSecret.Data, tlsSecretKey, "can't find %s in the %s secret data", tlsSecretKey, secretName)
-	assert.Contains(t, testSecret.Data, tlsSecretCrt, "can't find %s in the %s secret data", tlsSecretCrt, secretName)
-	assert.Equal(t, "secret key", string(testSecret.Data[tlsSecretKey]), "unexpected data in %s secret", secretName)
-	assert.Equal(t, "secret cert", string(testSecret.Data[tlsSecretCrt]), "unexpected data in %s secret", secretName)
+	assert.Contains(t, testSecret.Data, entitlementKeyPem, "can't find %s in the %s secret data", entitlementKeyPem, secretName)
+	assert.Contains(t, testSecret.Data, entitlementPem, "can't find %s in the %s secret data", entitlementPem, secretName)
+	assert.Equal(t, "secret key", string(testSecret.Data[entitlementKeyPem]), "unexpected data in %s secret", secretName)
+	assert.Equal(t, "secret cert", string(testSecret.Data[entitlementPem]), "unexpected data in %s secret", secretName)
 }
 
 func Test_OCMController_SecretIsUpdated(t *testing.T) {
@@ -62,8 +62,8 @@ func Test_OCMController_SecretIsUpdated(t *testing.T) {
 
 	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
 	assert.NoError(t, err, "can't get secret")
-	assert.Contains(t, testSecret.Data, tlsSecretKey, "can't find %s in the %s secret data", tlsSecretKey, secretName)
-	assert.Contains(t, testSecret.Data, tlsSecretCrt, "can't find %s in the %s secret data", tlsSecretCrt, secretName)
-	assert.Equal(t, "new secret testing key", string(testSecret.Data[tlsSecretKey]), "unexpected data in %s secret", secretName)
-	assert.Equal(t, "new secret testing cert", string(testSecret.Data[tlsSecretCrt]), "unexpected data in %s secret", secretName)
+	assert.Contains(t, testSecret.Data, entitlementKeyPem, "can't find %s in the %s secret data", entitlementKeyPem, secretName)
+	assert.Contains(t, testSecret.Data, entitlementPem, "can't find %s in the %s secret data", entitlementPem, secretName)
+	assert.Equal(t, "new secret testing key", string(testSecret.Data[entitlementKeyPem]), "unexpected data in %s secret", secretName)
+	assert.Equal(t, "new secret testing cert", string(testSecret.Data[entitlementPem]), "unexpected data in %s secret", secretName)
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This changes the type of the `etc-pki-entitlement` secret to opaque. It also change the attribute names to end with pem suffix so that it can be easily consumed by the Build API. if there is already a same secret of type TLS then delete it first and re-create as opaque secret. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Unit tests udated

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2005338
https://access.redhat.com/solutions/???
