### PR TITLE
[release-4.9] Bug 2027637: gather webhook configurations

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -439,6 +439,17 @@ Gathered metrics:
   - "vsphere_node_hw_version_total": 4.7.11+, 4.8+
 
 
+## MutatingWebhookConfigurations
+
+collects MutatingWebhookConfiguration resources
+Relevant OpenShift API docs:
+  - https://docs.openshift.com/container-platform/4.8/rest_api/extension_apis/mutatingwebhookconfiguration-admissionregistration-k8s-io-v1.html
+
+* Location in archive: config/mutatingwebhookconfigurations
+* Since versions:
+  * 4.10+
+
+
 ## NetNamespace
 
 collects NetNamespaces networking information
@@ -692,6 +703,17 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
   * 4.5.34+
   * 4.6.20+
   * 4.7+
+
+
+## ValidatingWebhookConfigurations
+
+collects ValidatingWebhookConfiguration resources
+Relevant OpenShift API docs:
+  - https://docs.openshift.com/container-platform/4.8/rest_api/extension_apis/validatingwebhookconfiguration-admissionregistration-k8s-io-v1.html
+
+* Location in archive: config/validatingwebhookconfigurations
+* Since versions:
+  * 4.10+
 
 
 ## WorkloadInfo

--- a/docs/insights-archive-sample/config/mutatingwebhookconfigurations/machine-api.json
+++ b/docs/insights-archive-sample/config/mutatingwebhookconfigurations/machine-api.json
@@ -1,0 +1,63 @@
+{
+  "metadata": {
+    "name": "pod-identity-webhook",
+    "uid": "258cd425-b18c-41ff-94c9-d64dd4b04e86",
+    "resourceVersion": "22309",
+    "generation": 2,
+    "creationTimestamp": "2021-09-20T15:20:41Z",
+    "annotations": {
+      "service.beta.openshift.io/inject-cabundle": "true"
+    }
+  },
+  "webhooks": [
+    {
+      "name": "pod-identity-webhook.amazonaws.com",
+      "clientConfig": {
+        "service": {
+          "namespace": "openshift-cloud-credential-operator",
+          "name": "pod-identity-webhook",
+          "path": "/mutate",
+          "port": 443
+        },
+        "caBundle": "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+      },
+      "rules": [
+        {
+          "operations": [
+            "CREATE"
+          ],
+          "apiGroups": [
+            ""
+          ],
+          "apiVersions": [
+            "v1"
+          ],
+          "resources": [
+            "pods"
+          ],
+          "scope": "*"
+        }
+      ],
+      "failurePolicy": "Ignore",
+      "matchPolicy": "Equivalent",
+      "namespaceSelector": {
+        "matchExpressions": [
+          {
+            "key": "openshift.io/run-level",
+            "operator": "NotIn",
+            "values": [
+              "0"
+            ]
+          }
+        ]
+      },
+      "objectSelector": {},
+      "sideEffects": "None",
+      "timeoutSeconds": 10,
+      "admissionReviewVersions": [
+        "v1beta1"
+      ],
+      "reinvocationPolicy": "Never"
+    }
+  ]
+}

--- a/docs/insights-archive-sample/config/mutatingwebhookconfigurations/pod-identity-webhook.json
+++ b/docs/insights-archive-sample/config/mutatingwebhookconfigurations/pod-identity-webhook.json
@@ -1,0 +1,63 @@
+{
+  "metadata": {
+    "name": "pod-identity-webhook",
+    "uid": "258cd425-b18c-41ff-94c9-d64dd4b04e86",
+    "resourceVersion": "22309",
+    "generation": 2,
+    "creationTimestamp": "2021-09-20T15:20:41Z",
+    "annotations": {
+      "service.beta.openshift.io/inject-cabundle": "true"
+    }
+  },
+  "webhooks": [
+    {
+      "name": "pod-identity-webhook.amazonaws.com",
+      "clientConfig": {
+        "service": {
+          "namespace": "openshift-cloud-credential-operator",
+          "name": "pod-identity-webhook",
+          "path": "/mutate",
+          "port": 443
+        },
+        "caBundle": "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+      },
+      "rules": [
+        {
+          "operations": [
+            "CREATE"
+          ],
+          "apiGroups": [
+            ""
+          ],
+          "apiVersions": [
+            "v1"
+          ],
+          "resources": [
+            "pods"
+          ],
+          "scope": "*"
+        }
+      ],
+      "failurePolicy": "Ignore",
+      "matchPolicy": "Equivalent",
+      "namespaceSelector": {
+        "matchExpressions": [
+          {
+            "key": "openshift.io/run-level",
+            "operator": "NotIn",
+            "values": [
+              "0"
+            ]
+          }
+        ]
+      },
+      "objectSelector": {},
+      "sideEffects": "None",
+      "timeoutSeconds": 10,
+      "admissionReviewVersions": [
+        "v1beta1"
+      ],
+      "reinvocationPolicy": "Never"
+    }
+  ]
+}

--- a/docs/insights-archive-sample/config/validatingwebhookconfigurations/autoscaling.openshift.io.json
+++ b/docs/insights-archive-sample/config/validatingwebhookconfigurations/autoscaling.openshift.io.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "name": "snapshot.storage.k8s.io",
+    "uid": "9910ab8e-622c-4aa2-a00b-07d918aaf570",
+    "resourceVersion": "5972",
+    "generation": 2,
+    "creationTimestamp": "2021-09-20T15:13:35Z",
+    "labels": {
+      "app": "csi-snapshot-webhook"
+    },
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true",
+      "include.release.openshift.io/single-node-developer": "true",
+      "operator.openshift.io/spec-hash": "f21cd4bafe69f05d800b1d8beda3f76f8eba610c663075ffaf71229630eccfbb",
+      "service.beta.openshift.io/inject-cabundle": "true"
+    }
+  },
+  "webhooks": [
+    {
+      "name": "volumesnapshotclasses.snapshot.storage.k8s.io",
+      "clientConfig": {
+        "service": {
+          "namespace": "openshift-cluster-storage-operator",
+          "name": "csi-snapshot-webhook",
+          "path": "/volumesnapshot",
+          "port": 443
+        },
+        "caBundle": "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+      },
+      "rules": [
+        {
+          "operations": [
+            "CREATE",
+            "UPDATE"
+          ],
+          "apiGroups": [
+            "snapshot.storage.k8s.io"
+          ],
+          "apiVersions": [
+            "v1beta1",
+            "v1"
+          ],
+          "resources": [
+            "volumesnapshots",
+            "volumesnapshotcontents"
+          ],
+          "scope": "*"
+        }
+      ],
+      "failurePolicy": "Ignore",
+      "matchPolicy": "Equivalent",
+      "namespaceSelector": {},
+      "objectSelector": {},
+      "sideEffects": "None",
+      "timeoutSeconds": 10,
+      "admissionReviewVersions": [
+        "v1",
+        "v1beta1"
+      ]
+    }
+  ]
+}

