### PR TITLE
Remove unnecessary division into important and failable gatherers

### DIFF
--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/openshift/insights-operator/pkg/anonymization"
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
-	"github.com/openshift/insights-operator/pkg/controller/status"
 	"github.com/openshift/insights-operator/pkg/controllerstatus"
 	"github.com/openshift/insights-operator/pkg/gather"
 	"github.com/openshift/insights-operator/pkg/gatherers"
@@ -94,18 +93,6 @@ func (c *Controller) Gather() {
 		return
 	}
 
-	interval := c.configurator.Config().Interval
-	threshold := status.GatherFailuresCountThreshold
-	duration := interval / (time.Duration(threshold) * 2)
-	// IMPORTANT: We NEED to run retry $threshold times or we will never set status to degraded.
-	backoff := wait.Backoff{
-		Duration: duration,
-		Factor:   1.35,
-		Jitter:   0,
-		Steps:    threshold,
-		Cap:      interval,
-	}
-
 	// flush when all necessary gatherers were processed
 	defer func() {
 		if err := c.recorder.Flush(); err != nil {
@@ -129,33 +116,30 @@ func (c *Controller) Gather() {
 	allFunctionReports := make(map[string]gather.GathererFunctionReport)
 
 	for _, gatherer := range gatherersToProcess {
-		_ = wait.ExponentialBackoff(backoff, func() (bool, error) {
-			name := gatherer.GetName()
-			start := time.Now()
+		name := gatherer.GetName()
+		start := time.Now()
 
-			ctx, cancel := context.WithTimeout(context.Background(), c.configurator.Config().Interval/2)
-			defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), c.configurator.Config().Interval/2)
+		defer cancel()
 
-			klog.V(4).Infof("Running %s gatherer", gatherer.GetName())
-			functionReports, err := gather.CollectAndRecordGatherer(ctx, gatherer, c.recorder, c.configurator)
-			for i := range functionReports {
-				allFunctionReports[functionReports[i].FuncName] = functionReports[i]
-			}
-			if err == nil {
-				klog.V(3).Infof("Periodic gather %s completed in %s", name, time.Since(start).Truncate(time.Millisecond))
-				c.statuses[name].UpdateStatus(controllerstatus.Summary{Healthy: true})
-				return true, nil
-			}
+		klog.V(4).Infof("Running %s gatherer", gatherer.GetName())
+		functionReports, err := gather.CollectAndRecordGatherer(ctx, gatherer, c.recorder, c.configurator)
+		for i := range functionReports {
+			allFunctionReports[functionReports[i].FuncName] = functionReports[i]
+		}
+		if err == nil {
+			klog.V(3).Infof("Periodic gather %s completed in %s", name, time.Since(start).Truncate(time.Millisecond))
+			c.statuses[name].UpdateStatus(controllerstatus.Summary{Healthy: true})
+			continue
+		}
 
-			utilruntime.HandleError(fmt.Errorf("%v failed after %s with: %v", name, time.Since(start).Truncate(time.Millisecond), err))
-			c.statuses[name].UpdateStatus(
-				controllerstatus.Summary{
-					Operation: controllerstatus.GatheringReport,
-					Reason:    "PeriodicGatherFailed",
-					Message:   fmt.Sprintf("Source %s could not be retrieved: %v", name, err),
-				})
-			return false, nil
-		})
+		utilruntime.HandleError(fmt.Errorf("%v failed after %s with: %v", name, time.Since(start).Truncate(time.Millisecond), err))
+		/* 			c.statuses[name].UpdateStatus(
+		controllerstatus.Summary{
+			Operation: controllerstatus.GatheringReport,
+			Reason:    "PeriodicGatherFailed",
+			Message:   fmt.Sprintf("Source %s could not be retrieved: %v", name, err),
+		}) */
 	}
 
 	err := gather.RecordArchiveMetadata(mapToArray(allFunctionReports), c.recorder, c.anonymizer)

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -134,12 +134,12 @@ func (c *Controller) Gather() {
 		}
 
 		utilruntime.HandleError(fmt.Errorf("%v failed after %s with: %v", name, time.Since(start).Truncate(time.Millisecond), err))
-		/* 			c.statuses[name].UpdateStatus(
-		controllerstatus.Summary{
-			Operation: controllerstatus.GatheringReport,
-			Reason:    "PeriodicGatherFailed",
-			Message:   fmt.Sprintf("Source %s could not be retrieved: %v", name, err),
-		}) */
+		c.statuses[name].UpdateStatus(
+			controllerstatus.Summary{
+				Operation: controllerstatus.GatheringReport,
+				Reason:    "PeriodicGatherFailed",
+				Message:   fmt.Sprintf("Source %s could not be retrieved: %v", name, err),
+			})
 	}
 
 	err := gather.RecordArchiveMetadata(mapToArray(allFunctionReports), c.recorder, c.anonymizer)

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -151,8 +151,7 @@ func Test_Controller_FailingGatherer(t *testing.T) {
 
 	c.Gather()
 	metadataFound := false
-	// failing gatherer failed 5x (see GatherFailuresCountThreshold const) + metadata
-	assert.Len(t, mockRecorder.Records, 6)
+	assert.Len(t, mockRecorder.Records, 2)
 	for i := range mockRecorder.Records {
 		// find metadata record
 		if mockRecorder.Records[i].Name != recorder.MetadataRecordName {

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -27,8 +27,6 @@ const (
 	// How many upload failures in a row we tolerate before starting reporting
 	// as InsightsUploadDegraded
 	uploadFailuresCountThreshold = 5
-	// GatherFailuresCountThreshold defines how many gatherings can fail in a row before we report Degraded
-	GatherFailuresCountThreshold = 5
 	// OCMAPIFailureCountThreshold defines how many unsuccessful responses from the OCM API in a row is tolerated
 	// before the operator is marked as Degraded
 	OCMAPIFailureCountThreshold = 5

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -101,7 +101,6 @@ func CollectAndRecordGatherer(
 			)
 
 			errs = append(errs, fmt.Errorf(errStr))
-
 		}
 		recordedRecs := 0
 		for _, r := range result.Records {

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -100,11 +100,8 @@ func CollectAndRecordGatherer(
 				gathererName, result.FunctionName, err,
 			)
 
-			if result.IgnoreErrors {
-				klog.Error(errStr)
-			} else {
-				errs = append(errs, fmt.Errorf(errStr))
-			}
+			errs = append(errs, fmt.Errorf(errStr))
+
 		}
 		recordedRecs := 0
 		for _, r := range result.Records {

--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -128,12 +128,10 @@ func Test_StartGatheringConcurrently(t *testing.T) {
 				fmt.Errorf("error2"),
 				fmt.Errorf("error3"),
 			},
-			IgnoreErrors: false,
 		},
 		{
 			FunctionName: "panic",
 			Panic:        "test panic",
-			IgnoreErrors: false,
 		},
 	})
 
@@ -229,7 +227,7 @@ func Test_CollectAndRecord(t *testing.T) {
 	assert.NoError(t, err)
 
 	functionReports, err := CollectAndRecordGatherer(context.Background(), gatherer, mockRecorder, mockConfigurator)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	err = RecordArchiveMetadata(functionReports, mockRecorder, anonymizer)
 	assert.NoError(t, err)

--- a/pkg/gather/mock_gatherers.go
+++ b/pkg/gather/mock_gatherers.go
@@ -23,31 +23,26 @@ func (g *MockGatherer) GetGatheringFunctions(context.Context) (map[string]gather
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.GatherName(ctx)
 			},
-			CanFail: false,
 		},
 		"some_field": {
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.GatherSomeField(ctx)
 			},
-			CanFail: false,
 		},
 		"3_records": {
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.Gather3Records(ctx)
 			},
