### PR TITLE
Send gathering time as metadata field with upload request

### DIFF
--- a/pkg/recorder/diskrecorder/diskrecorder_test.go
+++ b/pkg/recorder/diskrecorder/diskrecorder_test.go
@@ -30,8 +30,9 @@ func Test_Diskrecorder_Save(t *testing.T) {
 	dr := newDiskRecorder()
 	records := getMemoryRecords()
 	saved, err := dr.Save(records)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, saved, len(records))
+	assert.WithinDuration(t, time.Now(), dr.lastRecording, 10*time.Second)
 }
 
 func Test_Diskrecorder_SaveInvalidPath(t *testing.T) {
@@ -63,15 +64,15 @@ func Test_Diskrecorder_SaveFailsIfDuplicatedReport(t *testing.T) {
 func Test_Diskrecorder_Summary(t *testing.T) {
 	since := time.Now().Add(time.Duration(-5) * time.Minute)
 	dr := newDiskRecorder()
-	reader, ok, err := dr.Summary(context.TODO(), since)
-	assert.IsType(t, reader, reader)
+	source, ok, err := dr.Summary(context.TODO(), since)
+	assert.NoError(t, err)
 	assert.True(t, ok)
-	assert.Nil(t, err)
+	assert.NotNil(t, source)
 }
 
 func Test_Diskrecorder_Prune(t *testing.T) {
 	olderThan := time.Now().Add(time.Duration(5) * time.Minute)
 	dr := newDiskRecorder()
 	err := dr.Prune(olderThan)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This extends the HTTP content-disposition header to send the new metadata file including the gathering time attribute. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No doc update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

Minor update in
- `pkg/recorder/diskrecorder/diskrecorder_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
