### PR TITLE
adding gatherer for collecting silenced alerts

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -774,6 +774,17 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
   * 4.7+
 
 
+## SilencedAlerts
+
+gathers the alerts that have been silenced.
+
+* Location in archive: config/silenced_alerts
+* See: docs/insights-archive-sample/config/silenced_alerts
+* Id in config: silenced_alerts
+* Since version:
+  * 4.10+
+
+
 ## TSDBStatus
 
 gathers the Prometheus TSDB status.

--- a/docs/insights-archive-sample/config/silenced_alerts.json
+++ b/docs/insights-archive-sample/config/silenced_alerts.json
@@ -1,0 +1,62 @@
+[
+    {
+        "annotations": {
+            "description": "Alerts are not configured to be sent to a notification system, meaning that you may not be notified in a timely fashion when important failures occur. Check the OpenShift documentation to learn how to configure notifications with Alertmanager.",
+            "summary": "Receivers (notification integrations) are not configured on Alertmanager"
+        },
+        "endsAt": "2021-11-26T13:13:25.342Z",
+        "fingerprint": "36dc4a4e69cb6fd9",
+        "receivers": [
+            {
+                "name": "Default"
+            }
+        ],
+        "startsAt": "2021-11-26T13:02:25.342Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [
+                "2c5a3bfc-d960-4529-bc7e-cc7ee68bf7b2"
+            ],
+            "state": "suppressed"
+        },
+        "updatedAt": "2021-11-26T13:09:25.410Z",
+        "generatorURL": "https://prometheus-k8s-openshift-monitoring.apps.ci-ln-x65rhk2-72292.origin-ci-int-gce.dev.rhcloud.com/graph?g0.expr=cluster%3Aalertmanager_integrations%3Amax+%3D%3D+0\u0026g0.tab=1",
+        "labels": {
+            "alertname": "AlertmanagerReceiversNotConfigured",
+            "namespace": "openshift-monitoring",
+            "prometheus": "openshift-monitoring/k8s",
+            "severity": "warning"
+        }
+    },
+    {
+        "annotations": {
+            "description": "The API server is burning too much error budget. This alert fires when too many requests are failing with high latency. Use the 'API Performance' monitoring dashboards to narrow down the request states and latency. The 'etcd' monitoring dashboards also provides metrics to help determine etcd stability and performance.",
+            "summary": "The API server is burning too much error budget."
+        },
+        "endsAt": "2021-11-26T13:12:23.886Z",
+        "fingerprint": "4b3356c241bc9026",
+        "receivers": [
+            {
+                "name": "Critical"
+            }
+        ],
+        "startsAt": "2021-11-26T13:08:23.886Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [
+                "cef4c12f-83da-4d50-9c56-e3df6f701878"
+            ],
+            "state": "suppressed"
+        },
+        "updatedAt": "2021-11-26T13:08:23.899Z",
+        "generatorURL": "https://prometheus-k8s-openshift-monitoring.apps.ci-ln-x65rhk2-72292.origin-ci-int-gce.dev.rhcloud.com/graph?g0.expr=sum%28apiserver_request%3Aburnrate6h%29+%3E+%286+%2A+0.01%29+and+sum%28apiserver_request%3Aburnrate30m%29+%3E+%286+%2A+0.01%29\u0026g0.tab=1",
+        "labels": {
+            "alertname": "KubeAPIErrorBudgetBurn",
+            "long": "6h",
+            "namespace": "openshift-kube-apiserver",
+            "prometheus": "openshift-monitoring/k8s",
+            "severity": "critical",
+            "short": "30m"
+        }
+    }
+]

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -77,6 +77,26 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: insights-operator-alertmanager
+  namespace: openshift-monitoring
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  kind: Role
+  name: monitoring-alertmanager-edit
+subjects:
+  - kind: ServiceAccount
+    namespace: openshift-insights
+    name: operator
+
+---
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: insights-operator
@@ -203,7 +223,7 @@ rules:
     verbs:
       - get
       - list
-      - watch    
+      - watch
   - apiGroups:
       - logging.openshift.io
     resources:
@@ -235,7 +255,7 @@ rules:
     verbs:
       - get
       - list