-			CanFail: false,
 		},
 		"errors": {
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.GatherErrors(ctx)
 			},
-			CanFail: g.CanFail,
 		},
 		"panic": {
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.GatherPanic(ctx)
 			},
-			CanFail: g.CanFail,
 		},
 	}, nil
 }
@@ -113,7 +108,6 @@ func (g *MockCustomPeriodGatherer) GetGatheringFunctions(context.Context) (map[s
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.GatherPeriod(ctx)
 			},
-			CanFail: false,
 		},
 	}, nil
 }
@@ -155,7 +149,6 @@ func (g *MockCustomPeriodGathererNoPeriod) GetGatheringFunctions(context.Context
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.GatherShouldBeProcessed(ctx)
 			},
-			CanFail: false,
 		},
 	}, nil
 }
@@ -191,7 +184,6 @@ func (g *MockFailingGatherer) GetGatheringFunctions(context.Context) (map[string
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.FailingGatherer(ctx)
 			},
-			CanFail: false,
 		},
 	}, nil
 }

--- a/pkg/gather/tasks_processing.go
+++ b/pkg/gather/tasks_processing.go
@@ -25,7 +25,6 @@ type GatheringFunctionResult struct {
 	Errs         []error
 	Panic        interface{}
 	TimeElapsed  time.Duration
-	IgnoreErrors bool
 }
 
 // HandleTasksConcurrently processes tasks concurrently and returns iterator like channel with the results
