### PR TITLE
Bug 2020250: Replacing deprecated ioutil

### DIFF
--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -78,8 +78,8 @@ func createPullRequestLink(id string) string {
 func main() {
 	log.SetFlags(0)
 	if len(os.Args) != 1 && len(os.Args) != 3 {
-		log.Fatalf(`Either specify two date arguments, AFTER and UNTIL, 
-		to create a brand new CHANGELOG, or call it without arguments to 
+		log.Fatalf(`Either specify two date arguments, AFTER and UNTIL,
+		to create a brand new CHANGELOG, or call it without arguments to
 		update the current one with new changes.`)
 	}
 	gitHubToken = os.Getenv("GITHUB_TOKEN")
@@ -121,7 +121,7 @@ type MarkdownReleaseBlock struct {
 
 func readCHANGELOG() map[string]MarkdownReleaseBlock {
 	releaseBlocks := make(map[string]MarkdownReleaseBlock)
-	rawBytes, _ := ioutil.ReadFile("./CHANGELOG.md")
+	rawBytes, _ := os.ReadFile("./CHANGELOG.md")
 	rawString := string(rawBytes)
 	if match := latestHashRegexp.FindStringSubmatch(rawString); len(match) > 0 {
 		latestHash = match[1]
@@ -182,7 +182,7 @@ func updateToMarkdownReleaseBlock(releaseBlocks map[string]MarkdownReleaseBlock,
 func createCHANGELOG(releaseBlocks map[string]MarkdownReleaseBlock) {
 	file, _ := os.Create("CHANGELOG.md")
 	defer file.Close()
-	_, _ = file.WriteString(`# Note: This CHANGELOG is only for the changes in insights operator. 
+	_, _ = file.WriteString(`# Note: This CHANGELOG is only for the changes in insights operator.
 	Please see OpenShift release notes for official changes\n`)
 	_, _ = file.WriteString(fmt.Sprintf("<!--Latest hash: %s-->\n", latestHash))
 	var releases []string
@@ -243,7 +243,7 @@ func getPullRequestFromGitHub(id string) *Change {
 		log.Fatalf(err.Error())
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		defer log.Fatalf(err.Error())
 		return nil

--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -232,7 +232,11 @@ func getPullRequestFromGitHub(id string) *Change {
 	// There is a limit for the GitHub API, if you use auth then its 5000/hour
 	var bearer = "token " + gitHubToken
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id), http.NoBody)
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		"GET",
+		fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id),
+		http.NoBody)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -232,7 +232,7 @@ func getPullRequestFromGitHub(id string) *Change {
 	// There is a limit for the GitHub API, if you use auth then its 5000/hour
 	var bearer = "token " + gitHubToken
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id), nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id), http.NoBody)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}

