### PR TITLE
HyperShift - Add required annotation to remaining manifests

### DIFF
--- a/manifests/05-service.yaml
+++ b/manifests/05-service.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: openshift-insights-serving-cert
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
   labels:
     app: insights-operator
   name: metrics

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
 spec:
   strategy:
     type: Recreate

--- a/manifests/07-cluster-operator.yaml
+++ b/manifests/07-cluster-operator.yaml
@@ -6,6 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
 spec: {}
 status:
   versions:

--- a/manifests/07-servicemonitor.yaml
+++ b/manifests/07-servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is adding the required annotations to the remaining manifests resource so that the Insights operator can be installed on HyperShift hosted clusters.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No docs update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->
https://issues.redhat.com/browse/CCXDEV-6636
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