@@ -98,6 +97,5 @@ func handleTask(ctx context.Context, task Task, resultsChan chan<- GatheringFunc
 		Errs:         errs,
 		Panic:        panicked,
 		TimeElapsed:  time.Since(startTime),
-		IgnoreErrors: task.F.CanFail,
 	}
 }

--- a/pkg/gather/tasks_processing_test.go
+++ b/pkg/gather/tasks_processing_test.go
@@ -33,7 +33,6 @@ func Test_HandleTasksConcurrently(t *testing.T) {
 
 					return records, nil
 				},
-				CanFail: false,
 			},
 		})
 	}
@@ -75,7 +74,6 @@ func Test_HandleTasksConcurrently_CannotFail_Panic(t *testing.T) {
 			Run: func(context.Context) ([]record.Record, []error) {
 				panic("test panic")
 			},
-			CanFail: false,
 		},
 	}})
 
@@ -83,8 +81,7 @@ func Test_HandleTasksConcurrently_CannotFail_Panic(t *testing.T) {
 	results[0].TimeElapsed = 0
 	assert.Equal(t, results, []GatheringFunctionResult{
 		{
-			Panic:        "test panic",
-			IgnoreErrors: false,
+			Panic: "test panic",
 		},
 	})
 }
@@ -97,7 +94,6 @@ func Test_HandleTasksConcurrently_CannotFail_Error(t *testing.T) {
 					fmt.Errorf("test error"),
 				}
 			},
-			CanFail: false,
 		},
 	}})
 
@@ -108,7 +104,6 @@ func Test_HandleTasksConcurrently_CannotFail_Error(t *testing.T) {
 			Errs: []error{
 				fmt.Errorf("test error"),
 			},
-			IgnoreErrors: false,
 		},
 	})
 }
@@ -121,7 +116,6 @@ func Test_HandleTasksConcurrently_CanFail_Error(t *testing.T) {
 					fmt.Errorf("test error"),
 				}
 			},
-			CanFail: true,
 		},
 	}})
 
@@ -132,7 +126,6 @@ func Test_HandleTasksConcurrently_CanFail_Error(t *testing.T) {
 			Errs: []error{
 				fmt.Errorf("test error"),
 			},
-			IgnoreErrors: true,
 		},
 	})
 }
@@ -143,7 +136,6 @@ func Test_HandleTasksConcurrently_CanFail_Panic(t *testing.T) {
 			Run: func(context.Context) ([]record.Record, []error) {
 				panic("test panic")
 			},
-			CanFail: true,
 		},
 	}})
 