--- a/docs/insights-archive-sample/config/validatingwebhookconfigurations/machine-api.json
+++ b/docs/insights-archive-sample/config/validatingwebhookconfigurations/machine-api.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "name": "snapshot.storage.k8s.io",
+    "uid": "9910ab8e-622c-4aa2-a00b-07d918aaf570",
+    "resourceVersion": "5972",
+    "generation": 2,
+    "creationTimestamp": "2021-09-20T15:13:35Z",
+    "labels": {
+      "app": "csi-snapshot-webhook"
+    },
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true",
+      "include.release.openshift.io/single-node-developer": "true",
+      "operator.openshift.io/spec-hash": "f21cd4bafe69f05d800b1d8beda3f76f8eba610c663075ffaf71229630eccfbb",
+      "service.beta.openshift.io/inject-cabundle": "true"
+    }
+  },
+  "webhooks": [
+    {
+      "name": "volumesnapshotclasses.snapshot.storage.k8s.io",
+      "clientConfig": {
+        "service": {
+          "namespace": "openshift-cluster-storage-operator",
+          "name": "csi-snapshot-webhook",
+          "path": "/volumesnapshot",
+          "port": 443
+        },
+        "caBundle": "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+      },
+      "rules": [
+        {
+          "operations": [
+            "CREATE",
+            "UPDATE"
+          ],
+          "apiGroups": [
+            "snapshot.storage.k8s.io"
+          ],
+          "apiVersions": [
+            "v1beta1",
+            "v1"
+          ],
+          "resources": [
+            "volumesnapshots",
+            "volumesnapshotcontents"
+          ],
+          "scope": "*"
+        }
+      ],
+      "failurePolicy": "Ignore",
+      "matchPolicy": "Equivalent",
+      "namespaceSelector": {},
+      "objectSelector": {},
+      "sideEffects": "None",
+      "timeoutSeconds": 10,
+      "admissionReviewVersions": [
+        "v1",
+        "v1beta1"
+      ]
+    }
+  ]
+}