--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -6,7 +6,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -219,7 +218,7 @@ func findGoMod(pkgFilePath string) (goModPath, relPkgPath string, err error) {
 
 // getModuleNameFromGoMod parses the go.mod file and returns the name (URL) of the module.
 func getModuleNameFromGoMod(goModPath string) (string, error) {
-	goModBytes, err := ioutil.ReadFile(goModPath)
+	goModBytes, err := os.ReadFile(goModPath)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/obfuscate-archive/main.go
+++ b/cmd/obfuscate-archive/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -190,7 +189,7 @@ func readArchive(path string) (map[string]*record.MemoryRecord, error) {
 			return nil, err
 		}
 
-		content, err := ioutil.ReadAll(tarReader)
+		content, err := io.ReadAll(tarReader)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -2,7 +2,6 @@ package start
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"time"
@@ -87,7 +86,7 @@ func runGather(operator *controller.GatherJob, cfg *controllercmd.ControllerComm
 
 		var clientConfig *rest.Config
 		if kubeConfigPath := cmd.Flags().Lookup("kubeconfig").Value.String(); len(kubeConfigPath) > 0 {
-			kubeConfigBytes, err := ioutil.ReadFile(kubeConfigPath) //nolint: govet
+			kubeConfigBytes, err := os.ReadFile(kubeConfigPath) //nolint: govet
 			if err != nil {
 				klog.Exit(err)
 			}
@@ -143,7 +142,7 @@ func runOperator(operator *controller.Operator, cfg *controllercmd.ControllerCom
 		}
 
 		// if the service CA is rotated, we want to restart
-		if data, err := ioutil.ReadFile(serviceCACertPath); err == nil {
+		if data, err := os.ReadFile(serviceCACertPath); err == nil {
 			startingFileContent[serviceCACertPath] = data
 		} else {
 			klog.V(4).Infof("Unable to read service ca bundle: %v", err)

--- a/pkg/gatherers/clusterconfig/certificate_signing_requests_test.go
+++ b/pkg/gatherers/clusterconfig/certificate_signing_requests_test.go
@@ -3,7 +3,7 @@ package clusterconfig
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -33,7 +33,7 @@ func Test_CSR(t *testing.T) {
 				t.Fatal("test failed to unmarshal csr data", err)
 			}
 			defer f.Close()
-			bts, err := ioutil.ReadAll(f)
+			bts, err := io.ReadAll(f)
 			if err != nil {
 				t.Fatal("error reading test data file", err)
 			}
@@ -48,7 +48,7 @@ func Test_CSR(t *testing.T) {
 				t.Fatal("test failed to unmarshal csr anonymized data", err)
 			}
 			defer f.Close()
-			bts, err = ioutil.ReadAll(f)
+			bts, err = io.ReadAll(f)
 			if err != nil {
 				t.Fatal("error reading test data file", err)
 			}

--- a/pkg/gatherers/clusterconfig/config_maps_test.go
+++ b/pkg/gatherers/clusterconfig/config_maps_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -119,7 +119,7 @@ func readConfigMapsTestData() (*corev1.ConfigMapList, error) {
 
 	defer f.Close()
 
-	bts, err := ioutil.ReadAll(f)
+	bts, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("error reading test data file %+v ", err)
 	}

--- a/pkg/gatherers/clusterconfig/config_maps_test.go
+++ b/pkg/gatherers/clusterconfig/config_maps_test.go
@@ -1,6 +1,7 @@
 package clusterconfig
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -86,7 +87,7 @@ func Test_ConfigMap_Anonymizer(t *testing.T) {
 			mustNotFail(t, err, "unmarshaling of expected failed %+v")
 			exp, err := json.Marshal(d)
 			mustNotFail(t, err, "marshaling of expected failed %+v")
-			if string(exp) != string(md) {
+			if !bytes.Equal(exp, md) {
 				t.Fatalf("The test %s result is unexpected. Result: \n%s \nExpected \n%s", tt.testName, string(md), string(exp))
 			}
 		})

--- a/pkg/gatherers/clusterconfig/install_plans_test.go
+++ b/pkg/gatherers/clusterconfig/install_plans_test.go
@@ -2,7 +2,7 @@ package clusterconfig
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -63,7 +63,7 @@ func Test_InstallPlans_Gather(t *testing.T) {
 					t.Fatal("test failed to read installplan data", err)
 				}
 				defer f.Close()
-				installplancontent, err := ioutil.ReadAll(f)
+				installplancontent, err := io.ReadAll(f)
 				if err != nil {
 					t.Fatal("error reading test data file", err)
 				}

--- a/pkg/gatherers/clusterconfig/olm_operators_test.go
+++ b/pkg/gatherers/clusterconfig/olm_operators_test.go
@@ -3,7 +3,7 @@ package clusterconfig
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -154,7 +154,7 @@ func readFromFile(filePath string) ([]byte, error) {
 
 	defer f.Close()
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatherers/clusterconfig/recent_metrics.go
+++ b/pkg/gatherers/clusterconfig/recent_metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -76,7 +75,7 @@ func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) 
 		return nil, []error{err}
 	}
 	r := utils.NewLineLimitReader(rsp, metricsAlertsLinesLimit)
-	alerts, err := ioutil.ReadAll(r)
+	alerts, err := io.ReadAll(r)
 	if err != nil && err != io.EOF {
 		klog.Errorf("Unable to read most recent alerts from metrics: %v", err)
 		return nil, []error{err}

--- a/pkg/gatherers/conditional/conditional_gatherer_test.go
+++ b/pkg/gatherers/conditional/conditional_gatherer_test.go
@@ -3,7 +3,7 @@ package conditional
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -175,7 +175,7 @@ func newFakeClientWithMetrics(metrics string) *fake.RESTClient {
 		Client: fake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(metrics + "\n")),
+				Body:       io.NopCloser(strings.NewReader(metrics + "\n")),
 			}
 			return resp, nil
 		}),

--- a/pkg/gatherers/workloads/workloads_info_test.go
+++ b/pkg/gatherers/workloads/workloads_info_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -50,7 +49,7 @@ func Test_gatherWorkloadInfo(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err = ioutil.WriteFile("../../../docs/insights-archive-sample/config/workload_info.json", out, 0750); err != nil {
+		if err = os.WriteFile("../../../docs/insights-archive-sample/config/workload_info.json", out, 0750); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -102,7 +101,7 @@ func New(client *http.Client, maxBytes int64, metricsName string, authorizer Aut
 }
 
 func getTrustedCABundle() (*x509.CertPool, error) {
-	caBytes, err := ioutil.ReadFile("/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt")
+	caBytes, err := os.ReadFile("/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -251,7 +250,7 @@ func (c *Client) Send(ctx context.Context, endpoint string, source Source) error
 	requestID := resp.Header.Get(insightsReqId)
 
 	defer func() {
-		if _, err := io.Copy(ioutil.Discard, resp.Body); err != nil {
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 			klog.Warningf("error copying body: %v", err)
 		}
 		if err := resp.Body.Close(); err != nil {
@@ -332,7 +331,7 @@ func (c Client) RecvReport(ctx context.Context, endpoint string) (*http.Response
 	}
 
 	if resp.StatusCode == http.StatusBadRequest {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		if len(body) > 1024 {
 			body = body[:1024]
 		}
@@ -340,7 +339,7 @@ func (c Client) RecvReport(ctx context.Context, endpoint string) (*http.Response
 		return nil, fmt.Errorf("gateway server bad request: %s (request=%s): %s", resp.Request.URL, requestID, string(body))
 	}
 	if resp.StatusCode == http.StatusNotFound {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		if len(body) > 1024 {
 			body = body[:1024]
 		}
@@ -353,7 +352,7 @@ func (c Client) RecvReport(ctx context.Context, endpoint string) (*http.Response
 	}
 
 	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		if len(body) > 1024 {
 			body = body[:1024]
 		}
@@ -404,14 +403,14 @@ func (c Client) RecvSCACerts(ctx context.Context, endpoint string) ([]byte, erro
 		}
 	}()
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func responseBody(r *http.Response) string {
 	if r == nil {
 		return ""
 	}
-	body, _ := ioutil.ReadAll(r.Body)
+	body, _ := io.ReadAll(r.Body)
 	if len(body) > responseBodyLogLen {
 		body = body[:responseBodyLogLen]
 	}

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -146,8 +147,10 @@ func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (io.ReadClose
 		return nil, false, nil
 	}
 	recentFiles := make([]string, 0, len(files))
+
+	var fileInfo fs.FileInfo
 	for _, file := range files {
-		fileInfo, err := file.Info()
+		fileInfo, err = file.Info()
 		if err != nil {
 			return nil, false, err
 		}

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,17 +101,18 @@ func (d *DiskRecorder) SaveAtPath(records record.MemoryRecords, path string) (re
 
 // Prune the archives older than given time
 func (d *DiskRecorder) Prune(olderThan time.Time) error {
-	files, err := ioutil.ReadDir(d.basePath)
+	files, err := os.ReadDir(d.basePath)
 	if err != nil {
 		return err
 	}
 	count := 0
 	var errors []string
 	for _, file := range files {
-		if isNotArchiveFile(file) {
+		fileInfo, _ := file.Info()
+		if isNotArchiveFile(fileInfo) {
 			continue
 		}
-		if file.ModTime().After(olderThan) {
+		if fileInfo.ModTime().After(olderThan) {
 			continue
 		}
 		if err := os.Remove(filepath.Join(d.basePath, file.Name())); err != nil {
@@ -135,7 +135,7 @@ func (d *DiskRecorder) Prune(olderThan time.Time) error {
 
 // Summary implements summarizer interface to insights uploader
 func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (io.ReadCloser, bool, error) {
-	files, err := ioutil.ReadDir(d.basePath)
+	files, err := os.ReadDir(d.basePath)
 	if err != nil {
 		return nil, false, err
 	}
@@ -144,10 +144,11 @@ func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (io.ReadClose
 	}
 	recentFiles := make([]string, 0, len(files))
 	for _, file := range files {
-		if isNotArchiveFile(file) {
+		fileInfo, _ := file.Info()
+		if isNotArchiveFile(fileInfo) {
 			continue
 		}
-		if !file.ModTime().After(since) {
+		if !fileInfo.ModTime().After(since) {
 			continue
 		}
 		recentFiles = append(recentFiles, file.Name())

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -108,7 +108,10 @@ func (d *DiskRecorder) Prune(olderThan time.Time) error {
 	count := 0
 	var errors []string
 	for _, file := range files {
-		fileInfo, _ := file.Info()
+		fileInfo, err := file.Info()
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
 		if isNotArchiveFile(fileInfo) {
 			continue
 		}
@@ -144,7 +147,10 @@ func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (io.ReadClose
 	}
 	recentFiles := make([]string, 0, len(files))
 	for _, file := range files {
-		fileInfo, _ := file.Info()
+		fileInfo, err := file.Info()
+		if err != nil {
+			return nil, false, err
+		}
 		if isNotArchiveFile(fileInfo) {
 			continue
 		}

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -111,7 +111,7 @@ func (d *DiskRecorder) Prune(olderThan time.Time) error {
 	for _, file := range files {
 		fileInfo, err := file.Info()
 		if err != nil {
-			errors = append(errors, err.Error())
+			continue
 		}
 		if isNotArchiveFile(fileInfo) {
 			continue


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR replaces the deprecated `ioutil` as recommended by [golang 1.16 changelog](https://golang.org/doc/go1.16#ioutil) and makes our lint happy.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

n/a

## Documentation
<!-- Are these changes reflected in documentation? -->

n/a

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

n/a

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

n/a

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