@@ -151,8 +143,7 @@ func Test_HandleTasksConcurrently_CanFail_Panic(t *testing.T) {
 	results[0].TimeElapsed = 0
 	assert.Equal(t, results, []GatheringFunctionResult{
 		{
-			Panic:        "test panic",
-			IgnoreErrors: true,
+			Panic: "test panic",
 		},
 	})
 }

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -24,80 +24,58 @@ type Gatherer struct {
 // gathererFuncPtr is a type for pointers to functions of Gatherer
 type gathererFuncPtr = func(*Gatherer, context.Context) ([]record.Record, []error)
 
-// gatheringFunction describes a gathering function
-type gatheringFunction struct {
-	CanFail  bool
-	Function gathererFuncPtr
-}
-
-// importantFunc creates an object describing a gathering function that canNOT fail
-func importantFunc(function gathererFuncPtr) gatheringFunction {
-	return gatheringFunction{
-		CanFail:  false,
-		Function: function,
-	}
-}
-
-// failableFunc creates an object describing a gathering function that can fail
-func failableFunc(function gathererFuncPtr) gatheringFunction {
-	return gatheringFunction{
-		CanFail:  true,
-		Function: function,
-	}
-}
-
-var gatheringFunctions = map[string]gatheringFunction{
-	"pdbs":                              failableFunc((*Gatherer).GatherPodDisruptionBudgets),
-	"metrics":                           failableFunc((*Gatherer).GatherMostRecentMetrics),
-	"dvo_metrics":                       failableFunc((*Gatherer).GatherDVOMetrics),
-	"operators":                         importantFunc((*Gatherer).GatherClusterOperators),
-	"operators_pods_and_events":         importantFunc((*Gatherer).GatherClusterOperatorPodsAndEvents),
-	"container_images":                  importantFunc((*Gatherer).GatherContainerImages),
-	"nodes":                             importantFunc((*Gatherer).GatherNodes),
-	"config_maps":                       failableFunc((*Gatherer).GatherConfigMaps),
-	"version":                           importantFunc((*Gatherer).GatherClusterVersion),
-	"infrastructures":                   importantFunc((*Gatherer).GatherClusterInfrastructure),
-	"networks":                          importantFunc((*Gatherer).GatherClusterNetwork),
-	"authentication":                    importantFunc((*Gatherer).GatherClusterAuthentication),
-	"image_registries":                  importantFunc((*Gatherer).GatherClusterImageRegistry),
-	"image_pruners":                     importantFunc((*Gatherer).GatherClusterImagePruner),
-	"feature_gates":                     importantFunc((*Gatherer).GatherClusterFeatureGates),
-	"oauths":                            importantFunc((*Gatherer).GatherClusterOAuth),
-	"ingress":                           importantFunc((*Gatherer).GatherClusterIngress),
-	"proxies":                           importantFunc((*Gatherer).GatherClusterProxy),
-	"certificate_signing_requests":      importantFunc((*Gatherer).GatherCertificateSigningRequests),
-	"crds":                              importantFunc((*Gatherer).GatherCRD),
-	"host_subnets":                      importantFunc((*Gatherer).GatherHostSubnet),
-	"machine_sets":                      importantFunc((*Gatherer).GatherMachineSet),
-	"machine_configs":                   failableFunc((*Gatherer).GatherMachineConfigs),
-	"machine_healthchecks":              importantFunc((*Gatherer).GatherMachineHealthCheck),
-	"install_plans":                     importantFunc((*Gatherer).GatherInstallPlans),
-	"service_accounts":                  importantFunc((*Gatherer).GatherServiceAccounts),
-	"machine_config_pools":              importantFunc((*Gatherer).GatherMachineConfigPool),
-	"container_runtime_configs":         importantFunc((*Gatherer).GatherContainerRuntimeConfig),
-	"netnamespaces":                     importantFunc((*Gatherer).GatherNetNamespace),
-	"openshift_apiserver_operator_logs": failableFunc((*Gatherer).GatherOpenShiftAPIServerOperatorLogs),
-	"openshift_sdn_logs":                failableFunc((*Gatherer).GatherOpenshiftSDNLogs),
-	"openshift_sdn_controller_logs":     failableFunc((*Gatherer).GatherOpenshiftSDNControllerLogs),
-	"openshift_authentication_logs":     failableFunc((*Gatherer).GatherOpenshiftAuthenticationLogs),
-	"sap_config":                        failableFunc((*Gatherer).GatherSAPConfig),
-	"sap_license_management_logs":       failableFunc((*Gatherer).GatherSAPVsystemIptablesLogs),
-	"sap_pods":                          failableFunc((*Gatherer).GatherSAPPods),
-	"sap_datahubs":                      failableFunc((*Gatherer).GatherSAPDatahubs),
-	"olm_operators":                     failableFunc((*Gatherer).GatherOLMOperators),
-	"pod_network_connectivity_checks":   failableFunc((*Gatherer).GatherPNCC),
-	"machine_autoscalers":               failableFunc((*Gatherer).GatherMachineAutoscalers),
-	"openshift_logging":                 failableFunc((*Gatherer).GatherOpenshiftLogging),
-	"psps":                              failableFunc((*Gatherer).GatherPodSecurityPolicies),
-	"jaegers":                           failableFunc((*Gatherer).GatherJaegerCR),
-	"validating_webhook_configurations": failableFunc((*Gatherer).GatherValidatingWebhookConfigurations),
-	"mutating_webhook_configurations":   failableFunc((*Gatherer).GatherMutatingWebhookConfigurations),
-	"cost_management_metrics_configs":   failableFunc((*Gatherer).GatherCostManagementMetricsConfigs),
-	"node_logs":                         failableFunc((*Gatherer).GatherNodeLogs),
-	"tsdb_status":                       failableFunc((*Gatherer).GatherTSDBStatus),
-	"schedulers":                        failableFunc((*Gatherer).GatherSchedulers),
-	"scheduler_logs":                    failableFunc((*Gatherer).GatherSchedulerLogs),
-	"silenced_alerts":                   failableFunc((*Gatherer).GatherSilencedAlerts),
+var gatheringFunctions = map[string]gathererFuncPtr{
+	"pdbs":                              (*Gatherer).GatherPodDisruptionBudgets,
+	"metrics":                           (*Gatherer).GatherMostRecentMetrics,
+	"dvo_metrics":                       (*Gatherer).GatherDVOMetrics,
+	"operators":                         (*Gatherer).GatherClusterOperators,
+	"operators_pods_and_events":         (*Gatherer).GatherClusterOperatorPodsAndEvents,
+	"container_images":                  (*Gatherer).GatherContainerImages,
+	"nodes":                             (*Gatherer).GatherNodes,
+	"config_maps":                       (*Gatherer).GatherConfigMaps,
+	"version":                           (*Gatherer).GatherClusterVersion,
+	"infrastructures":                   (*Gatherer).GatherClusterInfrastructure,
+	"networks":                          (*Gatherer).GatherClusterNetwork,
+	"authentication":                    (*Gatherer).GatherClusterAuthentication,
+	"image_registries":                  (*Gatherer).GatherClusterImageRegistry,
+	"image_pruners":                     (*Gatherer).GatherClusterImagePruner,
+	"feature_gates":                     (*Gatherer).GatherClusterFeatureGates,
+	"oauths":                            (*Gatherer).GatherClusterOAuth,
+	"ingress":                           (*Gatherer).GatherClusterIngress,
+	"proxies":                           (*Gatherer).GatherClusterProxy,
+	"certificate_signing_requests":      (*Gatherer).GatherCertificateSigningRequests,
+	"crds":                              (*Gatherer).GatherCRD,
+	"host_subnets":                      (*Gatherer).GatherHostSubnet,
+	"machine_sets":                      (*Gatherer).GatherMachineSet,
+	"machine_configs":                   (*Gatherer).GatherMachineConfigs,
+	"machine_healthchecks":              (*Gatherer).GatherMachineHealthCheck,
+	"install_plans":                     (*Gatherer).GatherInstallPlans,
+	"service_accounts":                  (*Gatherer).GatherServiceAccounts,
+	"machine_config_pools":              (*Gatherer).GatherMachineConfigPool,
+	"container_runtime_configs":         (*Gatherer).GatherContainerRuntimeConfig,
+	"netnamespaces":                     (*Gatherer).GatherNetNamespace,
+	"openshift_apiserver_operator_logs": (*Gatherer).GatherOpenShiftAPIServerOperatorLogs,
+	"openshift_sdn_logs":                (*Gatherer).GatherOpenshiftSDNLogs,
+	"openshift_sdn_controller_logs":     (*Gatherer).GatherOpenshiftSDNControllerLogs,
+	"openshift_authentication_logs":     (*Gatherer).GatherOpenshiftAuthenticationLogs,
+	"sap_config":                        (*Gatherer).GatherSAPConfig,
+	"sap_license_management_logs":       (*Gatherer).GatherSAPVsystemIptablesLogs,
+	"sap_pods":                          (*Gatherer).GatherSAPPods,
+	"sap_datahubs":                      (*Gatherer).GatherSAPDatahubs,
+	"olm_operators":                     (*Gatherer).GatherOLMOperators,
+	"pod_network_connectivity_checks":   (*Gatherer).GatherPNCC,
+	"machine_autoscalers":               (*Gatherer).GatherMachineAutoscalers,
+	"openshift_logging":                 (*Gatherer).GatherOpenshiftLogging,
+	"psps":                              (*Gatherer).GatherPodSecurityPolicies,
+	"jaegers":                           (*Gatherer).GatherJaegerCR,
+	"validating_webhook_configurations": (*Gatherer).GatherValidatingWebhookConfigurations,
+	"mutating_webhook_configurations":   (*Gatherer).GatherMutatingWebhookConfigurations,
+	"cost_management_metrics_configs":   (*Gatherer).GatherCostManagementMetricsConfigs,
+	"node_logs":                         (*Gatherer).GatherNodeLogs,
+	"tsdb_status":                       (*Gatherer).GatherTSDBStatus,
+	"schedulers":                        (*Gatherer).GatherSchedulers,
+	"scheduler_logs":                    (*Gatherer).GatherSchedulerLogs,
+	"silenced_alerts":                   (*Gatherer).GatherSilencedAlerts,
 }
 
 func New(
@@ -126,9 +104,8 @@ func (g *Gatherer) GetGatheringFunctions(context.Context) (map[string]gatherers.
 
 		result[funcName] = gatherers.GatheringClosure{
 			Run: func(ctx context.Context) ([]record.Record, []error) {
-				return function.Function(g, ctx)
+				return function(g, ctx)
 			},
-			CanFail: function.CanFail,
 		}
 	}
 

--- a/pkg/gatherers/conditional/conditional_gatherer.go
+++ b/pkg/gatherers/conditional/conditional_gatherer.go
@@ -158,8 +158,6 @@ var defaultGatheringRules = []GatheringRule{
 	},
 }
 
-const canConditionalGathererFail = false
-
 // Gatherer implements the conditional gatherer
 type Gatherer struct {
 	gatherProtoKubeConfig   *rest.Config
@@ -256,7 +254,6 @@ func (g *Gatherer) GetGatheringFunctions(ctx context.Context) (map[string]gather
 				},
 			}, nil
 		},
-		CanFail: canConditionalGathererFail,
 	}
 
 	return gatheringFunctions, nil

