### PR TITLE
[release-4.9] Bug 2033540: Gather all CostManagementMericsConfig defi…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -273,6 +273,15 @@ Response see:
   * 4.7+
 
 
+## CostManagementMetricsConfigs
+
+collects CostManagementMetricsConfigs definitions.
+* Location in archive: config/cost_management_metrics_configs/<name>.json
+* Id in config: cost_management_metrics_configs
+* Since versions:
+  * 4.10+
+
+
 ## HostSubnet
 
 collects HostSubnet information

--- a/docs/insights-archive-sample/config/cost_management_metrics_configs/00-basic.json
+++ b/docs/insights-archive-sample/config/cost_management_metrics_configs/00-basic.json
@@ -1,0 +1,35 @@
+{
+    "apiVersion": "costmanagement-metrics-cfg.openshift.io/v1beta1",
+    "kind": "CostManagementMetricsConfig",
+    "metadata": {
+      "namespace": "costmanagement-metrics-operator",
+      "name": "costmanagementmetricscfg-sample-token"
+    },
+    "spec": {
+      "upload": {
+        "ingress_path": "/api/ingress/v1/upload",
+        "upload_cycle": 360,
+        "upload_toggle": true,
+        "validate_cert": true
+      },
+      "packaging": {
+        "max_reports_to_store": 30,
+        "max_size_MB": 100
+      },
+      "api_url": "https://cloud.redhat.com",
+      "prometheus_config": {
+        "service_address": "https://thanos-querier.openshift-monitoring.svc:9091",
+        "skip_tls_verification": false
+      },
+      "authentication": {
+        "type": "basic",
+        "secret_name": "console_basic"
+      },
+      "source": {
+        "check_cycle": 1440,
+        "create_source": false,
+        "name": "INSERT-SOURCE-NAME",
+        "sources_path": "/api/sources/v1.0/"
+      }
+    }
+  }

--- a/docs/insights-archive-sample/config/cost_management_metrics_configs/00-token.json
+++ b/docs/insights-archive-sample/config/cost_management_metrics_configs/00-token.json
@@ -1,0 +1,34 @@
+{
+    "apiVersion": "costmanagement-metrics-cfg.openshift.io/v1beta1",
+    "kind": "CostManagementMetricsConfig",
+    "metadata": {
+      "namespace": "costmanagement-metrics-operator",
+      "name": "costmanagementmetricscfg-sample-token"
+    },
+    "spec": {
+      "upload": {
+        "ingress_path": "/api/ingress/v1/upload",
+        "upload_cycle": 360,
+        "upload_toggle": true,
+        "validate_cert": true
+      },
+      "packaging": {
+        "max_reports_to_store": 30,
+        "max_size_MB": 100
+      },
+      "api_url": "https://cloud.redhat.com",
+      "prometheus_config": {
+        "service_address": "https://thanos-querier.openshift-monitoring.svc:9091",
+        "skip_tls_verification": false
+      },
+      "authentication": {
+        "type": "token"
+      },
+      "source": {
+        "check_cycle": 1440,
+        "create_source": false,
+        "name": "INSERT-SOURCE-NAME",
+        "sources_path": "/api/sources/v1.0/"
+      }
+    }
+  }

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -219,7 +219,16 @@ rules:
     verbs:
       - get
       - list
-      - watch  
+      - watch
+  - apiGroups:
+      - costmanagement-metrics-cfg.openshift.io
+    resources:
+      - costmanagementmetricsconfigs
+    verbs:
+      - get
+      - list
+      - watch    
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -89,6 +89,7 @@ var gatheringFunctions = map[string]gatheringFunction{
 	"psps":                              failableFunc((*Gatherer).GatherPodSecurityPolicies),
 	"validating_webhook_configurations": failableFunc((*Gatherer).GatherValidatingWebhookConfigurations),
 	"mutating_webhook_configurations":   failableFunc((*Gatherer).GatherMutatingWebhookConfigurations),
+	"cost_management_metrics_configs":   failableFunc((*Gatherer).GatherCostManagementMetricsConfigs),
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -35,6 +35,9 @@ var (
 	openshiftLoggingResource = schema.GroupVersionResource{
 		Group: "logging.openshift.io", Version: "v1", Resource: "clusterloggings",
 	}
+	costManagementMetricsConfigResource = schema.GroupVersionResource{
+		Group: "costmanagement-metrics-cfg.openshift.io", Version: "v1beta1", Resource: "costmanagementmetricsconfigs",
+	}
 )
 
 func init() { //nolint: gochecknoinits

--- a/pkg/gatherers/clusterconfig/cost_management_metrics_configs.go
+++ b/pkg/gatherers/clusterconfig/cost_management_metrics_configs.go
@@ -1,0 +1,49 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+// GatherCostManagementMetricsConfigs collects CostManagementMetricsConfigs definitions.
+// * Location in archive: config/cost_management_metrics_configs/<name>.json
+// * Id in config: cost_management_metrics_configs
+// * Since versions:
+//   * 4.10+
+func (g *Gatherer) GatherCostManagementMetricsConfigs(ctx context.Context) ([]record.Record, []error) {
+	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherCostManagementMetricsConfigs(ctx, gatherDynamicClient)
+}
+
+func gatherCostManagementMetricsConfigs(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	mcList, err := dynamicClient.Resource(costManagementMetricsConfigResource).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	records := []record.Record{}
+	var errs []error
+	for i := range mcList.Items {
+		mc := mcList.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("config/cost_management_metrics_configs/%s", mc.GetName()),
+			Item: record.ResourceMarshaller{Resource: &mc},
+		})
+	}
+	if len(errs) > 0 {
+		return records, errs
+	}
+	return records, nil
+}

