### PR TITLE
[release-4.9] Bug 2026644: Gather all the container logs from relate namespaces of degraded clusteroperator

### DIFF
--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -77,8 +77,8 @@ func createPullRequestLink(id string) string {
 func main() {
 	log.SetFlags(0)
 	if len(os.Args) != 1 && len(os.Args) != 3 {
-		log.Fatalf(`Either specify two date arguments, AFTER and UNTIL, 
-		to create a brand new CHANGELOG, or call it without arguments to 
+		log.Fatalf(`Either specify two date arguments, AFTER and UNTIL,
+		to create a brand new CHANGELOG, or call it without arguments to
 		update the current one with new changes.`)
 	}
 	gitHubToken = os.Getenv("GITHUB_TOKEN")
@@ -120,7 +120,7 @@ type MarkdownReleaseBlock struct {
 
 func readCHANGELOG() map[string]MarkdownReleaseBlock {
 	releaseBlocks := make(map[string]MarkdownReleaseBlock)
-	rawBytes, _ := ioutil.ReadFile("./CHANGELOG.md")
+	rawBytes, _ := os.ReadFile("./CHANGELOG.md")
 	rawString := string(rawBytes)
 	if match := latestHashRegexp.FindStringSubmatch(rawString); len(match) > 0 {
 		latestHash = match[1]
@@ -181,7 +181,7 @@ func updateToMarkdownReleaseBlock(releaseBlocks map[string]MarkdownReleaseBlock,
 func createCHANGELOG(releaseBlocks map[string]MarkdownReleaseBlock) {
 	file, _ := os.Create("CHANGELOG.md")
 	defer file.Close()
-	_, _ = file.WriteString(`# Note: This CHANGELOG is only for the changes in insights operator. 
+	_, _ = file.WriteString(`# Note: This CHANGELOG is only for the changes in insights operator.
 	Please see OpenShift release notes for official changes\n`)
 	_, _ = file.WriteString(fmt.Sprintf("<!--Latest hash: %s-->\n", latestHash))
 	var releases []string
@@ -231,7 +231,11 @@ func getPullRequestFromGitHub(id string) *Change {
 	// There is a limit for the GitHub API, if you use auth then its 5000/hour
 	var bearer = "token " + gitHubToken
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id), nil)
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		"GET",
+		fmt.Sprintf(gitHubAPIFormat, gitHubRepoOwner, gitHubRepo, id),
+		http.NoBody)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
@@ -242,7 +246,7 @@ func getPullRequestFromGitHub(id string) *Change {
 		log.Fatalf(err.Error())
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		defer log.Fatalf(err.Error())
 		return nil

--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -6,7 +6,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -219,7 +218,7 @@ func findGoMod(pkgFilePath string) (goModPath, relPkgPath string, err error) {
 
 // getModuleNameFromGoMod parses the go.mod file and returns the name (URL) of the module.
 func getModuleNameFromGoMod(goModPath string) (string, error) {
-	goModBytes, err := ioutil.ReadFile(goModPath)
+	goModBytes, err := os.ReadFile(goModPath)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/obfuscate-archive/main.go
+++ b/cmd/obfuscate-archive/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -190,7 +189,7 @@ func readArchive(path string) (map[string]*record.MemoryRecord, error) {
 			return nil, err
 		}
 
-		content, err := ioutil.ReadAll(tarReader)
+		content, err := io.ReadAll(tarReader)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -146,12 +146,12 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 ## ClusterOperatorPodsAndEvents
 
-collects information about all pods
+collects information about pods
 and events from namespaces of degraded cluster operators. The collected
 information includes:
 
-- Pod definitions
-- Previous and current logs of pod containers (when available)
+- Definitions for non-running (terminated, pending) Pods
+- Previous (if container was terminated) and current logs of all related pod containers
 - Namespace events
 
 * Location of pod definitions: config/pod/{namespace}/{pod}.json

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -2,7 +2,6 @@ package start
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"time"
@@ -87,7 +86,7 @@ func runGather(operator *controller.GatherJob, cfg *controllercmd.ControllerComm
 
 		var clientConfig *rest.Config
 		if kubeConfigPath := cmd.Flags().Lookup("kubeconfig").Value.String(); len(kubeConfigPath) > 0 {
-			kubeConfigBytes, err := ioutil.ReadFile(kubeConfigPath) //nolint: govet
+			kubeConfigBytes, err := os.ReadFile(kubeConfigPath) //nolint: govet
 			if err != nil {
 				klog.Exit(err)
 			}
@@ -143,7 +142,7 @@ func runOperator(operator *controller.Operator, cfg *controllercmd.ControllerCom
 		}
 
 		// if the service CA is rotated, we want to restart
-		if data, err := ioutil.ReadFile(serviceCACertPath); err == nil {
+		if data, err := os.ReadFile(serviceCACertPath); err == nil {
 			startingFileContent[serviceCACertPath] = data
 		} else {
 			klog.V(4).Infof("Unable to read service ca bundle: %v", err)

--- a/pkg/gatherers/clusterconfig/certificate_signing_requests_test.go
+++ b/pkg/gatherers/clusterconfig/certificate_signing_requests_test.go
@@ -3,7 +3,7 @@ package clusterconfig
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -33,7 +33,7 @@ func Test_CSR(t *testing.T) {
 				t.Fatal("test failed to unmarshal csr data", err)
 			}
 			defer f.Close()
-			bts, err := ioutil.ReadAll(f)
+			bts, err := io.ReadAll(f)
 			if err != nil {
 				t.Fatal("error reading test data file", err)
 			}
@@ -48,7 +48,7 @@ func Test_CSR(t *testing.T) {
 				t.Fatal("test failed to unmarshal csr anonymized data", err)
 			}
 			defer f.Close()
-			bts, err = ioutil.ReadAll(f)
+			bts, err = io.ReadAll(f)
 			if err != nil {
 				t.Fatal("error reading test data file", err)
 			}

--- a/pkg/gatherers/clusterconfig/config_maps_test.go
+++ b/pkg/gatherers/clusterconfig/config_maps_test.go
@@ -1,10 +1,11 @@
 package clusterconfig
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -86,7 +87,7 @@ func Test_ConfigMap_Anonymizer(t *testing.T) {
 			mustNotFail(t, err, "unmarshaling of expected failed %+v")
 			exp, err := json.Marshal(d)
 			mustNotFail(t, err, "marshaling of expected failed %+v")
-			if string(exp) != string(md) {
+			if !bytes.Equal(exp, md) {
 				t.Fatalf("The test %s result is unexpected. Result: \n%s \nExpected \n%s", tt.testName, string(md), string(exp))
 			}
 		})
@@ -119,7 +120,7 @@ func readConfigMapsTestData() (*corev1.ConfigMapList, error) {
 
 	defer f.Close()
 
-	bts, err := ioutil.ReadAll(f)
+	bts, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("error reading test data file %+v ", err)
 	}

--- a/pkg/gatherers/clusterconfig/install_plans_test.go
+++ b/pkg/gatherers/clusterconfig/install_plans_test.go
@@ -2,7 +2,7 @@ package clusterconfig
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -63,7 +63,7 @@ func Test_InstallPlans_Gather(t *testing.T) {
 					t.Fatal("test failed to read installplan data", err)
 				}
 				defer f.Close()
-				installplancontent, err := ioutil.ReadAll(f)
+				installplancontent, err := io.ReadAll(f)
 				if err != nil {
 					t.Fatal("error reading test data file", err)
 				}

--- a/pkg/gatherers/clusterconfig/olm_operators_test.go
+++ b/pkg/gatherers/clusterconfig/olm_operators_test.go
@@ -3,7 +3,7 @@ package clusterconfig
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -154,7 +154,7 @@ func readFromFile(filePath string) ([]byte, error) {
 
 	defer f.Close()
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -42,12 +42,12 @@ type CompactedEventList struct {
 // Used to detect the possible stack trace on logs
 var stackTraceRegex = regexp.MustCompile(`\.go:\d+\s\+0x`)
 
-// GatherClusterOperatorPodsAndEvents collects information about all pods
+// GatherClusterOperatorPodsAndEvents collects information about pods
 // and events from namespaces of degraded cluster operators. The collected
 // information includes:
 //
-// - Pod definitions
-// - Previous and current logs of pod containers (when available)
+// - Definitions for non-running (terminated, pending) Pods
+// - Previous (if container was terminated) and current logs of all related pod containers
 // - Namespace events
 //
 // * Location of pod definitions: config/pod/{namespace}/{pod}.json
@@ -91,7 +91,7 @@ func gatherClusterOperatorPodsAndEvents(ctx context.Context,
 		return nil, err
 	}
 
-	// gather pods from unhealthy operators
+	// get all related pods for unhealthy operator
 	pods, records, totalContainers := unhealthyClusterOperator(ctx, config.Items, coreClient, interval)
 	// Exit early if no pods found
 	klog.V(2).Infof("Found %d pods with %d containers", len(pods), totalContainers)
@@ -99,9 +99,8 @@ func gatherClusterOperatorPodsAndEvents(ctx context.Context,
 		return records, nil
 	}
 
-	// gather pods containers logs
 	bufferSize := int64(recorder.MaxArchiveSize * logCompressionRatio / totalContainers / 2)
-	clogs, err := gatherPodContainersLogs(ctx, coreClient, pods, bufferSize)
+	clogs, err := gatherPodsAndTheirContainersLogs(ctx, coreClient, pods, bufferSize)
 	if err != nil {
 		klog.V(2).Infof("Unable to gather pod containers logs: %v", err)
 		return records, nil
@@ -138,22 +137,21 @@ func unhealthyClusterOperator(ctx context.Context,
 				continue
 			}
 
-			uhPods, uhRecords, uhTotal := gatherUnhealthyPods(podList.Items)
-			pods = append(pods, uhPods...)
-			records = append(records, uhRecords...)
-			totalContainers += uhTotal
+			nsPods, nsTotal := getAllRelatedPods(podList.Items)
+			pods = append(pods, nsPods...)
+			totalContainers += nsTotal
 
 			if namespaceEventsCollected.Has(namespace) {
 				continue
 			}
 
-			namespaceRecords, err := gatherNamespaceEvents(ctx, coreClient, namespace, interval)
+			eventRecords, err := gatherNamespaceEvents(ctx, coreClient, namespace, interval)
 			if err != nil {
 				klog.V(2).Infof("Unable to collect events for namespace %q: %#v", namespace, err)
 				continue
 			}
 
-			records = append(records, namespaceRecords...)
+			records = append(records, eventRecords...)
 			namespaceEventsCollected.Insert(namespace)
 		}
 	}
@@ -161,27 +159,19 @@ func unhealthyClusterOperator(ctx context.Context,
 	return pods, records, totalContainers
 }
 
-// gatherUnhealthyPods collects cluster operator unhealthy pods
-func gatherUnhealthyPods(pods []corev1.Pod) ([]*corev1.Pod, []record.Record, int) {
-	var records []record.Record
+// getAllRelatedPods collects all the cluster operator's related pods
+// nolint: gocritic
+func getAllRelatedPods(pods []corev1.Pod) ([]*corev1.Pod, int) {
 	var podList []*corev1.Pod
 	total := 0
-	now := time.Now()
 
 	for j := range pods {
 		pod := &pods[j]
-		if check.IsHealthyPod(pod, now) {
-			continue
-		}
-		records = append(records, record.Record{
-			Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name),
-			Item: record.ResourceMarshaller{Resource: pod},
-		})
 		podList = append(podList, pod)
 		total += len(pod.Spec.InitContainers) + len(pod.Spec.Containers)
 	}
 
-	return podList, records, total
+	return podList, total
 }
 
 // gatherNamespaceEvents gather all namespace events
@@ -236,8 +226,10 @@ func gatherNamespaceEvents(ctx context.Context,
 	return []record.Record{{Name: fmt.Sprintf("events/%s", namespace), Item: record.JSONMarshaller{Object: &compactedEvents}}}, nil
 }
 
-// gatherPodContainersLogs collect the pod current and previous containers logs
-func gatherPodContainersLogs(ctx context.Context,
+// gatherPodsAndTheirContainersLogs iterates over all related pods and gets container
+// log for every pod and tries to get previous log for every non-running/unhealthy pod. The definition
+// of non-running/unhealthy pod is added to records as well.
+func gatherPodsAndTheirContainersLogs(ctx context.Context,
 	client corev1client.CoreV1Interface,
 	pods []*corev1.Pod,
 	bufferSize int64) ([]record.Record, error) {
@@ -245,20 +237,23 @@ func gatherPodContainersLogs(ctx context.Context,
 		return nil, fmt.Errorf("invalid buffer size %d", bufferSize)
 	}
 
-	// Fetch a list of containers in pods and calculate a log size quota
-	// Total log size must not exceed maxLogsSize multiplied by logCompressionRatio
 	klog.V(2).Infof("Maximum buffer size: %v bytes", bufferSize)
 	buf := bytes.NewBuffer(make([]byte, 0, bufferSize))
 
 	// Fetch previous and current container logs
 	var records []record.Record
-	for _, isPrevious := range []bool{true, false} {
-		for _, pod := range pods {
-			clog := getContainerLogs(ctx, client, pod, isPrevious, buf)
-			if len(clog) > 0 {
-				records = append(records, clog...)
-			}
+	for _, pod := range pods {
+		// if pod is not healthy then record its definition and try to get previous log
+		if !check.IsHealthyPod(pod, time.Now()) {
+			records = append(records, record.Record{
+				Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name),
+				Item: record.ResourceMarshaller{Resource: pod},
+			})
+			previousLog := getContainerLogs(ctx, client, pod, true, buf)
+			records = append(records, previousLog...)
 		}
+		currentLog := getContainerLogs(ctx, client, pod, false, buf)
+		records = append(records, currentLog...)
 	}
 
 	return records, nil

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events_test.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events_test.go
@@ -74,7 +74,7 @@ func Test_UnhealtyOperators_GatherPodContainersLogs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := gatherPodContainersLogs(tt.args.ctx, tt.args.client, tt.args.pods, tt.args.bufferSize)
+			got, err := gatherPodsAndTheirContainersLogs(tt.args.ctx, tt.args.client, tt.args.pods, tt.args.bufferSize)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("gatherNamespaceEvents() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -191,15 +191,12 @@ func Test_UnhealtyOperators_GatherUnhealthyPods(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2 := gatherUnhealthyPods(tt.args.pods)
+			got, got2 := getAllRelatedPods(tt.args.pods)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("gatherUnhealthyPods() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("gatherUnhealthyPods() got1 = %v, want %v", got1, tt.want1)
+				t.Errorf("getAllRelatedPods() got = %v, want %v", got, tt.want)
 			}
 			if got2 != tt.want2 {
-				t.Errorf("gatherUnhealthyPods() got2 = %v, want %v", got2, tt.want2)
+				t.Errorf("getAllRelatedPods() got2 = %v, want %v", got2, tt.want2)
 			}
 		})
 	}

--- a/pkg/gatherers/clusterconfig/recent_metrics.go
+++ b/pkg/gatherers/clusterconfig/recent_metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -76,7 +75,7 @@ func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) 
 		return nil, []error{err}
 	}
 	r := utils.NewLineLimitReader(rsp, metricsAlertsLinesLimit)
-	alerts, err := ioutil.ReadAll(r)
+	alerts, err := io.ReadAll(r)
 	if err != nil && err != io.EOF {
 		klog.Errorf("Unable to read most recent alerts from metrics: %v", err)
 		return nil, []error{err}

--- a/pkg/gatherers/conditional/conditional_gatherer_test.go
+++ b/pkg/gatherers/conditional/conditional_gatherer_test.go
@@ -3,7 +3,7 @@ package conditional
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -175,7 +175,7 @@ func newFakeClientWithMetrics(metrics string) *fake.RESTClient {
 		Client: fake.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader(metrics + "\n")),
+				Body:       io.NopCloser(strings.NewReader(metrics + "\n")),
 			}
 			return resp, nil
 		}),

--- a/pkg/gatherers/workloads/workloads_info_test.go
+++ b/pkg/gatherers/workloads/workloads_info_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -50,7 +49,7 @@ func Test_gatherWorkloadInfo(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err = ioutil.WriteFile("../../../docs/insights-archive-sample/config/workload_info.json", out, 0750); err != nil {
+		if err = os.WriteFile("../../../docs/insights-archive-sample/config/workload_info.json", out, 0750); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is backport of https://github.com/openshift/insights-operator/pull/516 + update of deprecated `ioutil` 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-6467
https://bugzilla.redhat.com/show_bug.cgi?id=2026644
https://access.redhat.com/solutions/???