--- a/pkg/gatherers/conditional/gather_alertmanager_logs.go
+++ b/pkg/gatherers/conditional/gather_alertmanager_logs.go
@@ -45,7 +45,6 @@ func (g *Gatherer) BuildGatherAlertmanagerLogs(paramsInterface interface{}) (gat
 			}
 			return records, nil
 		},
-		CanFail: canConditionalGathererFail,
 	}, nil
 }
 

--- a/pkg/gatherers/conditional/gather_alertmanager_logs_test.go
+++ b/pkg/gatherers/conditional/gather_alertmanager_logs_test.go
@@ -23,23 +23,6 @@ var testAlertManagerFiringAlerts = map[string][]AlertLabels{
 	},
 }
 
-func TestGatherer_BuildGatherAlertmanagerLogs(t *testing.T) {
-	g := &Gatherer{firingAlerts: testAlertManagerFiringAlerts}
-	gather, err := g.BuildGatherAlertmanagerLogs(GatherAlertmanagerLogsParams{
-		AlertName: "AlertmanagerFailedToSendAlerts",
-		TailLines: 100,
-	})
-
-	if err != nil {
-		t.Errorf("BuildGatherAlertmanagerLogs() error = %v, it must not fail to be build", err)
-		return
-	}
-
-	if gather.CanFail != canConditionalGathererFail {
-		t.Errorf("BuildGatherAlertmanagerLogs() got = %v, want %v", gather.CanFail, canConditionalGathererFail)
-	}
-}
-
 func TestGatherer_gatherAlertmanagerLogs(t *testing.T) {
 	ctx := context.TODO()
 	testPod := &corev1.Pod{

--- a/pkg/gatherers/conditional/gather_api_request_count.go
+++ b/pkg/gatherers/conditional/gather_api_request_count.go
@@ -50,7 +50,6 @@ func (g *Gatherer) BuildGatherAPIRequestCounts(paramsInterface interface{}) (gat
 			}
 			return records, nil
 		},
-		CanFail: canConditionalGathererFail,
 	}, nil
 }
 

