### PR TITLE
Bug 2061304: Don't serialize empty `images` attribute in the workload info gatherer

### DIFF
--- a/pkg/gatherers/workloads/types.go
+++ b/pkg/gatherers/workloads/types.go
@@ -19,7 +19,7 @@ type workloadPods struct {
 	// Images is a map of image ID to data about the images referenced by pods. Images are
 	// only populated if the cluster had imported the image ID to the image API via an
 	// import or an image stream.
-	Images map[string]workloadImage `json:"images"`
+	Images map[string]workloadImage `json:"images,omitempty"`
 	// Namespaces is a map of namespace name hash to data about the namespace. The namespace
 	// is populated even if it has no pods.
 	Namespaces map[string]workloadNamespacePods `json:"namespaces"`


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

If the images couldn't be read (for example due to timeout - see [here](https://github.com/openshift/insights-operator/blob/master/pkg/gatherers/workloads/workloads_info.go#L205)) then we ended up with json containing `"images":null`. It's better to omit the attribute completely

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No update

## Documentation
<!-- Are these changes reflected in documentation? -->

No update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-7109
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
