### PR TITLE
alert about disconnected cluster

### DIFF
--- a/manifests/08-prometheus_rule.yaml
+++ b/manifests/08-prometheus_rule.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: insights-prometheus-rules
+  namespace: openshift-insights
+spec:
+  groups:
+  - name: insights
+    rules:
+    - alert: InsightsDisabled
+      annotations:
+        description: 'Insights operator is disabled and the cluster will not receive any remote health checks and recommendations'
+        summary: Insights operator is disabled.
+      expr: |
+       cluster_operator_conditions{name="insights", condition="Disabled"} == 1
+      for: 5m
+      labels:
+        severity: info
+        

--- a/manifests/08-prometheus_rule.yaml
+++ b/manifests/08-prometheus_rule.yaml
@@ -13,7 +13,7 @@ spec:
     rules:
     - alert: InsightsDisabled
       annotations:
-        description: 'Insights operator is disabled and the cluster will not receive any remote health checks and recommendations'
+        description: 'Insights operator is disabled. In order to enable Insights and benefit from recommendations specific to your cluster, please follow steps listed in the documentation: https://docs.openshift.com/container-platform/latest/support/remote_health_monitoring/enabling-remote-health-reporting.html'
         summary: Insights operator is disabled.
       expr: |
        cluster_operator_conditions{name="insights", condition="Disabled"} == 1


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
New alert definition for disabled Insights operator.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

Requires the new docs - https://github.com/openshift/openshift-docs/pull/39518

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No unit test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
