### PR TITLE
Removing one unnecessary case statement from workload_info

### DIFF
--- a/pkg/gatherers/workloads/workloads_info.go
+++ b/pkg/gatherers/workloads/workloads_info.go
@@ -121,13 +121,11 @@ func gatherWorkloadInfo(
 				// track terminal pods but do not report their data
 				namespacePods.TerminalCount++
 				continue
-			case pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending:
-				// only consider pods that are in a known state
-				namespacePods.IgnoredCount++
-				continue
-			case len(pod.Status.InitContainerStatuses) != len(pod.Spec.InitContainers),
+			case pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodPending,
+				len(pod.Status.InitContainerStatuses) != len(pod.Spec.InitContainers),
 				len(pod.Status.ContainerStatuses) != len(pod.Spec.Containers):
-				// pods without filled out status are invalid
+				// consider pods that are in a known state
+				// or pods without filled out status are invalid
 				namespacePods.IgnoredCount++
 				continue
 			}
@@ -305,8 +303,6 @@ func gatherWorkloadImageInfo(
 // namespace, returning the index of the matching shape or -1. It exploits the
 // property that identical pods tend to have similar name prefixes and searches
 // in reverse order from the most recent shape (since pods appear in name order).
-// TODO: some optimization in very large namespaces with diverse shapes may be
-//   necessary
 func workloadPodShapeIndex(shapes []workloadPodShape, shape workloadPodShape) int {
 	for i := len(shapes) - 1; i >= 0; i-- {
 		existing := shapes[i]


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR removes a very simple code smell from workload_info.go as well one TODO comment from the same file, that was converted to a task.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

n/a

## Documentation
<!-- Are these changes reflected in documentation? -->

n/a

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

n/a

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
