### PR TITLE
Bug 2054095: Gather cluster images.config.openshift.io resource definition

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -79,6 +79,19 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 * Id in config: feature_gates
 
 
+## ClusterImage
+
+gathers cluster "images.config.openshift.io" resource definition
+
+The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/config_client.go#L72
+Response see https://docs.openshift.com/container-platform/latest/rest_api/config_apis/image-config-openshift-io-v1.html#image-config-openshift-io-v1
+
+* Location in archive: config/image.json
+* Id in config: image
+* Since versions:
+  * 4.11+
+
+
 ## ClusterImagePruner
 
 fetches the image pruner configuration

--- a/docs/insights-archive-sample/config/image.json
+++ b/docs/insights-archive-sample/config/image.json
@@ -1,0 +1,32 @@
+{
+    "metadata": {
+        "name": "cluster",
+        "uid": "6b109ced-672b-4570-9d8b-0416394b2d46",
+        "resourceVersion": "21068",
+        "generation": 1,
+        "creationTimestamp": "2022-02-08T13:24:30Z",
+        "annotations": {
+            "include.release.openshift.io/ibm-cloud-managed": "true",
+            "include.release.openshift.io/self-managed-high-availability": "true",
+            "include.release.openshift.io/single-node-developer": "true",
+            "release.openshift.io/create-only": "true"
+        },
+        "ownerReferences": [
+            {
+                "apiVersion": "config.openshift.io/v1",
+                "kind": "ClusterVersion",
+                "name": "version",
+                "uid": "9af31338-5de0-45d0-bf8f-965abc00e1ed"
+            }
+        ]
+    },
+    "spec": {
+        "additionalTrustedCA": {
+            "name": ""
+        },
+        "registrySources": {}
+    },
+    "status": {
+        "internalRegistryHostname": "image-registry.openshift-image-registry.svc:5000"
+    }
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -76,6 +76,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"schedulers":                        (*Gatherer).GatherSchedulers,
 	"scheduler_logs":                    (*Gatherer).GatherSchedulerLogs,
 	"silenced_alerts":                   (*Gatherer).GatherSilencedAlerts,
+	"image":                             (*Gatherer).GatherClusterImage,
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/image.go
+++ b/pkg/gatherers/clusterconfig/image.go
@@ -1,0 +1,42 @@
+//nolint: dupl
+package clusterconfig
+
+import (
+	"context"
+
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/insights-operator/pkg/record"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GatherClusterImages gathers cluster "images.config.openshift.io" resource definition
+//
+// The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/config_client.go#L72
+// Response see https://docs.openshift.com/container-platform/latest/rest_api/config_apis/image-config-openshift-io-v1.html#image-config-openshift-io-v1
+//
+// * Location in archive: config/image.json
+// * Id in config: image
+// * Since versions:
+//   * 4.11+
+func (g *Gatherer) GatherClusterImage(ctx context.Context) ([]record.Record, []error) {
+	configCli, err := configv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherClusterImage(ctx, configCli)
+}
+
+func gatherClusterImage(ctx context.Context, configCli configv1client.ConfigV1Interface) ([]record.Record, []error) {
+	image, err := configCli.Images().Get(ctx, "cluster", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	return []record.Record{{
+		Name: "config/image",
+		Item: record.ResourceMarshaller{Resource: image},
+	}}, nil
+}

--- a/pkg/gatherers/clusterconfig/image_test.go
+++ b/pkg/gatherers/clusterconfig/image_test.go
@@ -1,0 +1,40 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/openshift/api/config/v1"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_GatherClusterImage(t *testing.T) {
+	cfg := configfake.NewSimpleClientset()
+	testImage := &v1.Image{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: v1.ImageSpec{
+			AdditionalTrustedCA: v1.ConfigMapNameReference{
+				Name: "test-cm-reference",
+			},
+		},
+		Status: v1.ImageStatus{
+			InternalRegistryHostname: "test-registry-name",
+		},
+	}
+	_, err := cfg.ConfigV1().Images().Create(context.Background(), testImage, metav1.CreateOptions{})
+	assert.NoError(t, err, "unable to create fake image")
+	records, errs := gatherClusterImage(context.Background(), cfg.ConfigV1())
+	assert.Len(t, records, 1)
+	assert.Len(t, errs, 0)
+
+	item := records[0].Item
+	clusterImage, ok := item.(record.ResourceMarshaller).Resource.(*v1.Image)
+	assert.True(t, ok)
+	assert.Equal(t, "test-cm-reference", clusterImage.Spec.AdditionalTrustedCA.Name)
+	assert.Equal(t, "test-registry-name", clusterImage.Status.InternalRegistryHostname)
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
New clusterconfig gatherer for cluster `images.config.openshift.io` resource definition

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
- `docs/insights-archive-sample/config/image.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/image_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
