### PR TITLE
Regenerate changelog & update some gatherers OCP versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Note: This CHANGELOG is only for the changes in insights operator. 
-	Please see OpenShift release notes for official changes\n<!--Latest hash: 0deaa57e6088c46fc375402255dc8629d47397a1-->
+	Please see OpenShift release notes for official changes\n<!--Latest hash: 66d737fc1e0516222ac73726ee5df667048c1399-->
 ## 4.9
 
 ### Enhancement
@@ -12,6 +12,7 @@
 - [#433](https://github.com/openshift/insights-operator/pull/433) Conditional gathering
 - [#447](https://github.com/openshift/insights-operator/pull/447) fix logs format in sample archive
 - [#449](https://github.com/openshift/insights-operator/pull/449) Gather all MachineConfig definitions
+- [#446](https://github.com/openshift/insights-operator/pull/446) add egress ips support to anonymizer
 
 ### Bugfix
 - [#485](https://github.com/openshift/insights-operator/pull/485) Don't try to record an empty Record if gatherClusterConfigV1 fails
@@ -22,6 +23,7 @@
 - [#472](https://github.com/openshift/insights-operator/pull/472) Set also the summary operation when updating status
 - [#466](https://github.com/openshift/insights-operator/pull/466) fix obfuscation translation table secret manifest
 - [#461](https://github.com/openshift/insights-operator/pull/461) fix obfuscation translation table secret
+- [#444](https://github.com/openshift/insights-operator/pull/444) MemoryRecord name can be obfuscated & fix case of duplicate records
 
 ### Others
 - [#488](https://github.com/openshift/insights-operator/pull/488) Update K8s & OpenShift API versions
@@ -37,6 +39,7 @@
 - [#455](https://github.com/openshift/insights-operator/pull/455) Updating the owners list
 - [#463](https://github.com/openshift/insights-operator/pull/463) Enables godox on precommit
 - [#454](https://github.com/openshift/insights-operator/pull/454) Update changelog
+- [#452](https://github.com/openshift/insights-operator/pull/452) Update versions in the metrics gather documentation
 
 ### Misc
 - [#457](https://github.com/openshift/insights-operator/pull/457) Updating ose-insights-operator images to be consistent with ART
@@ -91,7 +94,6 @@
 - [#336](https://github.com/openshift/insights-operator/pull/336) Disable instead of Degrade in case of gather fails
 - [#334](https://github.com/openshift/insights-operator/pull/334) Do not create the metrics file in case of any error
 - [#332](https://github.com/openshift/insights-operator/pull/332) Relax the recent log gatherers to avoid degrading during…
-- [#329](https://github.com/openshift/insights-operator/pull/329) Remove StatefulSet gatherer & replace it with gathering "cluster-mon…
 
 ### Others
 - [#439](https://github.com/openshift/insights-operator/pull/439) Adds tasks pool to tasks_processing
@@ -148,6 +150,7 @@
 - [#297](https://github.com/openshift/insights-operator/pull/297) Gather netnamespaces network info
 
 ### Bugfix
+- [#329](https://github.com/openshift/insights-operator/pull/329) Remove StatefulSet gatherer & replace it with gathering "cluster-mon…
 - [#325](https://github.com/openshift/insights-operator/pull/325) Fixes error metadata gathering
 - [#320](https://github.com/openshift/insights-operator/pull/320) Monitors how many gatherings failed in a row, and applies degraded status accordingly
 - [#317](https://github.com/openshift/insights-operator/pull/317) Update the sample archive and remove IP anonymization in clusteropera…
@@ -298,19 +301,21 @@
 ## 
 
 ### Enhancement
+- [#504](https://github.com/openshift/insights-operator/pull/504) Reduce stacktrace size in logs
 - [#492](https://github.com/openshift/insights-operator/pull/492) ApiRequestCount conditional gathering
-- [#446](https://github.com/openshift/insights-operator/pull/446) add egress ips support to anonymizer
 
 ### Bugfix
+- [#495](https://github.com/openshift/insights-operator/pull/495)  Respect user defined proxy's CA cert
 - [#497](https://github.com/openshift/insights-operator/pull/497) insightsclient - close response body
 - [#494](https://github.com/openshift/insights-operator/pull/494) Fix the error logic in the OCM controller & degrade only…
-- [#444](https://github.com/openshift/insights-operator/pull/444) MemoryRecord name can be obfuscated & fix case of duplicate records
 
 ### Others
+- [#501](https://github.com/openshift/insights-operator/pull/501) Update changelog
 - [#499](https://github.com/openshift/insights-operator/pull/499) Fix the sample archive path for the last conditional gatherer
 - [#481](https://github.com/openshift/insights-operator/pull/481) Add a script for updating files in the sample archive
-- [#452](https://github.com/openshift/insights-operator/pull/452) Update versions in the metrics gather documentation
 
 ### Misc
+- [#500](https://github.com/openshift/insights-operator/pull/500) OCM controller - change type of the secret
+- [#502](https://github.com/openshift/insights-operator/pull/502) Updating ose-insights-operator images to be consistent with ART
 - [#491](https://github.com/openshift/insights-operator/pull/491) Updating ose-insights-operator images to be consistent with ART
 

--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -25,7 +25,8 @@ const (
 )
 
 var (
-	squashRegexp       = regexp.MustCompile(`(.*)-(\d+)`)
+	// the assumption here is that the PR id is the last number in the string
+	squashRegexp       = regexp.MustCompile(`(.*)-(\d+)$`)
 	mergeRequestRegexp = regexp.MustCompile(`Merge-pull-request-(\d+)`)
 	prefixRegexp       = regexp.MustCompile(`^.+: (.+)`)
 	releaseRegexp      = regexp.MustCompile(`(release-\d\.\d)`)

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -378,6 +378,7 @@ Response see https://docs.openshift.com/container-platform/4.7/rest_api/machine_
 * Location in archive: config/machineconfigs/<name>.json
 * Id in config: machine_configs
 * Since versions:
+  * 4.8.5+
   * 4.9+
 
 
@@ -607,7 +608,8 @@ The Kubernetes API https://github.com/kubernetes/client-go/blob/v12.0.0/kubernet
 * See: docs/insights-archive-sample/config/psp_names.json
 * Id in config: psps
 * Since versions:
-  * 4.10+
+  * 4.8.12+
+  * 4.9+
 
 
 ## SAPConfig

--- a/pkg/gatherers/clusterconfig/machine_configs.go
+++ b/pkg/gatherers/clusterconfig/machine_configs.go
@@ -22,6 +22,7 @@ import (
 // * Location in archive: config/machineconfigs/<name>.json
 // * Id in config: machine_configs
 // * Since versions:
+//   * 4.8.5+
 //   * 4.9+
 func (g *Gatherer) GatherMachineConfigs(ctx context.Context) ([]record.Record, []error) {
 	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)

--- a/pkg/gatherers/clusterconfig/pod_security_policies.go
+++ b/pkg/gatherers/clusterconfig/pod_security_policies.go
@@ -16,7 +16,8 @@ import (
 // * See: docs/insights-archive-sample/config/psp_names.json
 // * Id in config: psps
 // * Since versions:
-//   * 4.10+
+//   * 4.8.12+
+//   * 4.9+
 func (g *Gatherer) GatherPodSecurityPolicies(ctx context.Context) ([]record.Record, []error) {
 	gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
 	if err != nil {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is to address [CCXDEV-5537](https://issues.redhat.com/browse/CCXDEV-5537). The changelog was probably generated wrongly and I used the command without the date attributes, which means that it was only updating the original wrong version. 

I think it's better to use the command with the date attributes (specifying time range). I used `go run cmd/changelog/main.go 2020-01-01 2021-09-22` for this one. I also found one minor bug in one of the regexes. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No docs.

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new tests
## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

Changelog was regenerated and one minor bug fixed there.

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-5537
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