--- a/docs/insights-archive-sample/config/validatingwebhookconfigurations/multus.openshift.io.json
+++ b/docs/insights-archive-sample/config/validatingwebhookconfigurations/multus.openshift.io.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "name": "snapshot.storage.k8s.io",
+    "uid": "9910ab8e-622c-4aa2-a00b-07d918aaf570",
+    "resourceVersion": "5972",
+    "generation": 2,
+    "creationTimestamp": "2021-09-20T15:13:35Z",
+    "labels": {
+      "app": "csi-snapshot-webhook"
+    },
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true",
+      "include.release.openshift.io/single-node-developer": "true",
+      "operator.openshift.io/spec-hash": "f21cd4bafe69f05d800b1d8beda3f76f8eba610c663075ffaf71229630eccfbb",
+      "service.beta.openshift.io/inject-cabundle": "true"
+    }
+  },
+  "webhooks": [
+    {
+      "name": "volumesnapshotclasses.snapshot.storage.k8s.io",
+      "clientConfig": {
+        "service": {
+          "namespace": "openshift-cluster-storage-operator",
+          "name": "csi-snapshot-webhook",
+          "path": "/volumesnapshot",
+          "port": 443
+        },
+        "caBundle": "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+      },
+      "rules": [
+        {
+          "operations": [
+            "CREATE",
+            "UPDATE"
+          ],
+          "apiGroups": [
+            "snapshot.storage.k8s.io"
+          ],
+          "apiVersions": [
+            "v1beta1",
+            "v1"
+          ],
+          "resources": [
+            "volumesnapshots",
+            "volumesnapshotcontents"
+          ],
+          "scope": "*"
+        }
+      ],
+      "failurePolicy": "Ignore",
+      "matchPolicy": "Equivalent",
+      "namespaceSelector": {},
+      "objectSelector": {},
+      "sideEffects": "None",
+      "timeoutSeconds": 10,
+      "admissionReviewVersions": [
+        "v1",
+        "v1beta1"
+      ]
+    }
+  ]
+}

--- a/docs/insights-archive-sample/config/validatingwebhookconfigurations/prometheusrules.openshift.io.json
+++ b/docs/insights-archive-sample/config/validatingwebhookconfigurations/prometheusrules.openshift.io.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "name": "snapshot.storage.k8s.io",
+    "uid": "9910ab8e-622c-4aa2-a00b-07d918aaf570",
+    "resourceVersion": "5972",
+    "generation": 2,
+    "creationTimestamp": "2021-09-20T15:13:35Z",
+    "labels": {
+      "app": "csi-snapshot-webhook"
+    },
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true",
+      "include.release.openshift.io/single-node-developer": "true",
+      "operator.openshift.io/spec-hash": "f21cd4bafe69f05d800b1d8beda3f76f8eba610c663075ffaf71229630eccfbb",
+      "service.beta.openshift.io/inject-cabundle": "true"
+    }
+  },
+  "webhooks": [
+    {
+      "name": "volumesnapshotclasses.snapshot.storage.k8s.io",
+      "clientConfig": {
+        "service": {
+          "namespace": "openshift-cluster-storage-operator",
+          "name": "csi-snapshot-webhook",
+          "path": "/volumesnapshot",
+          "port": 443
+        },
+        "caBundle": "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+      },
+      "rules": [
+        {
+          "operations": [
+            "CREATE",
+            "UPDATE"
+          ],
+          "apiGroups": [
+            "snapshot.storage.k8s.io"
+          ],
+          "apiVersions": [
+            "v1beta1",
+            "v1"
+          ],
+          "resources": [
+            "volumesnapshots",
+            "volumesnapshotcontents"
+          ],
+          "scope": "*"
+        }
+      ],
+      "failurePolicy": "Ignore",
+      "matchPolicy": "Equivalent",
+      "namespaceSelector": {},
+      "objectSelector": {},
+      "sideEffects": "None",
+      "timeoutSeconds": 10,
+      "admissionReviewVersions": [
+        "v1",
+        "v1beta1"
+      ]
+    }
+  ]
+}

