### PR TITLE
Remove "InsightsOperatorPullingSCA" TP feature check

### DIFF
--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -88,6 +88,8 @@ func (c *Controller) Run() {
 }
 
 func (c *Controller) requestDataAndCheckSecret(endpoint string) {
+	klog.Infof("Pulling SCA certificates from %s. Next check is in %s", c.configurator.Config().OCMConfig.Endpoint,
+		c.configurator.Config().OCMConfig.Interval)
 	data, err := c.requestSCAWithExpBackoff(endpoint)
 	if err != nil {
 		httpErr, ok := err.(insightsclient.HttpError)


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This removes the check of enabled features in cluster feature gate. In other words it means that IO will always try to download the entitlement certificates from the OCM API. See https://github.com/openshift/enhancements/blob/master/enhancements/insights/pulling-sca-certs-from-ocm.md

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
This is documented (and will be updated) in the official OCP documentation - https://docs.openshift.com/container-platform/4.9/support/remote_health_monitoring/insights-operator-simple-access.html

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
