### PR TITLE
Bug 2002504: Gather all the container logs from related namespaces of degraded clu…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -146,12 +146,12 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 ## ClusterOperatorPodsAndEvents
 
-collects information about all pods
+collects information about pods
 and events from namespaces of degraded cluster operators. The collected
 information includes:
 
-- Pod definitions
-- Previous and current logs of pod containers (when available)
+- Definitions for non-running (terminated, pending) Pods
+- Previous (if container was terminated) and current logs of all related pod containers
 - Namespace events
 
 * Location of pod definitions: config/pod/{namespace}/{pod}.json

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events_test.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events_test.go
@@ -77,7 +77,7 @@ func Test_UnhealtyOperators_GatherPodContainersLogs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := gatherPodContainersLogs(tt.args.ctx, tt.args.client, tt.args.pods, tt.args.bufferSize)
+			got, err := gatherPodsAndTheirContainersLogs(tt.args.ctx, tt.args.client, tt.args.pods, tt.args.bufferSize)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("gatherNamespaceEvents() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -194,15 +194,12 @@ func Test_UnhealtyOperators_GatherUnhealthyPods(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2 := gatherUnhealthyPods(tt.args.pods)
+			got, got2 := getAllRelatedPods(tt.args.pods)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("gatherUnhealthyPods() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("gatherUnhealthyPods() got1 = %v, want %v", got1, tt.want1)
+				t.Errorf("getAllRelatedPods() got = %v, want %v", got, tt.want)
 			}
 			if got2 != tt.want2 {
-				t.Errorf("gatherUnhealthyPods() got2 = %v, want %v", got2, tt.want2)
+				t.Errorf("getAllRelatedPods() got2 = %v, want %v", got2, tt.want2)
 			}
 		})
 	}


### PR DESCRIPTION
…steroperator

<!-- Short description of the PR. What does it do? -->
Gather all container logs from related namespaces of degraded/unhealthy clusteroperator. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No update

## Documentation
<!-- Are these changes reflected in documentation? -->

- docs slightly updated in  `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

no new unit test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2002504
https://access.redhat.com/solutions/???