--- a/docs/insights-archive-sample/config/validatingwebhookconfigurations/snapshot.storage.k8s.io.json
+++ b/docs/insights-archive-sample/config/validatingwebhookconfigurations/snapshot.storage.k8s.io.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "name": "snapshot.storage.k8s.io",
+    "uid": "9910ab8e-622c-4aa2-a00b-07d918aaf570",
+    "resourceVersion": "5972",
+    "generation": 2,
+    "creationTimestamp": "2021-09-20T15:13:35Z",
+    "labels": {
+      "app": "csi-snapshot-webhook"
+    },
+    "annotations": {
+      "include.release.openshift.io/self-managed-high-availability": "true",
+      "include.release.openshift.io/single-node-developer": "true",
+      "operator.openshift.io/spec-hash": "f21cd4bafe69f05d800b1d8beda3f76f8eba610c663075ffaf71229630eccfbb",
+      "service.beta.openshift.io/inject-cabundle": "true"
+    }
+  },
+  "webhooks": [
+    {
+      "name": "volumesnapshotclasses.snapshot.storage.k8s.io",
+      "clientConfig": {
+        "service": {
+          "namespace": "openshift-cluster-storage-operator",
+          "name": "csi-snapshot-webhook",
+          "path": "/volumesnapshot",
+          "port": 443
+        },
+        "caBundle": "eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4"
+      },
+      "rules": [
+        {
+          "operations": [
+            "CREATE",
+            "UPDATE"
+          ],
+          "apiGroups": [
+            "snapshot.storage.k8s.io"
+          ],
+          "apiVersions": [
+            "v1beta1",
+            "v1"
+          ],
+          "resources": [
+            "volumesnapshots",
+            "volumesnapshotcontents"
+          ],
+          "scope": "*"
+        }
+      ],
+      "failurePolicy": "Ignore",
+      "matchPolicy": "Equivalent",
+      "namespaceSelector": {},
+      "objectSelector": {},
+      "sideEffects": "None",
+      "timeoutSeconds": 10,
+      "admissionReviewVersions": [
+        "v1",
+        "v1beta1"
+      ]
+    }
+  ]
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -87,6 +87,8 @@ var gatheringFunctions = map[string]gatheringFunction{
 	"machine_autoscalers":               failableFunc((*Gatherer).GatherMachineAutoscalers),
 	"openshift_logging":                 failableFunc((*Gatherer).GatherOpenshiftLogging),
 	"psps":                              failableFunc((*Gatherer).GatherPodSecurityPolicies),
+	"validating_webhook_configurations": failableFunc((*Gatherer).GatherValidatingWebhookConfigurations),
+	"mutating_webhook_configurations":   failableFunc((*Gatherer).GatherMutatingWebhookConfigurations),
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/mutatingwebhookconfigurations.go
+++ b/pkg/gatherers/clusterconfig/mutatingwebhookconfigurations.go
@@ -1,0 +1,64 @@
+//nolint:dupl
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	admissionregistrationv1types "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	admissionregistrationv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils/anonymize"
+)
+
+// GatherMutatingWebhookConfigurations collects MutatingWebhookConfiguration resources
+// Relevant OpenShift API docs:
+//   - https://docs.openshift.com/container-platform/4.8/rest_api/extension_apis/mutatingwebhookconfiguration-admissionregistration-k8s-io-v1.html
+//
+// * Location in archive: config/mutatingwebhookconfigurations
+// * Since versions:
+//   * 4.10+
+func (g *Gatherer) GatherMutatingWebhookConfigurations(ctx context.Context) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherMutatingWebhookConfigurations(ctx, gatherKubeClient.AdmissionregistrationV1())
+}
+
+func gatherMutatingWebhookConfigurations(
+	ctx context.Context, client admissionregistrationv1.AdmissionregistrationV1Interface,
+) ([]record.Record, []error) {
+	mutatingWebhookConfigurations, err := client.MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	var records []record.Record
+	for i := range mutatingWebhookConfigurations.Items {
+		mutatingWebhookConfiguration := mutatingWebhookConfigurations.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("config/mutatingwebhookconfigurations/%v", mutatingWebhookConfiguration.Name),
+			Item: record.ResourceMarshaller{
+				Resource: anonymizeMutatingWebhookConfiguration(&mutatingWebhookConfiguration),
+			},
+		})
+	}
+
+	return records, nil
+}
+
+func anonymizeMutatingWebhookConfiguration(
+	configuration *admissionregistrationv1types.MutatingWebhookConfiguration,
+) *admissionregistrationv1types.MutatingWebhookConfiguration {
+	for i := range configuration.Webhooks {
+		webhook := &configuration.Webhooks[i]
+		webhook.ClientConfig.CABundle = []byte(anonymize.String(string(webhook.ClientConfig.CABundle)))
+	}
+
+	return configuration
+}

