### PR TITLE
fix: defer in loop

### DIFF
--- a/pkg/authorizer/clusterauthorizer/clusterauthorizer_test.go
+++ b/pkg/authorizer/clusterauthorizer/clusterauthorizer_test.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openshift/insights-operator/pkg/config"
 	"golang.org/x/net/http/httpproxy"
+
+	"github.com/openshift/insights-operator/pkg/config"
 )
 
 // nonCachedProxyFromEnvironment creates Proxier if Proxy is set. It uses always fresh Env
@@ -84,9 +85,9 @@ func Test_Proxy(tt *testing.T) {
 	for _, tcase := range testCases {
 		tc := tcase
 		tt.Run(tc.Name, func(t *testing.T) {
-			// do not use parallel here
 			for k, v := range tc.EnvValues {
-				defer SafeRestoreEnv(k)()
+				// do not use parallel here
+				defer SafeRestoreEnv(k)() // nolint: gocritic
 				// nil will indicate the need to unset Env
 				if v != nil {
 					vv := v.(string)

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -95,21 +95,18 @@ func CollectAndRecordGatherer(
 		}
 
 		for _, err := range result.Errs {
-			errStr := fmt.Sprintf(
+			errs = append(errs, fmt.Errorf(
 				"gatherer %v's function %v failed with error: %v",
 				gathererName, result.FunctionName, err,
-			)
-
-			errs = append(errs, fmt.Errorf("%s", errStr))
+			))
 		}
 		recordedRecs := 0
 		for _, r := range result.Records {
 			if err := rec.Record(r); err != nil {
-				recErr := fmt.Errorf(
+				result.Errs = append(result.Errs, fmt.Errorf(
 					"unable to record gatherer %v function %v' result %v because of error: %v",
 					gathererName, result.FunctionName, r.Name, err,
-				)
-				result.Errs = append(result.Errs, recErr)
+				))
 				continue
 			}
 			recordedRecs++

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -100,7 +100,7 @@ func CollectAndRecordGatherer(
 				gathererName, result.FunctionName, err,
 			)
 
-			errs = append(errs, fmt.Errorf(errStr))
+			errs = append(errs, fmt.Errorf("%s", errStr))
 		}
 		recordedRecs := 0
 		for _, r := range result.Records {

--- a/pkg/gatherers/clusterconfig/install_plans_test.go
+++ b/pkg/gatherers/clusterconfig/install_plans_test.go
@@ -58,45 +58,47 @@ func Test_InstallPlans_Gather(t *testing.T) {
 			var client *dynamicfake.FakeDynamicClient
 			coreClient := kubefake.NewSimpleClientset()
 			for _, file := range test.testfiles {
-				f, err := os.Open(file)
-				if err != nil {
-					t.Fatal("test failed to read installplan data", err)
-				}
-				defer f.Close()
-				installplancontent, err := io.ReadAll(f)
-				if err != nil {
-					t.Fatal("error reading test data file", err)
-				}
+				func() {
+					f, err := os.Open(file)
+					if err != nil {
+						t.Fatal("test failed to read installplan data", err)
+					}
+					defer f.Close()
+					installplancontent, err := io.ReadAll(f)
+					if err != nil {
+						t.Fatal("error reading test data file", err)
+					}
 
-				decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-				installplan := &unstructured.Unstructured{}
+					decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+					installplan := &unstructured.Unstructured{}
 
-				_, _, err = decUnstructured.Decode(installplancontent, nil, installplan)
-				if err != nil {
-					t.Fatal("unable to decode", err)
-				}
-				gv, _ := schema.ParseGroupVersion(installplan.GetAPIVersion())
-				gvr := schema.GroupVersionResource{Version: gv.Version, Group: gv.Group, Resource: "installplans"}
-				ns, _, err := unstructured.NestedString(installplan.Object, "metadata", "namespace")
-				if err != nil {
-					t.Fatal("unable to read ns ", err)
-				}
-				_, err = coreClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
-				if errors.IsNotFound(err) {
-					_, err = coreClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-				}
-				if err != nil {
-					t.Fatal("unable to create ns fake ", err)
-				}
-				if client == nil {
-					client = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
-						gvr: "InstallPlansList",
-					})
-				}
-				_, err = client.Resource(gvr).Namespace(ns).Create(context.Background(), installplan, metav1.CreateOptions{})
-				if err != nil {
-					t.Fatal("unable to create installplan fake ", err)
-				}
+					_, _, err = decUnstructured.Decode(installplancontent, nil, installplan)
+					if err != nil {
+						t.Fatal("unable to decode", err)
+					}
+					gv, _ := schema.ParseGroupVersion(installplan.GetAPIVersion())
+					gvr := schema.GroupVersionResource{Version: gv.Version, Group: gv.Group, Resource: "installplans"}
+					ns, _, err := unstructured.NestedString(installplan.Object, "metadata", "namespace")
+					if err != nil {
+						t.Fatal("unable to read ns ", err)
+					}
+					_, err = coreClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+					if errors.IsNotFound(err) {
+						_, err = coreClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+					}
+					if err != nil {
+						t.Fatal("unable to create ns fake ", err)
+					}
+					if client == nil {
+						client = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+							gvr: "InstallPlansList",
+						})
+					}
+					_, err = client.Resource(gvr).Namespace(ns).Create(context.Background(), installplan, metav1.CreateOptions{})
+					if err != nil {
+						t.Fatal("unable to create installplan fake ", err)
+					}
+				}()
 			}
 			ctx := context.Background()
 			records, errs := gatherInstallPlans(ctx, client, coreClient.CoreV1())

--- a/pkg/gatherers/conditional/validation.go
+++ b/pkg/gatherers/conditional/validation.go
@@ -39,7 +39,7 @@ func validateGatheringRules(gatheringRules []GatheringRule) []error {
 	if !result.Valid() {
 		var errs []error
 		for _, err := range result.Errors() {
-			errs = append(errs, fmt.Errorf(err.String()))
+			errs = append(errs, fmt.Errorf("%s", err.String()))
 		}
 
 		return errs


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR removes the use of the `defer` function directly inside the loops, by wrapping it into some functions. It avoids some possible resource leaks. The `defer` functions inside the test files are not causing any issue, in this case, I'm just ignoring them to make the linter happy. And also, this PR fixes some small linting issues related to `fmt.Error`.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No

## Documentation
<!-- Are these changes reflected in documentation? -->

No

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-7149