--- a/pkg/gatherers/conditional/gather_image_stream_definitions_of_namespace.go
+++ b/pkg/gatherers/conditional/gather_image_stream_definitions_of_namespace.go
@@ -40,7 +40,6 @@ func (g *Gatherer) BuildGatherImageStreamsOfNamespace(paramsInterface interface{
 			}
 			return records, nil
 		},
-		CanFail: canConditionalGathererFail,
 	}, nil
 }
 

--- a/pkg/gatherers/conditional/gather_logs_of_namespace.go
+++ b/pkg/gatherers/conditional/gather_logs_of_namespace.go
@@ -41,7 +41,6 @@ func (g *Gatherer) BuildGatherLogsOfNamespace(paramsInterface interface{}) (gath
 			}
 			return records, nil
 		},
-		CanFail: canConditionalGathererFail,
 	}, nil
 }
 

--- a/pkg/gatherers/conditional/gather_logs_of_unhealthy_pods.go
+++ b/pkg/gatherers/conditional/gather_logs_of_unhealthy_pods.go
@@ -35,7 +35,6 @@ func (g *Gatherer) BuildGatherLogsOfUnhealthyPods(paramsInterface interface{}) (
 			}
 			return g.gatherLogsOfUnhealthyPods(ctx, kubeClient.CoreV1(), params)
 		},