-      - watch    
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/controller/const.go
+++ b/pkg/controller/const.go
@@ -1,6 +1,7 @@
 package controller
 
 const (
-	metricCAFile = "/var/run/configmaps/service-ca-bundle/service-ca.crt"
-	metricHost   = "https://prometheus-k8s.openshift-monitoring.svc:9091"
+	metricCAFile     = "/var/run/configmaps/service-ca-bundle/service-ca.crt"
+	metricHost       = "https://prometheus-k8s.openshift-monitoring.svc:9091"
+	alertManagerHost = "https://alertmanager-main.openshift-monitoring.svc:9094"
 )

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -53,11 +53,12 @@ type ArchiveMetadata struct {
 
 // CreateAllGatherers creates all the gatherers
 func CreateAllGatherers(
-	gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig *rest.Config,
+	gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig *rest.Config,
 	anonymizer *anonymization.Anonymizer, controller *config.Controller,
 ) []gatherers.Interface {
 	clusterConfigGatherer := clusterconfig.New(
-		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, anonymizer, controller.Interval,
+		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig,
+		anonymizer, controller.Interval,
 	)
 	workloadsGatherer := workloads.New(gatherProtoKubeConfig)
 	conditionalGatherer := conditional.New(gatherProtoKubeConfig, metricsGatherKubeConfig)

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -16,6 +16,7 @@ type Gatherer struct {
 	gatherKubeConfig        *rest.Config
 	gatherProtoKubeConfig   *rest.Config
 	metricsGatherKubeConfig *rest.Config
+	alertsGatherKubeConfig  *rest.Config
 	anonymizer              *anonymization.Anonymizer
 	interval                time.Duration
 }
@@ -94,16 +95,18 @@ var gatheringFunctions = map[string]gatheringFunction{
 	"cost_management_metrics_configs":   failableFunc((*Gatherer).GatherCostManagementMetricsConfigs),
 	"node_logs":                         failableFunc((*Gatherer).GatherNodeLogs),
 	"tsdb_status":                       failableFunc((*Gatherer).GatherTSDBStatus),
+	"silenced_alerts":                   failableFunc((*Gatherer).GatherSilencedAlerts),
 }
 
 func New(
-	gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig *rest.Config,
+	gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig *rest.Config,
 	anonymizer *anonymization.Anonymizer, interval time.Duration,
 ) *Gatherer {
 	return &Gatherer{
 		gatherKubeConfig:        gatherKubeConfig,
 		gatherProtoKubeConfig:   gatherProtoKubeConfig,
 		metricsGatherKubeConfig: metricsGatherKubeConfig,
+		alertsGatherKubeConfig:  alertsGatherKubeConfig,
 		anonymizer:              anonymizer,
 		interval:                interval,
 	}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer_test.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_Gatherer_Basic(t *testing.T) {
-	gatherer := clusterconfig.New(nil, nil, nil, nil, 1*time.Minute)
+	gatherer := clusterconfig.New(nil, nil, nil, nil, nil, 1*time.Minute)
 	assert.Equal(t, "clusterconfig", gatherer.GetName())
 	gatheringFunctions, err := gatherer.GetGatheringFunctions(context.TODO())
 	assert.NoError(t, err)

--- a/pkg/gatherers/clusterconfig/silenced_alerts.go
+++ b/pkg/gatherers/clusterconfig/silenced_alerts.go
@@ -1,0 +1,46 @@
+package clusterconfig
+
+import (
+	"context"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils/marshal"
+)
+
+// GatherSilencedAlerts gathers the alerts that have been silenced.
+//
+// * Location in archive: config/silenced_alerts
+// * See: docs/insights-archive-sample/config/silenced_alerts
+// * Id in config: silenced_alerts
+// * Since version:
+//   * 4.10+
+func (g *Gatherer) GatherSilencedAlerts(ctx context.Context) ([]record.Record, []error) {
+	alertsRESTClient, err := rest.RESTClientFor(g.alertsGatherKubeConfig)
+	if err != nil {
+		klog.Warningf("Unable to load alerts client, no alerts will be collected: %v", err)
+		return nil, nil
+	}
+
+	return gatherSilencedAlerts(ctx, alertsRESTClient)
+}
+
+func gatherSilencedAlerts(ctx context.Context, alertsClient rest.Interface) ([]record.Record, []error) {
+	data, err := alertsClient.Get().AbsPath("api/v2/alerts").
+		Param("silenced", "true").
+		Param("active", "false").
+		Param("inhibited", "false").
+		DoRaw(ctx)
+	if err != nil {
+		klog.Errorf("Unable to retrieve silenced alerts: %v", err)
+		return nil, []error{err}
+	}
+
+	records := []record.Record{
+		{Name: "config/silenced_alerts.json", Item: marshal.RawByte(data)},
+	}
+
+	return records, nil
+}


### PR DESCRIPTION
Signed-off-by: Prashant Balachandran <pnair@redhat.com>

This PR adds a new gatherer which can collect silenced alerts from the alertmanager.

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Documentation
- `docs/gathered-data.md`

## References

https://issues.redhat.com/browse/CCXDEV-6423

