### PR TITLE
Revert "Set default messages & reconcile clusteroperator status conditions (#584)

### DIFF
--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -53,21 +53,28 @@ func newConditions(cos *configv1.ClusterOperatorStatus, time metav1.Time) *condi
 	}
 }
 
-func (c *conditions) setCondition(conditionType configv1.ClusterStatusConditionType,
+func (c *conditions) setCondition(condition configv1.ClusterStatusConditionType,
 	status configv1.ConditionStatus, reason, message string, lastTime metav1.Time) {
-	originalCondition, ok := c.entryMap[conditionType]
-	// if condition is defined and there is not new status then don't update transition time
-	if ok && originalCondition.Status == status {
-		lastTime = originalCondition.LastTransitionTime
+	entries := make(conditionsMap)
+	for k, v := range c.entryMap {
+		entries[k] = v
 	}
 
-	c.entryMap[conditionType] = configv1.ClusterOperatorStatusCondition{
-		Type:               conditionType,
-		Reason:             reason,
-		Status:             status,
-		Message:            message,
-		LastTransitionTime: lastTime,
+	existing, ok := c.entryMap[condition]
+	if !ok || existing.Status != status || existing.Reason != reason {
+		if lastTime.IsZero() {
+			lastTime = metav1.Now()
+		}
+		entries[condition] = configv1.ClusterOperatorStatusCondition{
+			Type:               condition,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: lastTime,
+		}
 	}
+
+	c.entryMap = entries
 }
 
 func (c *conditions) removeCondition(condition configv1.ClusterStatusConditionType) {


### PR DESCRIPTION


This reverts commit 11e44f0f953a40fdedb2bb731eb2cceb62bd5dd9. After this
merged, some clusters are failing to install with this message:

```
unable to set initial cluster status:
ClusterOperator.config.openshift.io "insights" is invalid:
status.conditions.lastTransitionTime: Required value
```

OpenShift policy is to revert payload breaking changes immediately, and
the team can build their fix on top of the unrevert.