--- a/pkg/gatherers/clusterconfig/validatingwebhookconfigurations.go
+++ b/pkg/gatherers/clusterconfig/validatingwebhookconfigurations.go
@@ -1,0 +1,64 @@
+//nolint:dupl
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	admissionregistrationv1types "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	admissionregistrationv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils/anonymize"
+)
+
+// GatherValidatingWebhookConfigurations collects ValidatingWebhookConfiguration resources
+// Relevant OpenShift API docs:
+//   - https://docs.openshift.com/container-platform/4.8/rest_api/extension_apis/validatingwebhookconfiguration-admissionregistration-k8s-io-v1.html
+//
+// * Location in archive: config/validatingwebhookconfigurations
+// * Since versions:
+//   * 4.10+
+func (g *Gatherer) GatherValidatingWebhookConfigurations(ctx context.Context) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherValidatingWebhookConfigurations(ctx, gatherKubeClient.AdmissionregistrationV1())
+}
+
+func gatherValidatingWebhookConfigurations(
+	ctx context.Context, client admissionregistrationv1.AdmissionregistrationV1Interface,
+) ([]record.Record, []error) {
+	validatingWebhookConfigurations, err := client.ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	var records []record.Record
+	for i := range validatingWebhookConfigurations.Items {
+		validatingWebhookConfiguration := validatingWebhookConfigurations.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("config/validatingwebhookconfigurations/%v", validatingWebhookConfiguration.Name),
+			Item: record.ResourceMarshaller{
+				Resource: anonymizeValidatingWebhookConfiguration(&validatingWebhookConfiguration),
+			},
+		})
+	}
+
+	return records, nil
+}
+
+func anonymizeValidatingWebhookConfiguration(
+	configuration *admissionregistrationv1types.ValidatingWebhookConfiguration,
+) *admissionregistrationv1types.ValidatingWebhookConfiguration {
+	for i := range configuration.Webhooks {
+		webhook := &configuration.Webhooks[i]
+		webhook.ClientConfig.CABundle = []byte(anonymize.String(string(webhook.ClientConfig.CABundle)))
+	}
+
+	return configuration
+}

--- a/pkg/gatherers/clusterconfig/webhookconfigurations_test.go
+++ b/pkg/gatherers/clusterconfig/webhookconfigurations_test.go
@@ -1,0 +1,75 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+func Test_gatherValidatingWebhookConfigurations(t *testing.T) {
+	client := kubefake.NewSimpleClientset().AdmissionregistrationV1()
+	_, err := client.ValidatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "webhook_config",
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name: "webhook1",
+			},
+			{
+				Name: "webhook2",
+			},
+		},
+	}, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	records, errs := gatherValidatingWebhookConfigurations(context.TODO(), client)
+	assert.Empty(t, errs)
+
+	assertWebhookConfigurations(t, records, "config/validatingwebhookconfigurations/webhook_config")
+}
+
+func Test_gatherMutatingWebhookConfigurations(t *testing.T) {
+	client := kubefake.NewSimpleClientset().AdmissionregistrationV1()
+	_, err := client.MutatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "webhook_config",
+		},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
+			{
+				Name: "webhook1",
+			},
+			{
+				Name: "webhook2",
+			},
+		},
+	}, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	records, errs := gatherMutatingWebhookConfigurations(context.TODO(), client)
+	assert.Empty(t, errs)
+
+	assertWebhookConfigurations(t, records, "config/mutatingwebhookconfigurations/webhook_config")
+}
+
+func assertWebhookConfigurations(t *testing.T, records []record.Record, expectedName string) {
+	assert.Len(t, records, 1)
+	assert.Equal(t, records[0].Name, expectedName)
+
+	configurationBytes, err := records[0].Item.Marshal(context.TODO())
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"metadata": { "name": "webhook_config", "creationTimestamp": null },
+		"webhooks": [
+			{ "name": "webhook1", "clientConfig": {}, "sideEffects": null, "admissionReviewVersions": null },
+			{ "name": "webhook2", "clientConfig": {}, "sideEffects": null, "admissionReviewVersions": null }
+		]
+	}`, string(configurationBytes))
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Backport of gatherer for webhook configuration resources - https://github.com/openshift/insights-operator/pull/508

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/mutatingwebhookconfigurations/machine-api.json `
- `docs/insights-archive-sample/config/mutatingwebhookconfigurations/pod-identity-webhook.json`
- ...
- `docs/insights-archive-sample/config/validatingwebhookconfigurations/autoscaling.openshift.io.json`

## Documentation
<!-- Are these changes reflected in documentation? -->
Updated
- `docs/gathered-data.md `

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/webhookconfigurations_test.go `

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2027637
https://access.redhat.com/solutions/???
