### PR TITLE
Add list of anonymized data points to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ at [docs/gathered-data.md](docs/gathered-data.md)
 The resulting data is packed in `.tar.gz` archive with folder structure indicated in the document. Example of such
 archive is at [docs/insights-archive-sample](docs/insights-archive-sample).
 
+For more information on which data points are anonymized by the Insights
+Operator, please see [this list](docs/anonymized-data.md).
+
 ## Insights Operator Archive
 
 ### Sample IO archive

--- a/docs/anonymized-data.md
+++ b/docs/anonymized-data.md
@@ -1,8 +1,7 @@
 # Anonymized Data
 
-This is an approximate list of data point (Kubernetes/OpenShift resource fields)
-that are anonymized by the Insights Operator. This list is subject to change and
-may not include all anonymized fields.
+This is a list of data points (Kubernetes/OpenShift resource fields) that are
+anonymized by the Insights Operator. This list is subject to change.
 
 - Identity Provider
   - URL

--- a/docs/anonymized-data.md
+++ b/docs/anonymized-data.md
@@ -1,0 +1,82 @@
+# Anonymized Data
+
+This is an approximate list of data point (Kubernetes/OpenShift resource fields)
+that are anonymized by the Insights Operator. This list is subject to change and
+may not include all anonymized fields.
+
+- Identity Provider
+  - URL
+  - BindDN
+  - Hostname
+  - ClientID
+  - HostedDomain
+  - Issuer
+  - DomainName
+- MachineSet
+  - ServiceAccounts
+    - Email
+  - ProviderSpec
+    - ProjectID
+    - Region
+    - Placement.AvailabilityZone
+    - Placement.Region
+- ImageRegistry
+  - HTTP secret
+  - Spec.Storage
+  - Status.Storage
+  - "kubectl.kubernetes.io/last-applied-configuration" Annotation
+- Mutating Webhook Configuration
+  - ClientConfig.CABundle
+- Validating Webhook Configuration
+  - ClientConfig.CABundle
+- Infrastructure
+  - InfrastructureName
+  - PlatformStatus
+    - Region
+    - CloudName
+    - ProjectID
+    - Location
+- Nodes
+  - Non-product-namespaced Annotations
+  - Non-product-namespaced Labels
+  - Region Labels
+  - BootID
+  - SystemUUID
+  - MachineID
+  - Images
+- ImageStreams
+  - Spec.DockerImageRepository
+  - Spec.Tags.From.Name
+  - Status.DockerImageRepository
+  - Status.PublicDockerImageRepository
+  - Status.Tags.DockerImageReference
+- CertificateSigningRequests
+  - Requests
+    - Pkix Name
+    - DNS Names
+    - Email Addresses
+    - IP Addresses
+    - URIs
+  - Certificates
+    - Pkix Name
+- Install Config
+  - SSH key
+  - PullSecret
+  - Base domain
+  - Platform
+    - Region
+    - ProjectID
+    - Datacenter (VSphere)
+    - Username
+    - Password
+    - Cloud (OpenStack)
+- Cluster Version
+  - Spec.Upstream URL
+- Proxy
+  - Spec.HTTPProxy
+  - Spec.HTTPSProxy
+  - Spec.NoProxy
+  - Spec.ReadinessEndpoints
+  - Status.HTTPProxy
+  - Status.HTTPSProxy
+  - Status.NoProxy


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR adds a Markdown document with a list of the majority of anonymized data points (resource fields). This list was compiled by making reverse-searches of the anonymization helper functions, so it is very possible that there are anonymized data points missing from this list. If you are aware of any, please let me know, and I will gladly add them.

There were quite a few trailing spaces at the ends of lines in the README file, which were automatically removed by my formatter, and I feel like there's no good reason to have them there, so I kept it in this PR.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/anonymized-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

N/A

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. This is just a documentation update.

## Changelog
<!-- Was changelog updated? -->

N/A

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

Jira Task: https://issues.redhat.com/browse/CCXDEV-7267