### PR TITLE
WIP: Implement minimal Elasticsearch gatherer

### DIFF
--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -76,6 +76,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"schedulers":                        (*Gatherer).GatherSchedulers,
 	"scheduler_logs":                    (*Gatherer).GatherSchedulerLogs,
 	"silenced_alerts":                   (*Gatherer).GatherSilencedAlerts,
+	"elasticsearch":                     (*Gatherer).GatherElasticsearch,
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/openshift_elasticsearch.go
+++ b/pkg/gatherers/clusterconfig/openshift_elasticsearch.go
@@ -1,0 +1,80 @@
+package clusterconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net/http"
+	"strings"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+func (g *Gatherer) GatherElasticsearch(ctx context.Context) ([]record.Record, []error) {
+	conf := rest.CopyConfig(g.gatherProtoKubeConfig)
+	conf.Impersonate.UserName = ""
+
+	gatherKubeClient, err := kubernetes.NewForConfig(conf)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	coreClient := gatherKubeClient.CoreV1()
+
+	secretList, err := coreClient.Secrets("openshift-insights").List(ctx, v1.ListOptions{})
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	secretToken := ""
+	for _, s := range secretList.Items {
+		if s.Type != "kubernetes.io/service-account-token" {
+			continue
+		}
+		if saName, ok := s.ObjectMeta.Annotations["kubernetes.io/service-account.name"]; !ok || saName != "gather" {
+			continue
+		}
+		secretTokenBytes, ok := s.Data["token"]
+		if ok {
+			secretToken = string(secretTokenBytes)
+			break
+		}
+	}
+
+	postData := strings.NewReader(`{
+"query": {
+	"query_string": {
+	"query": "message:error AND (kubernetes.namespace_name:openshift-* OR kubernetes.namespace_name:kube*) AND NOT message:\"transport is closing\""
+	}
+}
+}`)
+
+	req, err := http.NewRequest(http.MethodPost, "https://elasticsearch.openshift-logging.svc:9200/_search", postData)
+	if err != nil {
+		return nil, []error{err}
+	}
+	req.Header.Set("Authorization", "Bearer "+secretToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, []error{err}
+	}
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return []record.Record{{Name: "config/elasticsearch", Item: RawJSON(respBytes)}}, nil
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR implements a new gatherer that collects the result of a search query executed against the optional Elasticsearch operator.

## TODO

- Check if the operator is installed on the cluster.
- Disover `elasticsearch` service dynamically and build the URL in a similar way to the DVO gatherer.
- Limit collected data size somehow.
- Collected data anonymization?

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
