### PR TITLE
Reverts "Respect user defined proxy's CA cert"

### DIFF
--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -31,7 +31,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/openshift/insights-operator/pkg/authorizer"
 )
@@ -121,9 +120,9 @@ func getTrustedCABundle() (*x509.CertPool, error) {
 }
 
 // clientTransport creates new http.Transport with either system or configured Proxy
-func (c *Client) clientTransport() http.RoundTripper {
+func clientTransport(authorizer Authorizer) http.RoundTripper {
 	clientTransport := &http.Transport{
-		Proxy: c.authorizer.NewSystemOrConfiguredProxy(),
+		Proxy: authorizer.NewSystemOrConfiguredProxy(),
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
@@ -137,21 +136,6 @@ func (c *Client) clientTransport() http.RoundTripper {
 	if err != nil {
 		klog.Errorf("Failed to get proxy trusted CA: %v", err)
 	}
-	// check if some proxy is set
-	if isProxySet() {
-		userCAPem, err := c.getUserCABundle()
-		if err != nil {
-			klog.Error(err)
-		}
-		if userCAPem != nil {
-			if ok := rootCAs.AppendCertsFromPEM(userCAPem); !ok {
-				klog.Error("failed to parse CA pem data")
-			} else {
-				klog.Infof("Sucecssfully added CA cert referenced in the clusterProxy.Spec.TrustedCA bundle")
-			}
-		}
-	}
-
 	if rootCAs != nil {
 		clientTransport.TLSClientConfig = &tls.Config{}
 		clientTransport.TLSClientConfig.RootCAs = rootCAs
@@ -253,7 +237,7 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 	req.Body = pr
 
 	// dynamically set the proxy environment
-	c.client.Transport = c.clientTransport()
+	c.client.Transport = clientTransport(c.authorizer)
 
 	klog.V(4).Infof("Uploading %s to %s", source.Type, req.URL.String())
 	resp, err := c.client.Do(req)
@@ -322,7 +306,7 @@ func (c Client) RecvReport(ctx context.Context, endpoint string) (io.ReadCloser,
 	}
 
 	// dynamically set the proxy environment
-	c.client.Transport = c.clientTransport()
+	c.client.Transport = clientTransport(c.authorizer)
 
 	klog.V(4).Infof("Retrieving report from %s", req.URL.String())
 	resp, err := c.client.Do(req)
@@ -398,7 +382,7 @@ func (c Client) RecvSCACerts(ctx context.Context, endpoint string) ([]byte, erro
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	c.client.Transport = c.clientTransport()
+	c.client.Transport = clientTransport(c.authorizer)
 	authHeader := fmt.Sprintf("AccessToken %s:%s", cv.Spec.ClusterID, token)
 	req.Header.Set("Authorization", authHeader)
 
@@ -438,43 +422,6 @@ func ocmErrorMessage(url *url.URL, r *http.Response) error {
 		Err:        err,
 		StatusCode: r.StatusCode,
 	}
-}
-
-// isProxySet looks up "HTTP_PROXY" and "HTTPS_PROXY" environment variables
-// and returns true if at least one is set
-func isProxySet() (ok bool) {
-	_, httpProxySet := os.LookupEnv("HTTP_PROXY")
-	_, httpsProxySet := os.LookupEnv("HTTPS_PROXY")
-
-	return httpProxySet || httpsProxySet
-}
-
-// getUserCABundle reads "cluster" proxy resource to get a name of config map with
-// "TrustedCA" certificate and then it tries to read the certificate data from "ca-bundle.crt" key
-// Returns the certificate data or an error in case of failed reading
-func (c *Client) getUserCABundle() ([]byte, error) {
-	configCli, err := configv1client.NewForConfig(c.gatherKubeConfig)
-	if err != nil {
-		return nil, err
-	}
-	clusterProxy, err := configCli.Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	cmWithCACert := clusterProxy.Spec.TrustedCA.Name
-	coreCli, err := corev1client.NewForConfig(c.gatherKubeConfig)
-	if err != nil {
-		return nil, err
-	}
-	cm, err := coreCli.ConfigMaps("openshift-config").Get(context.Background(), cmWithCACert, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	data, ok := cm.Data["ca-bundle.crt"]
-	if !ok {
-		return nil, fmt.Errorf("can't find ca-bundle.crt key in %s config map", cmWithCACert)
-	}
-	return []byte(data), nil
 }
 
 var (


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This reverts my previous https://github.com/openshift/insights-operator/commit/66d737fc1e0516222ac73726ee5df667048c1399. I was wrong. This should work as it is, because the file [/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt](https://github.com/openshift/insights-operator/blob/master/pkg/insights/insightsclient/insightsclient.go#L106) refers to the config map with user defined CA cert and when the map changes then the file is updated and thus the CA cert is respected. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No docs

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