--- a/pkg/gatherers/clusterconfig/cost_management_metrics_configs_test.go
+++ b/pkg/gatherers/clusterconfig/cost_management_metrics_configs_test.go
@@ -1,0 +1,119 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func createMockCostManagementMetricsConfig(t *testing.T, c dynamic.Interface, data string) {
+	decUnstructured1 := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	testCostManagementMetricsConfig := &unstructured.Unstructured{}
+	_, _, err := decUnstructured1.Decode([]byte(data), nil, testCostManagementMetricsConfig)
+	if err != nil {
+		t.Fatal("unable to decode CostManagementMetricsConfig YAML", err)
+	}
+
+	_, _ = c.
+		Resource(costManagementMetricsConfigResource).
+		Create(context.Background(), testCostManagementMetricsConfig, metav1.CreateOptions{})
+}
+
+func Test_CostManagementMetricsConfigs(t *testing.T) {
+	// Initialize the fake dynamic client.
+	costMgmtMetricsConfigClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(), map[schema.GroupVersionResource]string{
+			costManagementMetricsConfigResource: "CostManagementMetricsConfigList",
+		})
+
+	records, errs := gatherCostManagementMetricsConfigs(context.Background(), costMgmtMetricsConfigClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// 0 records because there is no CostManagementMetricsConfigs yet.
+	if len(records) != 0 {
+		t.Fatalf("unexpected number or records in the first run: %d", len(records))
+	}
+
+	// Create first CostManagementMetricsConfig resource.
+	costMgmtMetricsConfigYAML1 := `apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
+kind: CostManagementMetricsConfig
+metadata:
+    name: costmanagementmetricscfg-sample-1
+`
+
+	createMockCostManagementMetricsConfig(t, costMgmtMetricsConfigClient, costMgmtMetricsConfigYAML1)
+	records, errs = gatherCostManagementMetricsConfigs(context.Background(), costMgmtMetricsConfigClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// 1 record because there is now 1 CostManagementMetricsConfig resource.
+	if len(records) != 1 {
+		t.Fatalf("unexpected number or records in the second run: %d", len(records))
+	}
+
+	// Create second CostManagementMetricsConfig resource.
+	costMgmtMetricsConfigYAML2 := `apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
+kind: CostManagementMetricsConfig
+metadata:
+    name: costmanagementmetricscfg-sample-2
+`
+
+	createMockCostManagementMetricsConfig(t, costMgmtMetricsConfigClient, costMgmtMetricsConfigYAML2)
+	records, errs = gatherCostManagementMetricsConfigs(context.Background(), costMgmtMetricsConfigClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// 2 record because there are now 2 CostManagementMetricsConfig resource.
+	if len(records) != 2 {
+		t.Fatalf("unexpected number or records in the third run: %d", len(records))
+	}
+
+	// Create third CostManagementMetricsConfig resource.
+	costMgmtMetricsConfigYAML3 := `apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
+kind: CostManagementMetricsConfig
+metadata:
+    name: costmanagementmetricscfg-sample-3
+    spec:
+       authentication:
+            type: basic
+            secret_name: console_basic_auth
+`
+
+	createMockCostManagementMetricsConfig(t, costMgmtMetricsConfigClient, costMgmtMetricsConfigYAML3)
+	records, errs = gatherCostManagementMetricsConfigs(context.Background(), costMgmtMetricsConfigClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// 3 record because there are now 3 CostManagementMetricsConfig resource.
+	if len(records) != 3 {
+		t.Fatalf("unexpected number or records in the fourth run: %d", len(records))
+	}
+
+	// Create fourth CostManagementMetricsConfig resource.
+	costMgmtMetricsConfigYAML4 := `apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
+kind: CostManagementMetricsConfig
+metadata:
+    name: costmanagementmetricscfg-sample-4
+    spec:
+        authentication:
+            type: token
+`
+
+	createMockCostManagementMetricsConfig(t, costMgmtMetricsConfigClient, costMgmtMetricsConfigYAML4)
+	records, errs = gatherCostManagementMetricsConfigs(context.Background(), costMgmtMetricsConfigClient)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %#v", errs)
+	}
+	// 4 record because there are now 4 CostManagementMetricsConfig resource.
+	if len(records) != 4 {
+		t.Fatalf("unexpected number or records in the fifth run: %d", len(records))
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is backport of https://github.com/openshift/insights-operator/pull/525. Steps to verify:

1. Install "Cost Management Metrics Operator" via OLM
2. When it's installed then click on the `Installed operators` and on the new CMM operator
3. Create a new instance in the "Details" section
4. This instance should be gathered in `config/cost_management_metrics_configs/<instance_name>.json`

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/cost_management_metrics_configs/00-basic.json`
- `docs/insights-archive-sample/config/cost_management_metrics_configs/00-token.json`

## Documentation
<!-- Are these changes reflected in documentation? -->
Updated
- `docs/gathered-data.md `

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/cost_management_metrics_configs_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2033540
https://access.redhat.com/solutions/???
