### PR TITLE
changes for collecting tsdb status

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -760,6 +760,17 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
   * 4.7+
 
 
+## TSDBStatus
+
+gathers the Prometheus TSDB status.
+
+* Location in archive: config/tsdb
+* See: docs/insights-archive-sample/config/metrics
+* Id in config: tsdb_status
+* Since version:
+   * 4.10+
+
+
 ## ValidatingWebhookConfigurations
 
 collects ValidatingWebhookConfiguration resources

--- a/docs/insights-archive-sample/config/tsdb.json
+++ b/docs/insights-archive-sample/config/tsdb.json
@@ -1,0 +1,180 @@
+{
+    "status": "success",
+    "data": {
+        "headStats": {
+            "numSeries": 244189,
+            "numLabelPairs": 13065,
+            "chunkCount": 248790,
+            "minTime": 1636719873253,
+            "maxTime": 1636721983690
+        },
+        "seriesCountByMetricName": [
+            {
+                "name": "apiserver_request_duration_seconds_bucket",
+                "value": 20892
+            },
+            {
+                "name": "rest_client_request_duration_seconds_bucket",
+                "value": 17369
+            },
+            {
+                "name": "rest_client_rate_limiter_duration_seconds_bucket",
+                "value": 12980
+            },
+            {
+                "name": "etcd_request_duration_seconds_bucket",
+                "value": 11172
+            },
+            {
+                "name": "apiserver_response_sizes_bucket",
+                "value": 7960
+            },
+            {
+                "name": "rest_client_request_latency_seconds_bucket",
+                "value": 7315
+            },
+            {
+                "name": "workqueue_queue_duration_seconds_bucket",
+                "value": 6765
+            },
+            {
+                "name": "workqueue_work_duration_seconds_bucket",
+                "value": 6765
+            },
+            {
+                "name": "apiserver_watch_events_sizes_bucket",
+                "value": 4167
+            },
+            {
+                "name": "grpc_server_handled_total",
+                "value": 2737
+            }
+        ],
+        "labelValueCountByLabelName": [
+            {
+                "name": "__name__",
+                "value": 1824
+            },
+            {
+                "name": "id",
+                "value": 1445
+            },
+            {
+                "name": "name",
+                "value": 1229
+            },
+            {
+                "name": "secret",
+                "value": 1187
+            },
+            {
+                "name": "url",
+                "value": 834
+            },
+            {
+                "name": "container_id",
+                "value": 543
+            },
+            {
+                "name": "resource",
+                "value": 400
+            },
+            {
+                "name": "le",
+                "value": 363
+            },
+            {
+                "name": "configmap",
+                "value": 328
+            },
+            {
+                "name": "type",
+                "value": 314
+            }
+        ],
+        "memoryInBytesByLabelName": [
+            {
+                "name": "id",
+                "value": 236624
+            },
+            {
+                "name": "name",
+                "value": 98232
+            },
+            {
+                "name": "url",
+                "value": 96702
+            },
+            {
+                "name": "__name__",
+                "value": 68630
+            },
+            {
+                "name": "container_id",
+                "value": 39096
+            },
+            {
+                "name": "secret",
+                "value": 31518
+            },
+            {
+                "name": "mountpoint",
+                "value": 27729
+            },
+            {
+                "name": "uid",
+                "value": 10944
+            },
+            {
+                "name": "image_id",
+                "value": 10029
+            },
+            {
+                "name": "type",
+                "value": 9901
+            }
+        ],
+        "seriesCountByLabelValuePair": [
+            {
+                "name": "endpoint=https",
+                "value": 134670
+            },
+            {
+                "name": "namespace=default",
+                "value": 66977
+            },
+            {
+                "name": "service=kubernetes",
+                "value": 66933
+            },
+            {
+                "name": "job=apiserver",
+                "value": 66931
+            },
+            {
+                "name": "apiserver=kube-apiserver",
+                "value": 66930
+            },
+            {
+                "name": "service=kubelet",
+                "value": 56064
+            },
+            {
+                "name": "endpoint=https-metrics",
+                "value": 55158
+            },
+            {
+                "name": "job=kubelet",
+                "value": 54994
+            },
+            {
+                "name": "verb=GET",
+                "value": 46704
+            },
+            {
+                "name": "metrics_path=/metrics/cadvisor",
+                "value": 42953
+            }
+        ]
+    }
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -92,6 +92,7 @@ var gatheringFunctions = map[string]gatheringFunction{
 	"mutating_webhook_configurations":   failableFunc((*Gatherer).GatherMutatingWebhookConfigurations),
 	"cost_management_metrics_configs":   failableFunc((*Gatherer).GatherCostManagementMetricsConfigs),
 	"node_logs":                         failableFunc((*Gatherer).GatherNodeLogs),
+	"tsdb_status":                       failableFunc((*Gatherer).GatherTSDBStatus),
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/tsdb_status.go
+++ b/pkg/gatherers/clusterconfig/tsdb_status.go
@@ -1,0 +1,43 @@
+package clusterconfig
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils/marshal"
+)
+
+// GatherTSDBStatus gathers the Prometheus TSDB status.
+//
+// * Location in archive: config/tsdb
+// * See: docs/insights-archive-sample/config/metrics
+// * Id in config: tsdb_status
+// * Since version:
+//    * 4.10+
+func (g *Gatherer) GatherTSDBStatus(ctx context.Context) ([]record.Record, []error) {
+	metricsRESTClient, err := rest.RESTClientFor(g.metricsGatherKubeConfig)
+	if err != nil {
+		klog.Warningf("Unable to load metrics client, tsdb status cannot be collected: %v", err)
+		return nil, nil
+	}
+
+	return gatherTsdbStatus(ctx, metricsRESTClient)
+}
+
+func gatherTsdbStatus(ctx context.Context, metricsClient rest.Interface) ([]record.Record, []error) {
+	data, err := metricsClient.Get().AbsPath("api/v1/status/tsdb").
+		DoRaw(ctx)
+	if err != nil {
+		klog.Errorf("Unable to tsdb status: %v", err)
+		return nil, []error{err}
+	}
+
+	records := []record.Record{
+		{Name: "config/tsdb.json", Item: marshal.RawByte(data)},
+	}
+
+	return records, nil
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a method to collect and store TSDB status of the prometheus instance in the monitoring stack. It does this by creating a Gatherer that calls v1/status/tsdb endpoint.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-6332
https://issues.redhat.com/browse/MON-1971
