### PR TITLE
Bug 2063164: Revert "Set default messages & reconcile clusteroperator status conditions"

### DIFF
--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -53,21 +53,28 @@ func newConditions(cos *configv1.ClusterOperatorStatus, time metav1.Time) *condi
 	}
 }
 
-func (c *conditions) setCondition(conditionType configv1.ClusterStatusConditionType,
+func (c *conditions) setCondition(condition configv1.ClusterStatusConditionType,
 	status configv1.ConditionStatus, reason, message string, lastTime metav1.Time) {
-	originalCondition, ok := c.entryMap[conditionType]
-	// if condition is defined and there is not new status then don't update transition time
-	if ok && originalCondition.Status == status {
-		lastTime = originalCondition.LastTransitionTime
+	entries := make(conditionsMap)
+	for k, v := range c.entryMap {
+		entries[k] = v
 	}
 
-	c.entryMap[conditionType] = configv1.ClusterOperatorStatusCondition{
-		Type:               conditionType,
-		Reason:             reason,
-		Status:             status,
-		Message:            message,
-		LastTransitionTime: lastTime,
+	existing, ok := c.entryMap[condition]
+	if !ok || existing.Status != status || existing.Reason != reason {
+		if lastTime.IsZero() {
+			lastTime = metav1.Now()
+		}
+		entries[condition] = configv1.ClusterOperatorStatusCondition{
+			Type:               condition,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: lastTime,
+		}
 	}
+
+	c.entryMap = entries
 }
 
 func (c *conditions) removeCondition(condition configv1.ClusterStatusConditionType) {

--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -50,12 +50,12 @@ func (s *Simple) UpdateStatus(summary Summary) { //nolint: gocritic
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if summary.LastTransitionTime.IsZero() {
-		s.summary.LastTransitionTime = time.Now()
-	}
-
 	if s.summary.Healthy != summary.Healthy {
 		klog.V(2).Infof("name=%s healthy=%t reason=%s message=%s", s.Name, summary.Healthy, summary.Reason, summary.Message)
+		if summary.LastTransitionTime.IsZero() {
+			summary.LastTransitionTime = time.Now()
+		}
+
 		s.summary = summary
 		s.summary.Count = 1
 		return


### PR DESCRIPTION
Reverts openshift/insights-operator#588

This was previously reverted in https://github.com/openshift/insights-operator/pull/586.  This should **not** be reintroduced until e2e-metal-ipi-ovn-ipv6 is added to this repo (see https://github.com/openshift/release/pull/26721), and the change is verified to not break it.

Example failure:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv6/1501915647955701760

```
Operator unavailable (null): operator is not reporting conditions
```

