### PR TITLE
Bug 2005771: Anonymize the ImageRegistry storage information also in

### DIFF
--- a/pkg/gatherers/clusterconfig/image_registries_test.go
+++ b/pkg/gatherers/clusterconfig/image_registries_test.go
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-//nolint: goconst, funlen, gocyclo
+//nolint: goconst, funlen, gocyclo, dupl
 func Test_ImageRegistry_Gather(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
status

<!-- Short description of the PR. What does it do? -->
Anonymize sensitive information in the `ImageRegistry` config also in `status` and check if there's a `kubectl.kubernetes.io/last-applied-configuration` annotation present, which will probably include this sensitive information as well.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Corresponding unit test updated and extended

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2005771
https://access.redhat.com/solutions/???
