### PR TITLE
[release-4.7] Bug 2022637: Anonymize the ImageRegistry storage inform…

### DIFF
--- a/pkg/gather/clusterconfig/image_registries_test.go
+++ b/pkg/gather/clusterconfig/image_registries_test.go
@@ -11,6 +11,32 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
+var (
+	testS3Storage = imageregistryv1.ImageRegistryConfigStorage{
+		S3: &imageregistryv1.ImageRegistryConfigStorageS3{
+			Bucket:         "foo",
+			Region:         "bar",
+			RegionEndpoint: "point",
+			KeyID:          "key",
+		},
+	}
+	testAzureStorage = imageregistryv1.ImageRegistryConfigStorage{
+		Azure: &imageregistryv1.ImageRegistryConfigStorageAzure{
+			AccountName: "account",
+			Container:   "container",
+			CloudName:   "cloud",
+		},
+	}
+	testGCSStorage = imageregistryv1.ImageRegistryConfigStorage{
+		GCS: &imageregistryv1.ImageRegistryConfigStorageGCS{
+			Bucket:    "bucket",
+			Region:    "region",
+			ProjectID: "foo",
+			KeyID:     "bar",
+		},
+	}
+)
+
 func TestGatherClusterImageRegistry(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -40,27 +66,23 @@ func TestGatherClusterImageRegistry(t *testing.T) {
 					Name: "cluster",
 				},
 				Spec: imageregistryv1.ImageRegistrySpec{
-					Storage: imageregistryv1.ImageRegistryConfigStorage{
-						S3: &imageregistryv1.ImageRegistryConfigStorageS3{
-							Bucket:         "foo",
-							Region:         "bar",
-							RegionEndpoint: "point",
-							KeyID:          "key",
-						},
-					},
+					Storage: testS3Storage,
+				},
+				Status: imageregistryv1.ImageRegistryStatus{
+					Storage: testS3Storage,
 				},
 			},
 			evalOutput: func(t *testing.T, obj *imageregistryv1.Config) {
-				if obj.Spec.Storage.S3.Bucket != "xxx" {
+				if obj.Spec.Storage.S3.Bucket != "xxx" || obj.Status.Storage.S3.Bucket != "xxx" {
 					t.Errorf("expected s3 bucket anonymized, got %q", obj.Spec.Storage.S3.Bucket)
 				}
-				if obj.Spec.Storage.S3.Region != "xxx" {
+				if obj.Spec.Storage.S3.Region != "xxx" || obj.Status.Storage.S3.Region != "xxx" {
 					t.Errorf("expected s3 region anonymized, got %q", obj.Spec.Storage.S3.Region)
 				}
-				if obj.Spec.Storage.S3.RegionEndpoint != "xxxxx" {
+				if obj.Spec.Storage.S3.RegionEndpoint != "xxxxx" || obj.Status.Storage.S3.RegionEndpoint != "xxxxx" {
 					t.Errorf("expected s3 region endpoint anonymized, got %q", obj.Spec.Storage.S3.RegionEndpoint)
 				}
-				if obj.Spec.Storage.S3.KeyID != "xxx" {
+				if obj.Spec.Storage.S3.KeyID != "xxx" || obj.Status.Storage.S3.KeyID != "xxx" {
 					t.Errorf("expected s3 keyID anonymized, got %q", obj.Spec.Storage.S3.KeyID)
 				}
 			},
@@ -72,20 +94,21 @@ func TestGatherClusterImageRegistry(t *testing.T) {
 					Name: "cluster",
 				},
 				Spec: imageregistryv1.ImageRegistrySpec{
-					Storage: imageregistryv1.ImageRegistryConfigStorage{
-						Azure: &imageregistryv1.ImageRegistryConfigStorageAzure{
-							AccountName: "account",
-							Container:   "container",
-						},
-					},
+					Storage: testAzureStorage,
+				},
+				Status: imageregistryv1.ImageRegistryStatus{
+					Storage: testAzureStorage,
 				},
 			},
 			evalOutput: func(t *testing.T, obj *imageregistryv1.Config) {
-				if obj.Spec.Storage.Azure.AccountName != "xxxxxxx" {
+				if obj.Spec.Storage.Azure.AccountName != "xxxxxxx" || obj.Status.Storage.Azure.AccountName != "xxxxxxx" {
 					t.Errorf("expected azure account name anonymized, got %q", obj.Spec.Storage.Azure.AccountName)
 				}
-				if obj.Spec.Storage.Azure.Container == "xxxxxxx" {
+				if obj.Spec.Storage.Azure.Container != "xxxxxxxxx" || obj.Status.Storage.Azure.Container != "xxxxxxxxx" {
 					t.Errorf("expected azure container anonymized, got %q", obj.Spec.Storage.Azure.Container)
+				}
+				if obj.Spec.Storage.Azure.CloudName != "xxxxx" || obj.Status.Storage.Azure.CloudName != "xxxxx" {
+					t.Errorf("expected azure cloud name anonymized, got %q", obj.Spec.Storage.Azure.CloudName)
 				}
 			},
 		},
@@ -96,24 +119,20 @@ func TestGatherClusterImageRegistry(t *testing.T) {
 					Name: "cluster",
 				},
 				Spec: imageregistryv1.ImageRegistrySpec{
-					Storage: imageregistryv1.ImageRegistryConfigStorage{
-						GCS: &imageregistryv1.ImageRegistryConfigStorageGCS{
-							Bucket:    "bucket",
-							Region:    "region",
-							ProjectID: "foo",
-							KeyID:     "bar",
-						},
-					},
+					Storage: testGCSStorage,
+				},
+				Status: imageregistryv1.ImageRegistryStatus{
+					Storage: testGCSStorage,
 				},
 			},
 			evalOutput: func(t *testing.T, obj *imageregistryv1.Config) {
-				if obj.Spec.Storage.GCS.Bucket != "xxxxxx" {
+				if obj.Spec.Storage.GCS.Bucket != "xxxxxx" || obj.Status.Storage.GCS.Bucket != "xxxxxx" {
 					t.Errorf("expected gcs bucket anonymized, got %q", obj.Spec.Storage.GCS.Bucket)
 				}
-				if obj.Spec.Storage.GCS.ProjectID != "xxx" {
+				if obj.Spec.Storage.GCS.ProjectID != "xxx" || obj.Status.Storage.GCS.ProjectID != "xxx" {
 					t.Errorf("expected gcs projectID endpoint anonymized, got %q", obj.Spec.Storage.GCS.ProjectID)
 				}
-				if obj.Spec.Storage.GCS.KeyID != "xxx" {
+				if obj.Spec.Storage.GCS.KeyID != "xxx" || obj.Status.Storage.GCS.KeyID != "xxx" {
 					t.Errorf("expected gcs keyID anonymized, got %q", obj.Spec.Storage.GCS.KeyID)
 				}
 			},


### PR DESCRIPTION
…ation also in status

<!-- Short description of the PR. What does it do? -->
Backport of https://github.com/openshift/insights-operator/pull/536

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Updated & extended
- ` pkg/gather/clusterconfig/image_registries_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2022637
https://access.redhat.com/solutions/???
