### PR TITLE
[release-4.8] Bug 2020601: Anonymize the ImageRegistry storage information also in status

### DIFF
--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -77,8 +77,8 @@ func createPullRequestLink(id string) string {
 func main() {
 	log.SetFlags(0)
 	if len(os.Args) != 1 && len(os.Args) != 3 {
-		log.Fatalf(`Either specify two date arguments, AFTER and UNTIL, 
-		to create a brand new CHANGELOG, or call it without arguments to 
+		log.Fatalf(`Either specify two date arguments, AFTER and UNTIL,
+		to create a brand new CHANGELOG, or call it without arguments to
 		update the current one with new changes.`)
 	}
 	gitHubToken = os.Getenv("GITHUB_TOKEN")
@@ -120,7 +120,7 @@ type MarkdownReleaseBlock struct {
 
 func readCHANGELOG() map[string]MarkdownReleaseBlock {
 	releaseBlocks := make(map[string]MarkdownReleaseBlock)
-	rawBytes, _ := ioutil.ReadFile("./CHANGELOG.md")
+	rawBytes, _ := os.ReadFile("./CHANGELOG.md")
 	rawString := string(rawBytes)
 	if match := latestHashRegexp.FindStringSubmatch(rawString); len(match) > 0 {
 		latestHash = match[1]
@@ -181,7 +181,7 @@ func updateToMarkdownReleaseBlock(releaseBlocks map[string]MarkdownReleaseBlock,
 func createCHANGELOG(releaseBlocks map[string]MarkdownReleaseBlock) {
 	file, _ := os.Create("CHANGELOG.md")
 	defer file.Close()
-	_, _ = file.WriteString(`# Note: This CHANGELOG is only for the changes in insights operator. 
+	_, _ = file.WriteString(`# Note: This CHANGELOG is only for the changes in insights operator.
 	Please see OpenShift release notes for official changes\n`)
 	_, _ = file.WriteString(fmt.Sprintf("<!--Latest hash: %s-->\n", latestHash))
 	var releases []string
@@ -231,7 +231,11 @@ func getPullRequestFromGitHub(id string) *Change {
 	// There is a limit for the GitHub API, if you use auth then its 5000/hour
 	var bearer = "token " + gitHubToken
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id), nil)
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		"GET",
+		fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id),
+		http.NoBody)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
@@ -242,7 +246,7 @@ func getPullRequestFromGitHub(id string) *Change {
 		log.Fatalf(err.Error())
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		defer log.Fatalf(err.Error())
 		return nil

--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -6,7 +6,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -218,7 +217,7 @@ func findGoMod(pkgFilePath string) (goModPath, relPkgPath string, err error) {
 
 // getModuleNameFromGoMod parses the go.mod file and returns the name (URL) of the module.
 func getModuleNameFromGoMod(goModPath string) (string, error) {
-	goModBytes, err := ioutil.ReadFile(goModPath)
+	goModBytes, err := os.ReadFile(goModPath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -2,7 +2,6 @@ package start
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"time"
@@ -83,7 +82,7 @@ func runGather(operator *controller.GatherJob, cfg *controllercmd.ControllerComm
 
 		var clientConfig *rest.Config
 		if kubeConfigPath := cmd.Flags().Lookup("kubeconfig").Value.String(); len(kubeConfigPath) > 0 {
-			kubeConfigBytes, err := ioutil.ReadFile(kubeConfigPath) //nolint: govet
+			kubeConfigBytes, err := os.ReadFile(kubeConfigPath) //nolint: govet
 			if err != nil {
 				klog.Fatal(err)
 			}
@@ -139,7 +138,7 @@ func runOperator(operator *controller.Operator, cfg *controllercmd.ControllerCom
 		}
 
 		// if the service CA is rotated, we want to restart
-		if data, err := ioutil.ReadFile(serviceCACertPath); err == nil {
+		if data, err := os.ReadFile(serviceCACertPath); err == nil {
 			startingFileContent[serviceCACertPath] = data
 		} else {
 			klog.V(4).Infof("Unable to read service ca bundle: %v", err)

--- a/pkg/gatherers/clusterconfig/certificate_signing_requests_test.go
+++ b/pkg/gatherers/clusterconfig/certificate_signing_requests_test.go
@@ -3,7 +3,7 @@ package clusterconfig
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -33,7 +33,7 @@ func Test_CSR(t *testing.T) {
 				t.Fatal("test failed to unmarshal csr data", err)
 			}
 			defer f.Close()
-			bts, err := ioutil.ReadAll(f)
+			bts, err := io.ReadAll(f)
 			if err != nil {
 				t.Fatal("error reading test data file", err)
 			}
@@ -48,7 +48,7 @@ func Test_CSR(t *testing.T) {
 				t.Fatal("test failed to unmarshal csr anonymized data", err)
 			}
 			defer f.Close()
-			bts, err = ioutil.ReadAll(f)
+			bts, err = io.ReadAll(f)
 			if err != nil {
 				t.Fatal("error reading test data file", err)
 			}

--- a/pkg/gatherers/clusterconfig/config_maps_test.go
+++ b/pkg/gatherers/clusterconfig/config_maps_test.go
@@ -1,10 +1,11 @@
 package clusterconfig
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -86,7 +87,7 @@ func Test_ConfigMap_Anonymizer(t *testing.T) {
 			mustNotFail(t, err, "unmarshaling of expected failed %+v")
 			exp, err := json.Marshal(d)
 			mustNotFail(t, err, "marshaling of expected failed %+v")
-			if string(exp) != string(md) {
+			if !bytes.Equal(exp, md) {
 				t.Fatalf("The test %s result is unexpected. Result: \n%s \nExpected \n%s", tt.testName, string(md), string(exp))
 			}
 		})
@@ -119,7 +120,7 @@ func readConfigMapsTestData() (*corev1.ConfigMapList, error) {
 
 	defer f.Close()
 
-	bts, err := ioutil.ReadAll(f)
+	bts, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("error reading test data file %+v ", err)
 	}

--- a/pkg/gatherers/clusterconfig/image_registries.go
+++ b/pkg/gatherers/clusterconfig/image_registries.go
@@ -19,6 +19,8 @@ import (
 	"github.com/openshift/insights-operator/pkg/utils/anonymize"
 )
 
+var lacAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
+
 // GatherClusterImageRegistry fetches the cluster Image Registry configuration
 //
 // **Conditional data**: If the Image Registry configuration uses any PersistentVolumeClaim for the storage, the corresponding
@@ -120,28 +122,64 @@ func findPVByPVCName(ctx context.Context, coreClient corev1client.CoreV1Interfac
 func anonymizeImageRegistry(config *registryv1.Config) *registryv1.Config {
 	config.Spec.HTTPSecret = anonymize.String(config.Spec.HTTPSecret)
 	if config.Spec.Storage.S3 != nil {
-		config.Spec.Storage.S3.Bucket = anonymize.String(config.Spec.Storage.S3.Bucket)
-		config.Spec.Storage.S3.KeyID = anonymize.String(config.Spec.Storage.S3.KeyID)
-		config.Spec.Storage.S3.RegionEndpoint = anonymize.String(config.Spec.Storage.S3.RegionEndpoint)
-		config.Spec.Storage.S3.Region = anonymize.String(config.Spec.Storage.S3.Region)
+		anonymizeS3Storage(config.Spec.Storage.S3)
 	}
 	if config.Spec.Storage.Azure != nil {
-		config.Spec.Storage.Azure.AccountName = anonymize.String(config.Spec.Storage.Azure.AccountName)
-		config.Spec.Storage.Azure.Container = anonymize.String(config.Spec.Storage.Azure.Container)
+		anonymizeAzureStorage(config.Spec.Storage.Azure)
 	}
 	if config.Spec.Storage.GCS != nil {
-		config.Spec.Storage.GCS.Bucket = anonymize.String(config.Spec.Storage.GCS.Bucket)
-		config.Spec.Storage.GCS.ProjectID = anonymize.String(config.Spec.Storage.GCS.ProjectID)
-		config.Spec.Storage.GCS.KeyID = anonymize.String(config.Spec.Storage.GCS.KeyID)
+		anonymizeGCSStorage(config.Spec.Storage.GCS)
 	}
 	if config.Spec.Storage.Swift != nil {
-		config.Spec.Storage.Swift.AuthURL = anonymize.String(config.Spec.Storage.Swift.AuthURL)
-		config.Spec.Storage.Swift.Container = anonymize.String(config.Spec.Storage.Swift.Container)
-		config.Spec.Storage.Swift.Domain = anonymize.String(config.Spec.Storage.Swift.Domain)
-		config.Spec.Storage.Swift.DomainID = anonymize.String(config.Spec.Storage.Swift.DomainID)
-		config.Spec.Storage.Swift.Tenant = anonymize.String(config.Spec.Storage.Swift.Tenant)
-		config.Spec.Storage.Swift.TenantID = anonymize.String(config.Spec.Storage.Swift.TenantID)
-		config.Spec.Storage.Swift.RegionName = anonymize.String(config.Spec.Storage.Swift.RegionName)
+		anonymizeSwiftStorage(config.Spec.Storage.Swift)
 	}
+	if config.Status.Storage.S3 != nil {
+		anonymizeS3Storage(config.Status.Storage.S3)
+	}
+	if config.Status.Storage.GCS != nil {
+		anonymizeGCSStorage(config.Status.Storage.GCS)
+	}
+	if config.Status.Storage.Azure != nil {
+		anonymizeAzureStorage(config.Status.Storage.Azure)
+	}
+	if config.Status.Storage.Swift != nil {
+		anonymizeSwiftStorage(config.Status.Storage.Swift)
+	}
+	// kubectl.kubernetes.io/last-applied-configuration annotation contains complete previous resource definition
+	// including the sensitive information as bucket, keyIDs, etc.
+	if lac, ok := config.Annotations[lacAnnotation]; ok {
+		config.Annotations[lacAnnotation] = anonymize.String(lac)
+	}
+
 	return config
+}
+
+func anonymizeS3Storage(s3Storage *registryv1.ImageRegistryConfigStorageS3) {
+	s3Storage.Bucket = anonymize.String(s3Storage.Bucket)
+	s3Storage.KeyID = anonymize.String(s3Storage.KeyID)
+	s3Storage.RegionEndpoint = anonymize.String(s3Storage.RegionEndpoint)
+	s3Storage.Region = anonymize.String(s3Storage.Region)
+}
+
+func anonymizeGCSStorage(gcsStorage *registryv1.ImageRegistryConfigStorageGCS) {
+	gcsStorage.Bucket = anonymize.String(gcsStorage.Bucket)
+	gcsStorage.KeyID = anonymize.String(gcsStorage.KeyID)
+	gcsStorage.ProjectID = anonymize.String(gcsStorage.ProjectID)
+	gcsStorage.Region = anonymize.String(gcsStorage.Region)
+}
+
+func anonymizeAzureStorage(azureStorage *registryv1.ImageRegistryConfigStorageAzure) {
+	azureStorage.AccountName = anonymize.String(azureStorage.AccountName)
+	azureStorage.Container = anonymize.String(azureStorage.Container)
+	azureStorage.CloudName = anonymize.String(azureStorage.CloudName)
+}
+
+func anonymizeSwiftStorage(swiftStorage *registryv1.ImageRegistryConfigStorageSwift) {
+	swiftStorage.AuthURL = anonymize.String(swiftStorage.AuthURL)
+	swiftStorage.Container = anonymize.String(swiftStorage.Container)
+	swiftStorage.Domain = anonymize.String(swiftStorage.Domain)
+	swiftStorage.DomainID = anonymize.String(swiftStorage.DomainID)
+	swiftStorage.Tenant = anonymize.String(swiftStorage.Tenant)
+	swiftStorage.TenantID = anonymize.String(swiftStorage.TenantID)
+	swiftStorage.RegionName = anonymize.String(swiftStorage.RegionName)
 }

--- a/pkg/gatherers/clusterconfig/image_registries_test.go
+++ b/pkg/gatherers/clusterconfig/image_registries_test.go
@@ -12,7 +12,33 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
-//nolint: goconst, funlen, gocyclo
+var (
+	testS3Storage = imageregistryv1.ImageRegistryConfigStorage{
+		S3: &imageregistryv1.ImageRegistryConfigStorageS3{
+			Bucket:         "foo",
+			Region:         "bar",
+			RegionEndpoint: "point",
+			KeyID:          "key",
+		},
+	}
+	testAzureStorage = imageregistryv1.ImageRegistryConfigStorage{
+		Azure: &imageregistryv1.ImageRegistryConfigStorageAzure{
+			AccountName: "account",
+			Container:   "container",
+			CloudName:   "cloud",
+		},
+	}
+	testGCSStorage = imageregistryv1.ImageRegistryConfigStorage{
+		GCS: &imageregistryv1.ImageRegistryConfigStorageGCS{
+			Bucket:    "bucket",
+			Region:    "region",
+			ProjectID: "foo",
+			KeyID:     "bar",
+		},
+	}
+)
+
+//nolint: goconst, funlen, gocyclo, dupl
 func Test_ImageRegistry_Gather(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -42,27 +68,23 @@ func Test_ImageRegistry_Gather(t *testing.T) {
 					Name: "cluster",
 				},
 				Spec: imageregistryv1.ImageRegistrySpec{
-					Storage: imageregistryv1.ImageRegistryConfigStorage{
-						S3: &imageregistryv1.ImageRegistryConfigStorageS3{
-							Bucket:         "foo",
-							Region:         "bar",
-							RegionEndpoint: "point",
-							KeyID:          "key",
-						},
-					},
+					Storage: testS3Storage,
+				},
+				Status: imageregistryv1.ImageRegistryStatus{
+					Storage: testS3Storage,
 				},
 			},
 			evalOutput: func(t *testing.T, obj *imageregistryv1.Config) {
-				if obj.Spec.Storage.S3.Bucket != "xxx" {
+				if obj.Spec.Storage.S3.Bucket != "xxx" || obj.Status.Storage.S3.Bucket != "xxx" {
 					t.Errorf("expected s3 bucket anonymized, got %q", obj.Spec.Storage.S3.Bucket)
 				}
-				if obj.Spec.Storage.S3.Region != "xxx" {
+				if obj.Spec.Storage.S3.Region != "xxx" || obj.Status.Storage.S3.Region != "xxx" {
 					t.Errorf("expected s3 region anonymized, got %q", obj.Spec.Storage.S3.Region)
 				}
-				if obj.Spec.Storage.S3.RegionEndpoint != "xxxxx" {
+				if obj.Spec.Storage.S3.RegionEndpoint != "xxxxx" || obj.Status.Storage.S3.RegionEndpoint != "xxxxx" {
 					t.Errorf("expected s3 region endpoint anonymized, got %q", obj.Spec.Storage.S3.RegionEndpoint)
 				}
-				if obj.Spec.Storage.S3.KeyID != "xxx" {
+				if obj.Spec.Storage.S3.KeyID != "xxx" || obj.Status.Storage.S3.KeyID != "xxx" {
 					t.Errorf("expected s3 keyID anonymized, got %q", obj.Spec.Storage.S3.KeyID)
 				}
 			},
@@ -74,20 +96,21 @@ func Test_ImageRegistry_Gather(t *testing.T) {
 					Name: "cluster",
 				},
 				Spec: imageregistryv1.ImageRegistrySpec{
-					Storage: imageregistryv1.ImageRegistryConfigStorage{
-						Azure: &imageregistryv1.ImageRegistryConfigStorageAzure{
-							AccountName: "account",
-							Container:   "container",
-						},
-					},
+					Storage: testAzureStorage,
+				},
+				Status: imageregistryv1.ImageRegistryStatus{
+					Storage: testAzureStorage,
 				},
 			},
 			evalOutput: func(t *testing.T, obj *imageregistryv1.Config) {
-				if obj.Spec.Storage.Azure.AccountName != "xxxxxxx" {
+				if obj.Spec.Storage.Azure.AccountName != "xxxxxxx" || obj.Status.Storage.Azure.AccountName != "xxxxxxx" {
 					t.Errorf("expected azure account name anonymized, got %q", obj.Spec.Storage.Azure.AccountName)
 				}
-				if obj.Spec.Storage.Azure.Container == "xxxxxxx" {
+				if obj.Spec.Storage.Azure.Container != "xxxxxxxxx" || obj.Status.Storage.Azure.Container != "xxxxxxxxx" {
 					t.Errorf("expected azure container anonymized, got %q", obj.Spec.Storage.Azure.Container)
+				}
+				if obj.Spec.Storage.Azure.CloudName != "xxxxx" || obj.Status.Storage.Azure.CloudName != "xxxxx" {
+					t.Errorf("expected azure cloud name anonymized, got %q", obj.Spec.Storage.Azure.CloudName)
 				}
 			},
 		},
@@ -98,24 +121,20 @@ func Test_ImageRegistry_Gather(t *testing.T) {
 					Name: "cluster",
 				},
 				Spec: imageregistryv1.ImageRegistrySpec{
-					Storage: imageregistryv1.ImageRegistryConfigStorage{
-						GCS: &imageregistryv1.ImageRegistryConfigStorageGCS{
-							Bucket:    "bucket",
-							Region:    "region",
-							ProjectID: "foo",
-							KeyID:     "bar",
-						},
-					},
+					Storage: testGCSStorage,
+				},
+				Status: imageregistryv1.ImageRegistryStatus{
+					Storage: testGCSStorage,
 				},
 			},
 			evalOutput: func(t *testing.T, obj *imageregistryv1.Config) {
-				if obj.Spec.Storage.GCS.Bucket != "xxxxxx" {
+				if obj.Spec.Storage.GCS.Bucket != "xxxxxx" || obj.Status.Storage.GCS.Bucket != "xxxxxx" {
 					t.Errorf("expected gcs bucket anonymized, got %q", obj.Spec.Storage.GCS.Bucket)
 				}
-				if obj.Spec.Storage.GCS.ProjectID != "xxx" {
+				if obj.Spec.Storage.GCS.ProjectID != "xxx" || obj.Status.Storage.GCS.ProjectID != "xxx" {
 					t.Errorf("expected gcs projectID endpoint anonymized, got %q", obj.Spec.Storage.GCS.ProjectID)
 				}
-				if obj.Spec.Storage.GCS.KeyID != "xxx" {
+				if obj.Spec.Storage.GCS.KeyID != "xxx" || obj.Status.Storage.GCS.KeyID != "xxx" {
 					t.Errorf("expected gcs keyID anonymized, got %q", obj.Spec.Storage.GCS.KeyID)
 				}
 			},

--- a/pkg/gatherers/clusterconfig/install_plans_test.go
+++ b/pkg/gatherers/clusterconfig/install_plans_test.go
@@ -2,7 +2,7 @@ package clusterconfig
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -65,7 +65,7 @@ func Test_InstallPlans_Gather(t *testing.T) {
 					t.Fatal("test failed to read installplan data", err)
 				}
 				defer f.Close()
-				installplancontent, err := ioutil.ReadAll(f)
+				installplancontent, err := io.ReadAll(f)
 				if err != nil {
 					t.Fatal("error reading test data file", err)
 				}

--- a/pkg/gatherers/clusterconfig/olm_operators_test.go
+++ b/pkg/gatherers/clusterconfig/olm_operators_test.go
@@ -3,7 +3,7 @@ package clusterconfig
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -154,7 +154,7 @@ func readFromFile(filePath string) ([]byte, error) {
 
 	defer f.Close()
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatherers/clusterconfig/recent_metrics.go
+++ b/pkg/gatherers/clusterconfig/recent_metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -68,7 +67,7 @@ func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) 
 		return nil, []error{err}
 	}
 	r := utils.NewLineLimitReader(rsp, metricsAlertsLinesLimit)
-	alerts, err := ioutil.ReadAll(r)
+	alerts, err := io.ReadAll(r)
 	if err != nil && err != io.EOF {
 		klog.Errorf("Unable to read most recent alerts from metrics: %v", err)
 		return nil, []error{err}

--- a/pkg/gatherers/workloads/workloads_info_test.go
+++ b/pkg/gatherers/workloads/workloads_info_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -50,7 +49,7 @@ func Test_gatherWorkloadInfo(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err = ioutil.WriteFile("../../../docs/insights-archive-sample/config/workload_info.json", out, 0750); err != nil {
+		if err = os.WriteFile("../../../docs/insights-archive-sample/config/workload_info.json", out, 0750); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -89,17 +89,21 @@ func (d *DiskRecorder) Save(records record.MemoryRecords) (record.MemoryRecords,
 
 // Prune the archives older than given time
 func (d *DiskRecorder) Prune(olderThan time.Time) error {
-	files, err := ioutil.ReadDir(d.basePath)
+	files, err := os.ReadDir(d.basePath)
 	if err != nil {
 		return err
 	}
 	count := 0
 	var errors []string
 	for _, file := range files {
-		if isNotArchiveFile(file) {
+		fileInfo, err := file.Info()
+		if err != nil {
 			continue
 		}
-		if file.ModTime().After(olderThan) {
+		if isNotArchiveFile(fileInfo) {
+			continue
+		}
+		if fileInfo.ModTime().After(olderThan) {
 			continue
 		}
 		if err := os.Remove(filepath.Join(d.basePath, file.Name())); err != nil {
@@ -122,7 +126,7 @@ func (d *DiskRecorder) Prune(olderThan time.Time) error {
 
 // Summary implements summarizer interface to insights uploader
 func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (io.ReadCloser, bool, error) {
-	files, err := ioutil.ReadDir(d.basePath)
+	files, err := os.ReadDir(d.basePath)
 	if err != nil {
 		return nil, false, err
 	}
@@ -130,11 +134,17 @@ func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (io.ReadClose
 		return nil, false, nil
 	}
 	recentFiles := make([]string, 0, len(files))
+
+	var fileInfo fs.FileInfo
 	for _, file := range files {
-		if isNotArchiveFile(file) {
+		fileInfo, err = file.Info()
+		if err != nil {
+			return nil, false, err
+		}
+		if isNotArchiveFile(fileInfo) {
 			continue
 		}
-		if !file.ModTime().After(since) {
+		if !fileInfo.ModTime().After(since) {
 			continue
 		}
 		recentFiles = append(recentFiles, file.Name())


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This backport the https://github.com/openshift/insights-operator/pull/526 & removes deprecated `ioutil` usage to satisfy our linter

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Test updated and extended: 
- `pkg/gatherers/clusterconfig/image_registries_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2020601
https://access.redhat.com/solutions/???
