### PR TITLE
[release-4.7] Bug 2026659: Gather all the container logs from related…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -130,12 +130,13 @@ Id in config: oauths
 
 ## ClusterOperatorPodsAndEvents
 
-collects all the ClusterOperators degraded Pods
-for degraded cluster operators or that lives at the Cluster Operator's namespace, to collect:
+collects information about pods
+and events from namespaces of degraded cluster operators. The collected
+information includes:
 
-- Pod definitions
-- Previous and current Pod Container logs (when available)
-- Namespace Events
+- Definitions for non-running (terminated, pending) Pods
+- Previous (if container was terminated) and current logs of all related pod containers
+- Namespace events
 
 * Location of pods in archive: config/pod/
 * Location of events in archive: events/

--- a/pkg/gather/clusterconfig/operators_pods_and_events_test.go
+++ b/pkg/gather/clusterconfig/operators_pods_and_events_test.go
@@ -74,7 +74,7 @@ func Test_UnhealtyOperators_GatherPodContainersLogs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := gatherPodContainersLogs(tt.args.ctx, tt.args.client, tt.args.pods, tt.args.bufferSize)
+			got, err := gatherPodsAndTheirContainersLogs(tt.args.ctx, tt.args.client, tt.args.pods, tt.args.bufferSize)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("gatherNamespaceEvents() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -117,7 +117,7 @@ func Test_UnhealtyOperators_GetContainerLogs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getContainerLogs(tt.args.ctx, tt.args.client, tt.args.pod, tt.args.isPrevious, tt.args.buf, tt.args.bufferSize); !reflect.DeepEqual(got, tt.want) {
+			if got := getContainerLogs(tt.args.ctx, tt.args.client, tt.args.pod, tt.args.isPrevious, tt.args.buf); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getContainerLogs() = %v, want %v", got, tt.want)
 			}
 		})
@@ -186,15 +186,12 @@ func Test_UnhealtyOperators_GatherUnhealthyPods(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, got2 := gatherUnhealthyPods(tt.args.pods)
+			got, got2 := getAllRelatedPods(tt.args.pods)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("gatherUnhealthyPods() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("gatherUnhealthyPods() got1 = %v, want %v", got1, tt.want1)
+				t.Errorf("getAllRelatedPods() got = %v, want %v", got, tt.want)
 			}
 			if got2 != tt.want2 {
-				t.Errorf("gatherUnhealthyPods() got2 = %v, want %v", got2, tt.want2)
+				t.Errorf("getAllRelatedPods() got2 = %v, want %v", got2, tt.want2)
 			}
 		})
 	}

--- a/pkg/utils/check/is_healthy_pod.go
+++ b/pkg/utils/check/is_healthy_pod.go
@@ -1,0 +1,43 @@
+package check
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func IsHealthyPod(pod *corev1.Pod, now time.Time) bool {
+	// pending pods may be unable to schedule or start due to failures, and the info they provide in status is important
+	// for identifying why scheduling has not happened
+	if pod.Status.Phase == corev1.PodPending {
+		if now.Sub(pod.CreationTimestamp.Time) > 2*time.Minute {
+			return false
+		}
+	}
+	// pods that have containers that have terminated with non-zero exit codes are considered failure
+	for idx := range pod.Status.InitContainerStatuses {
+		status := pod.Status.InitContainerStatuses[idx]
+		if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.RestartCount > 0 {
+			return false
+		}
+	}
+	for idx := range pod.Status.ContainerStatuses {
+		status := pod.Status.ContainerStatuses[idx]
+		if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
+			return false
+		}
+		if status.RestartCount > 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
… namespaces of degraded clusteroperator (#516)

<!-- Short description of the PR. What does it do? -->
This is backport of https://github.com/openshift/insights-operator/pull/554

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2026659
https://access.redhat.com/solutions/???
