### PR TITLE
Create a new Prometheus metric providing Insights gathering time

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -8,7 +8,7 @@ endpoint: https://cloud.redhat.com/api/ingress/v1/upload
 conditionalGathererEndpoint: https://console.redhat.com/api/gathering/gathering_rules
 impersonate: system:serviceaccount:openshift-insights:gather
 pull_report:
-  endpoint: https://cloud.redhat.com/api/insights-results-aggregator/v1/clusters/%s/report
+  endpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports
   delay: "60s"
   timeout: "3000s"
   min_retry: "30s"

--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -50,9 +50,9 @@ var (
 	// number of pulling report retries
 	retryThreshold = 2
 
-	// insightsAnalysisTime contains time of the last Insights gathering
-	insightsAnalysisTime = metrics.NewGauge(&metrics.GaugeOpts{
-		Name: "insightsclient_analysis_time",
+	// insightsLastGatherTime contains time of the last Insights data gathering
+	insightsLastGatherTime = metrics.NewGauge(&metrics.GaugeOpts{
+		Name: "insightsclient_last_gather_time",
 	})
 )
 
@@ -61,7 +61,7 @@ func init() {
 	if err != nil {
 		fmt.Println(err)
 	}
-	err = legacyregistry.Register(insightsAnalysisTime)
+	err = legacyregistry.Register(insightsLastGatherTime)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -286,8 +286,8 @@ func updateInsightsMetrics(report SmartProxyReport) {
 
 	t, err := time.Parse(time.RFC3339, string(report.Meta.GatheredAt))
 	if err != nil {
-		klog.Errorf("Metric %s not updated. Failed to parse time: %v", insightsAnalysisTime.Name, err)
+		klog.Errorf("Metric %s not updated. Failed to parse time: %v", insightsLastGatherTime.Name, err)
 		return
 	}
-	insightsAnalysisTime.Set(float64(t.Unix()))
+	insightsLastGatherTime.Set(float64(t.Unix()))
 }

--- a/pkg/insights/insightsreport/types.go
+++ b/pkg/insights/insightsreport/types.go
@@ -7,6 +7,7 @@ type Timestamp string
 type ReportResponseMeta struct {
 	Count         int       `json:"count"`
 	LastCheckedAt Timestamp `json:"last_checked_at"`
+	GatheredAt    Timestamp `json:"gathered_at"`
 }
 
 // RuleWithContentResponse represents a single rule in the response of /report endpoint


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This registers new Prometheus metric providing last known time of gathering. This info is obtained from the smart-proxy report and it basically confirms that the data/archive was processed. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
