### PR TITLE
Remove "InsightsOperatorPullingSCA" TP feature check

### DIFF
--- a/pkg/ocm/sca/sca_test.go
+++ b/pkg/ocm/sca/sca_test.go
@@ -1,4 +1,4 @@
-package ocm
+package sca
 
 import (
 	"context"
@@ -16,7 +16,7 @@ var (
 	secTestData       = "secret testing data"
 )
 
-var testRes = &ScaResponse{
+var testRes = &Response{
 	Key:  "secret key",
 	Cert: "secret cert",
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is removing the TechPreview feature set check. IOW it means that the SCA certs will be pulled down automatically. There are also some minor enhancements in the related log messages.

This is not possible to test with cluster-bot cluster so you have to create your own cluster in AWS.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
This requires OCP doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No test update

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
