### PR TITLE
[release-4.7] Bug 2002539: Fix wrong rebase of PSP gatherer

### DIFF
--- a/pkg/gather/clusterconfig/0_gatherer.go
+++ b/pkg/gather/clusterconfig/0_gatherer.go
@@ -115,6 +115,7 @@ var gatherFunctions = map[string]gathering{
 	"sap_pods":                          failable(GatherSAPPods),
 	"sap_datahubs":                      failable(GatherSAPDatahubs),
 	"olm_operators":                     failable(GatherOLMOperators),
+	"psps":                              failable(GatherPodSecurityPolicies),
 }
 
 var startTime time.Time

--- a/pkg/gather/clusterconfig/pod_security_policies.go
+++ b/pkg/gather/clusterconfig/pod_security_policies.go
@@ -17,13 +17,13 @@ import (
 // * Id in config: psps
 // * Since versions:
 //   * 4.10+
-func (g *Gatherer) GatherPodSecurityPolicies(ctx context.Context) ([]record.Record, []error) {
+func GatherPodSecurityPolicies(g *Gatherer, c chan<- gatherResult) {
 	gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
-		return nil, []error{err}
+		c <- gatherResult{errors: []error{err}}
 	}
-
-	return gatherPodSecurityPolicies(ctx, gatherPolicyClient)
+	records, errs := gatherPodSecurityPolicies(g.ctx, gatherPolicyClient)
+	c <- gatherResult{records: records, errors: errs}
 }
 
 func gatherPodSecurityPolicies(ctx context.Context, policyClient policyclient.PolicyV1beta1Interface) ([]record.Record, []error) {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This fixes my previous backport of PSP gatherer

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2002539
https://access.redhat.com/solutions/???