-		CanFail: canConditionalGathererFail,
 	}, nil
 }
 

--- a/pkg/gatherers/interface.go
+++ b/pkg/gatherers/interface.go
@@ -30,8 +30,6 @@ type CustomPeriodGatherer interface {
 }
 
 // GatheringClosure is a struct containing a closure each gatherer returns
-// it also contains CanFail field showing if we should just log the failures
 type GatheringClosure struct {
-	Run     func(context.Context) ([]record.Record, []error)
-	CanFail bool
+	Run func(context.Context) ([]record.Record, []error)
 }

--- a/pkg/gatherers/workloads/workloads_gatherer.go
+++ b/pkg/gatherers/workloads/workloads_gatherer.go
@@ -35,7 +35,6 @@ func (g *Gatherer) GetGatheringFunctions(context.Context) (map[string]gatherers.
 			Run: func(ctx context.Context) ([]record.Record, []error) {
 				return g.GatherWorkloadInfo(ctx)
 			},
-			CanFail: true,
 		},
 	}, nil
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is removing the unnecessary division into important and failable gatherers. Why? Because every gatherer can fail and in case of failure of an important gatherer, it is not worth repeating the gathering sooner IMO. This was the only significant difference when having this division. 

This requires thorough testing

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no updates

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

updated

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
