### PR TITLE
new cluster operator condition providing info about unavailable SCA certs

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -12,7 +12,7 @@ pull_report:
   timeout: "3000s"
   min_retry: "30s"
 ocm:
-  endpoint: https://api.openshift.com/api/accounts_mgmt/v1/certificates
-  interval: "8h"
+  scaEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/certificates
+  scaInterval: "8h"
 gather:
   - ALL

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -33,8 +33,8 @@ func NewOperator() *cobra.Command {
 			ReportMinRetryTime:   10 * time.Second,
 			ReportPullingTimeout: 30 * time.Minute,
 			OCMConfig: config.OCMConfig{
-				Interval: 8 * time.Hour,
-				Endpoint: "https://api.openshift.com/api/accounts_mgmt/v1/certificates",
+				SCAInterval: 8 * time.Hour,
+				SCAEndpoint: "https://api.openshift.com/api/accounts_mgmt/v1/certificates",
 			},
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ type Serialized struct {
 	OCM                     struct {
 		SCAEndpoint string `json:"scaEndpoint"`
 		SCAInterval string `json:"scaInterval"`
-		SCADisabled bool   `json:"scaInterval"`
+		SCADisabled bool   `json:"scaDisabled"`
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,10 +24,10 @@ type Serialized struct {
 	Impersonate             string   `json:"impersonate"`
 	Gather                  []string `json:"gather"`
 	EnableGlobalObfuscation bool     `json:"enableGlobalObfuscation"`
-	Ocm                     struct {
-		Endpoint string `json:"endpoint"`
-		Interval string `json:"interval"`
-		Disabled bool   `json:"disabled"`
+	OCM                     struct {
+		SCAEndpoint string `json:"scaEndpoint"`
+		SCAInterval string `json:"scaInterval"`
+		SCADisabled bool   `json:"scaInterval"`
 	}
 }
 
@@ -73,9 +73,9 @@ type HTTPConfig struct {
 
 // OCMConfig configures the interval and endpoint for retrieving the data from OCM API
 type OCMConfig struct {
-	Interval time.Duration
-	Endpoint string
-	Disabled bool
+	SCAInterval time.Duration
+	SCAEndpoint string
+	SCADisabled bool
 }
 
 type Converter func(s *Serialized, cfg *Controller) (*Controller, error)
@@ -172,17 +172,17 @@ func ToController(s *Serialized, cfg *Controller) (*Controller, error) { // noli
 		return nil, fmt.Errorf("storagePath must point to a directory where snapshots can be stored")
 	}
 
-	if len(s.Ocm.Endpoint) > 0 {
-		cfg.OCMConfig.Endpoint = s.Ocm.Endpoint
+	if len(s.OCM.SCAEndpoint) > 0 {
+		cfg.OCMConfig.SCAEndpoint = s.OCM.SCAEndpoint
 	}
-	cfg.OCMConfig.Disabled = s.Ocm.Disabled
+	cfg.OCMConfig.SCADisabled = s.OCM.SCADisabled
 
-	if len(s.Ocm.Interval) > 0 {
-		i, err := time.ParseDuration(s.Ocm.Interval)
+	if len(s.OCM.SCAInterval) > 0 {
+		i, err := time.ParseDuration(s.OCM.SCAInterval)
 		if err != nil {
-			return nil, fmt.Errorf("ocm interval must be a valid duration: %v", err)
+			return nil, fmt.Errorf("OCM SCA interval must be a valid duration: %v", err)
 		}
-		cfg.OCMConfig.Interval = i
+		cfg.OCMConfig.SCAInterval = i
 	}
 	return cfg, nil
 }

--- a/pkg/config/configobserver/configobserver.go
+++ b/pkg/config/configobserver/configobserver.go
@@ -204,22 +204,22 @@ func (c *Controller) retrieveConfig(ctx context.Context) error { //nolint: gocyc
 		}
 
 		// OCM config
-		if ocmEndpoint, ok := secret.Data["ocmEndpoint"]; ok {
-			nextConfig.OCMConfig.Endpoint = string(ocmEndpoint)
+		if scaEndpoint, ok := secret.Data["scaEndpoint"]; ok {
+			nextConfig.OCMConfig.SCAEndpoint = string(scaEndpoint)
 		}
-		if ocmInterval, ok := secret.Data["ocmInterval"]; ok {
+		if scaInterval, ok := secret.Data["scaInterval"]; ok {
 			var newInterval time.Duration
-			if newInterval, err = time.ParseDuration(string(ocmInterval)); err == nil {
-				nextConfig.OCMConfig.Interval = newInterval
+			if newInterval, err = time.ParseDuration(string(scaInterval)); err == nil {
+				nextConfig.OCMConfig.SCAInterval = newInterval
 			} else {
 				klog.Warningf(
-					"secret contains an invalid value (%s) for ocmInterval. Using previous value",
-					ocmInterval,
+					"secret contains an invalid value (%s) for scaInterval. Using previous value",
+					scaInterval,
 				)
 			}
 		}
-		if ocmDisabled, ok := secret.Data["ocmPullDisabled"]; ok {
-			nextConfig.OCMConfig.Disabled = strings.EqualFold(string(ocmDisabled), "true")
+		if scaDisabled, ok := secret.Data["scaPullDisabled"]; ok {
+			nextConfig.OCMConfig.SCADisabled = strings.EqualFold(string(scaDisabled), "true")
 		}
 	}
 	if err != nil {
@@ -302,14 +302,14 @@ func (c *Controller) mergeConfigLocked() {
 		cfg.EnableGlobalObfuscation = cfg.EnableGlobalObfuscation || c.secretConfig.EnableGlobalObfuscation
 
 		// OCM config
-		if len(c.secretConfig.OCMConfig.Endpoint) > 0 {
-			cfg.OCMConfig.Endpoint = c.secretConfig.OCMConfig.Endpoint
+		if len(c.secretConfig.OCMConfig.SCAEndpoint) > 0 {
+			cfg.OCMConfig.SCAEndpoint = c.secretConfig.OCMConfig.SCAEndpoint
 		}
-		if c.secretConfig.OCMConfig.Interval > 0 {
-			cfg.OCMConfig.Interval = c.secretConfig.OCMConfig.Interval
+		if c.secretConfig.OCMConfig.SCAInterval > 0 {
+			cfg.OCMConfig.SCAInterval = c.secretConfig.OCMConfig.SCAInterval
 		}
 
-		cfg.OCMConfig.Disabled = c.secretConfig.OCMConfig.Disabled
+		cfg.OCMConfig.SCADisabled = c.secretConfig.OCMConfig.SCADisabled
 		cfg.HTTPConfig = c.secretConfig.HTTPConfig
 	}
 	if c.tokenConfig != nil {

--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -12,7 +12,7 @@ const (
 	InsightsUploadDegraded configv1.ClusterStatusConditionType = "UploadDegraded"
 	// InsightsDownloadDegraded defines the condition type (when set to True) when the Insights report can't be successfully downloaded
 	InsightsDownloadDegraded configv1.ClusterStatusConditionType = "InsightsDownloadDegraded"
-
+	// SCANotAvailable is a condition type providing info about unsuccessful SCA pull attempt from the OCM API
 	SCANotAvailable configv1.ClusterStatusConditionType = "SCANotAvailable"
 )
 

--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -12,6 +12,8 @@ const (
 	InsightsUploadDegraded configv1.ClusterStatusConditionType = "UploadDegraded"
 	// InsightsDownloadDegraded defines the condition type (when set to True) when the Insights report can't be successfully downloaded
 	InsightsDownloadDegraded configv1.ClusterStatusConditionType = "InsightsDownloadDegraded"
+
+	SCANotAvailable configv1.ClusterStatusConditionType = "SCANotAvailable"
 )
 
 type conditionsMap map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -196,7 +196,7 @@ func (c *Controller) currentControllerStatus() (allReady bool, lastTransition ti
 
 		degradingFailure := false
 
-		if summary.Operation == controllerstatus.Uploading {
+		if summary.Operation.Name == controllerstatus.Uploading.Name {
 			if summary.Count < uploadFailuresCountThreshold {
 				klog.V(4).Infof("Number of last upload failures %d lower than threshold %d. Not marking as degraded.",
 					summary.Count, uploadFailuresCountThreshold)
@@ -206,13 +206,17 @@ func (c *Controller) currentControllerStatus() (allReady bool, lastTransition ti
 					summary.Count, uploadFailuresCountThreshold)
 			}
 			c.ctrlStatus.setStatus(UploadStatus, summary.Reason, summary.Message)
-		} else if summary.Operation == controllerstatus.DownloadingReport {
+		} else if summary.Operation.Name == controllerstatus.DownloadingReport.Name {
 			klog.V(4).Info("Failed to download Insights report")
 			c.ctrlStatus.setStatus(DownloadStatus, summary.Reason, summary.Message)
-		} else if summary.Operation == controllerstatus.PullingSCACerts {
-			klog.V(4).Infof("Failed to download the SCA certs within the threshold %d with exponential backoff. Marking as degraded.",
-				OCMAPIFailureCountThreshold)
-			degradingFailure = true
+		} else if summary.Operation.Name == controllerstatus.PullingSCACerts.Name {
+			// mark as degraded only in case of HTTP 500 and higher
+			if summary.Operation.HTTPStatusCode >= 500 {
+				klog.V(4).Infof("Failed to download the SCA certs within the threshold %d with exponential backoff. Marking as degraded.",
+					OCMAPIFailureCountThreshold)
+				degradingFailure = true
+			}
+			c.ctrlStatus.setStatus(ScaPullStatus, summary.Reason, summary.Message)
 		}
 
 		if degradingFailure {
@@ -352,6 +356,13 @@ func updateControllerConditions(cs *conditions, ctrlStatus *controllerStatus,
 		cs.setCondition(InsightsDownloadDegraded, configv1.ConditionTrue, ds.reason, ds.message, metav1.Time{Time: lastTransition})
 	} else {
 		cs.removeCondition(InsightsDownloadDegraded)
+	}
+
+	// handler when SCA pull from OCM fails
+	if ss := ctrlStatus.getStatus(ScaPullStatus); ss != nil {
+		cs.setCondition(SCANotAvailable, configv1.ConditionTrue, ss.reason, ss.message, metav1.Time{Time: lastTransition})
+	} else {
+		cs.removeCondition(SCANotAvailable)
 	}
 }
 

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -216,7 +216,7 @@ func (c *Controller) currentControllerStatus() (allReady bool, lastTransition ti
 					OCMAPIFailureCountThreshold)
 				degradingFailure = true
 			}
-			c.ctrlStatus.setStatus(ScaPullStatus, summary.Reason, summary.Message)
+			c.ctrlStatus.setStatus(SCAPullStatus, summary.Reason, summary.Message)
 		}
 
 		if degradingFailure {
@@ -359,7 +359,7 @@ func updateControllerConditions(cs *conditions, ctrlStatus *controllerStatus,
 	}
 
 	// handler when SCA pull from OCM fails
-	if ss := ctrlStatus.getStatus(ScaPullStatus); ss != nil {
+	if ss := ctrlStatus.getStatus(SCAPullStatus); ss != nil {
 		cs.setCondition(SCANotAvailable, configv1.ConditionTrue, ss.reason, ss.message, metav1.Time{Time: lastTransition})
 	} else {
 		cs.removeCondition(SCANotAvailable)

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -5,6 +5,7 @@ const (
 	UploadStatus   = "upload"
 	DownloadStatus = "download"
 	ErrorStatus    = "error"
+	ScaPullStatus  = "scaPullStatus"
 )
 
 type controllerStatus struct {

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -5,7 +5,7 @@ const (
 	UploadStatus   = "upload"
 	DownloadStatus = "download"
 	ErrorStatus    = "error"
-	ScaPullStatus  = "scaPullStatus"
+	SCAPullStatus  = "scaPullStatus"
 )
 
 type controllerStatus struct {

--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -11,17 +11,20 @@ type Interface interface {
 	CurrentStatus() (summary Summary, ready bool)
 }
 
-type Operation string
+type Operation struct {
+	Name           string
+	HTTPStatusCode int
+}
 
-const (
+var (
 	// DownloadingReport specific flag for Smart Proxy report downloading process.
-	DownloadingReport Operation = "DownloadingReport"
+	DownloadingReport = Operation{Name: "DownloadingReport"}
 	// Uploading specific flag for summary related to uploading process.
-	Uploading Operation = "Uploading"
+	Uploading = Operation{Name: "Uploading"}
 	// GatheringReport specific for gathering the report from the cluster
-	GatheringReport Operation = "GatheringReport"
+	GatheringReport = Operation{Name: "GatheringReport"}
 	// PullingSCACerts is specific operation for pulling the SCA certs data from the OCM API
-	PullingSCACerts Operation = "PullingSCACerts"
+	PullingSCACerts = Operation{Name: "PullingSCACerts"}
 )
 
 // Summary represents the status summary of an Operation

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -64,9 +64,9 @@ func New(ctx context.Context, coreClient corev1client.CoreV1Interface, configura
 // Run periodically queries the OCM API and update corresponding secret accordingly
 func (c *Controller) Run() {
 	cfg := c.configurator.Config()
-	endpoint := cfg.OCMConfig.Endpoint
-	interval := cfg.OCMConfig.Interval
-	disabled := cfg.OCMConfig.Disabled
+	endpoint := cfg.OCMConfig.SCAEndpoint
+	interval := cfg.OCMConfig.SCAInterval
+	disabled := cfg.OCMConfig.SCADisabled
 	configCh, cancel := c.configurator.ConfigChanged()
 	defer cancel()
 	if !disabled {
@@ -80,9 +80,9 @@ func (c *Controller) Run() {
 			}
 		case <-configCh:
 			cfg := c.configurator.Config()
-			interval = cfg.OCMConfig.Interval
-			endpoint = cfg.OCMConfig.Endpoint
-			disabled = cfg.OCMConfig.Disabled
+			interval = cfg.OCMConfig.SCAInterval
+			endpoint = cfg.OCMConfig.SCAEndpoint
+			disabled = cfg.OCMConfig.SCADisabled
 		}
 	}
 }
@@ -193,11 +193,11 @@ func (c *Controller) updateSecret(s *v1.Secret, ocmData *ScaResponse) (*v1.Secre
 // The exponential backoff is applied only for HTTP errors >= 500.
 func (c *Controller) requestSCAWithExpBackoff(endpoint string) ([]byte, error) {
 	bo := wait.Backoff{
-		Duration: c.configurator.Config().OCMConfig.Interval / 32, // 15 min by default
+		Duration: c.configurator.Config().OCMConfig.SCAInterval / 32, // 15 min by default
 		Factor:   2,
 		Jitter:   0,
 		Steps:    status.OCMAPIFailureCountThreshold,
-		Cap:      c.configurator.Config().OCMConfig.Interval,
+		Cap:      c.configurator.Config().OCMConfig.SCAInterval,
 	}
 	var data []byte
 	err := wait.ExponentialBackoff(bo, func() (bool, error) {

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/openshift/insights-operator/pkg/config"
@@ -98,7 +99,7 @@ func (c *Controller) requestDataAndCheckSecret(endpoint string) {
 					Name:           controllerstatus.PullingSCACerts.Name,
 					HTTPStatusCode: httpErr.StatusCode,
 				},
-				Reason:  fmt.Sprintf("HTTP%d", httpErr.StatusCode),
+				Reason:  strings.ReplaceAll(http.StatusText(httpErr.StatusCode), " ", ""),
 				Message: errMsg,
 			})
 			return

--- a/pkg/ocm/ocm.go
+++ b/pkg/ocm/ocm.go
@@ -78,6 +78,8 @@ func (c *Controller) Run() {
 		case <-time.After(interval):
 			if !disabled {
 				c.requestDataAndCheckSecret(endpoint)
+			} else {
+				klog.Warning("Pulling of the SCA certs from the OCM API is disabled")
 			}
 		case <-configCh:
 			cfg := c.configurator.Config()


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is adding a new clusteroperator condition type called "SCANotAvailable". This condition will occur in case of an OCM API response status code > 399 || < 200 and will provide the HTTP status message (e.g "NotFound") as the condition reason. 
The reason for this, is to inform users about errors when pulling down the SCA certs automatically

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No doc update. It's documented in the official OCP documentation

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
