### PR TITLE
Gather documentation update

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -19,6 +19,7 @@ Params is of type AlertIsFiringConditionParams:
   - alert_name string - name of the firing alert
 
 * Location in archive: conditional/alerts/<alert_name>/api_request_counts.json
+* Id in config: conditional/api_request_counts_of_resource_from_alert
 * Since versions:
   * 4.10+
 
@@ -34,7 +35,7 @@ The following CRDs are gathered:
 The CRD sizes above are in the raw (uncompressed) state.
 
 * Location in archive: config/crd/
-* Id in config: crds
+* Id in config: clusterconfig/crds
 
 
 ## CertificateSigningRequests
@@ -48,7 +49,7 @@ Response see:
     https://docs.openshift.com/container-platform/4.3/rest_api/index.html#certificatesigningrequestlist-v1beta1certificates
 
 * Location in archive: config/certificatesigningrequests/
-* Id in config: certificate_signing_requests
+* Id in config: clusterconfig/certificate_signing_requests
 * Since versions:
   * 4.3.25+
   * 4.4.12+
@@ -64,7 +65,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 * Location in archive: config/authentication/
 * See: docs/insights-archive-sample/config/authentication
-* Id in config: authentication
+* Id in config: clusterconfig/authentication
 
 
 ## ClusterFeatureGates
@@ -76,7 +77,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 * Location in archive: config/featuregate.json
 * See: docs/insights-archive-sample/config/featuregate.json
-* Id in config: feature_gates
+* Id in config: clusterconfig/feature_gates
 
 
 ## ClusterImage
@@ -87,7 +88,7 @@ The Kubernetes api https://github.com/openshift/client-go/blob/master/config/cli
 Response see https://docs.openshift.com/container-platform/latest/rest_api/config_apis/image-config-openshift-io-v1.html#image-config-openshift-io-v1
 
 * Location in archive: config/image.json
-* Id in config: image
+* Id in config: clusterconfig/image
 * Since versions:
   * 4.11+
 
@@ -98,7 +99,7 @@ fetches the image pruner configuration
 
 * Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
 * Location in older versions: config/imagepruner.json
-* Id in config: image_pruners
+* Id in config: clusterconfig/image_pruners
 
 
 ## ClusterImageRegistry
@@ -110,7 +111,7 @@ PersistentVolume definition is gathered
 
 * Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 * Location in older versions: config/imageregistry.json
-* Id in config: image_registries
+* Id in config: clusterconfig/image_registries
 * Since versions:
   * 4.3.40+
   * 4.4.12+
@@ -129,7 +130,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 * Location in archive: config/infrastructure/
 * See: docs/insights-archive-sample/config/infrastructure
-* Id in config: infrastructures
+* Id in config: clusterconfig/infrastructures
 
 
 ## ClusterIngress
@@ -141,7 +142,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 * Location in archive: config/ingress.json
 * See: docs/insights-archive-sample/config/ingress.json
-* Id in config: ingress
+* Id in config: clusterconfig/ingress
 
 
 ## ClusterNetwork
@@ -153,7 +154,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 * Location in archive: config/network/
 * See: docs/insights-archive-sample/config/network
-* Id in config: networks
+* Id in config: clusterconfig/networks
 
 
 ## ClusterOAuth
@@ -165,7 +166,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 * Location in archive: config/oauth/
 * See: docs/insights-archive-sample/config/oauth
-* Id in config: oauths
+* Id in config: clusterconfig/oauths
 
 
 ## ClusterOperatorPodsAndEvents
@@ -184,7 +185,7 @@ information includes:
 * Location of pod container previous logs:
   config/pod/{namespace}/logs/{pod}/{container}_previous.log
 * Location of events in archive: events/
-* Id in config: operators_pods_and_events
+* Id in config: clusterconfig/operators_pods_and_events
 * Spec config for CO resources since versions:
   * 4.6.16+
   * 4.7+
@@ -201,7 +202,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 * Location of operators in archive: config/clusteroperator/
 * Location of operators related resources in older versions: config/clusteroperator/{kind}-{name}
 * See: docs/insights-archive-sample/config/clusteroperator
-* Id in config: operators
+* Id in config: clusterconfig/operators
 * Spec config for CO resources since versions:
   * 4.6.16+
   * 4.7+
@@ -216,7 +217,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 * Location in archive: config/proxy.json
 * See: docs/insights-archive-sample/config/proxy.json
-* Id in config: proxies
+* Id in config: clusterconfig/proxies
 
 
 ## ClusterVersion
@@ -232,7 +233,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 * Location of events in archive: events/
 * Location of cluster ID: config/id
 * See: docs/insights-archive-sample/config/id
-* Id in config: version
+* Id in config: clusterconfig/version
 
 
 ## ConfigMaps
@@ -251,7 +252,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 * Location in archive: config/configmaps/{namespace-name}/{configmap-name}/
 * Location in older versions: config/configmaps/{configmap-name}/
 * See: docs/insights-archive-sample/config/configmaps
-* Id in config: config_maps
+* Id in config: clusterconfig/config_maps
 * Since versions:
   * 4.3.25+
   * 4.4.6+
@@ -269,7 +270,7 @@ collects essential information about running containers.
 Specifically, the age of pods, the set of running images and the container names are collected.
 
 * Location in archive: config/running_containers.json
-* Id in config: container_images
+* Id in config: clusterconfig/container_images
 * Since versions:
   * 4.5.33+
   * 4.6.16+
@@ -286,7 +287,7 @@ Response see:
    https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
 
 * Location in archive: config/containerruntimeconfigs/
-* Id in config: container_runtime_configs
+* Id in config: clusterconfig/container_runtime_configs
 * Since versions:
   * 4.6.18+
   * 4.7+
@@ -297,7 +298,7 @@ Response see:
 collects either current or previous containers logs for pods firing one of the configured alerts.
 
 * Location in archive: conditional/namespaces/<namespace>/pods/<pod>/containers/<container>/<logs|logs-previous>/last-<tail length>-lines.log
-* Id in config: containers_logs
+* Id in config: conditional/containers_logs
 * Since versions:
   * 4.10+
 
@@ -306,7 +307,7 @@ collects either current or previous containers logs for pods firing one of the c
 
 collects CostManagementMetricsConfigs definitions.
 * Location in archive: config/cost_management_metrics_configs/<name>.json
-* Id in config: cost_management_metrics_configs
+* Id in config: clusterconfig/cost_management_metrics_configs
 * Since versions:
   * 4.8.27+
   * 4.9.13+
@@ -321,7 +322,7 @@ filtered to only include those with a deployment_validation_operator_ prefix.
 
 * Location in archive: config/dvo_metrics
 * See: docs/insights-archive-sample/config/dvo_metrics
-* Id in config: dvo_metrics
+* Id in config: clusterconfig/dvo_metrics
 * Since version:
   - 4.10
 
@@ -334,7 +335,7 @@ The Kubernetes api https://github.com/openshift/client-go/blob/master/network/cl
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#hostsubnet-v1-network-openshift-io
 
 * Location in archive: config/hostsubnet/
-* Id in config: host_subnets
+* Id in config: clusterconfig/host_subnets
 * Since versions:
   * 4.4.29+
   * 4.5.15+
@@ -351,6 +352,7 @@ API reference:
   https://docs.openshift.com/container-platform/4.7/rest_api/image_apis/imagestream-image-openshift-io-v1.html#apisimage-openshift-iov1namespacesnamespaceimagestreams
 
 * Location in archive: conditional/namespaces/{namespace}/imagestreams/{name}
+* Id in config: conditional/image_streams_of_namespace
 * Since versions:
   * 4.9+
 
@@ -365,7 +367,7 @@ It also collects Total number of all installplans and all non-unique installplan
 The Operators-Framework api https://github.com/operator-framework/api/blob/master/pkg/operators/v1alpha1/installplan_types.go#L26
 
 * Location in archive: config/installplans/
-* Id in config: install_plans
+* Id in config: clusterconfig/install_plans
 * Since versions:
   * 4.5.33+
   * 4.6.16+
@@ -378,7 +380,7 @@ collects maximum of 5 jaegers.jaegertracing.io custom resources
 installed in the cluster
 
 * Location in archive: config/jaegertracing.io/
-* Id in config: jaegers
+* Id in config: clusterconfig/jaegers
 * Since versions:
   * 4.10+
 
@@ -412,6 +414,7 @@ Response see:
          https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 
 * Location in archive: conditional/namespaces/{namespace}/pods/{pod_name}/containers/{container_name}/logs/last-{n}-lines.log
+* Id in config: conditional/logs_of_namespace
 * Since versions:
   * 4.9+
 
@@ -426,7 +429,7 @@ Response see:
       https://docs.openshift.com/container-platform/4.7/rest_api/autoscale_apis/machineautoscaler-autoscaling-openshift-io-v1beta1.html#machineautoscaler-autoscaling-openshift-io-v1beta1
 
 * Location in archive: config/machineautoscalers/{namespace}/{machineautoscaler-name}.json
-* Id in config: machine_autoscalers
+* Id in config: clusterconfig/machine_autoscalers
 * Since versions:
   * 4.8+
 
@@ -441,7 +444,7 @@ Response see:
     https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.html
 
 * Location in archive: config/machineconfigpools/
-* Id in config: machine_config_pools
+* Id in config: clusterconfig/machine_config_pools
 * Since versions:
   * 4.5.33+
   * 4.6+
@@ -456,7 +459,7 @@ collects MachineConfigs definitions. Following data is intentionally removed fro
 Response see https://docs.openshift.com/container-platform/4.7/rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.html
 
 * Location in archive: config/machineconfigs/<name>.json
-* Id in config: machine_configs
+* Id in config: clusterconfig/machine_configs
 * Since versions:
   * 4.8.5+
   * 4.9+
@@ -472,7 +475,7 @@ Response see:
       https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machinehealthcheck-v1beta1-machine-openshift-io
 
 * Location in archive: config/machinehealthchecks
-* Id in config: machine_healthchecks
+* Id in config: clusterconfig/machine_healthchecks
 * Since versions:
   * 4.8+
 
@@ -487,7 +490,7 @@ Response see:
       https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machineset-v1beta1-machine-openshift-io
 
 * Location in archive: machinesets/
-* Id in config: machine_sets
+* Id in config: clusterconfig/machine_sets
 * Since versions:
   * 4.4.29+
   * 4.5.15+
@@ -509,7 +512,7 @@ Gathered metrics:
 
 * Location in archive: config/metrics
 * See: docs/insights-archive-sample/config/metrics
-* Id in config: metrics
+* Id in config: clusterconfig/metrics
 * Since version:
   - "etcd_object_counts": 4.3+
   - "cluster_installer": 4.3+
@@ -527,6 +530,7 @@ Relevant OpenShift API docs:
   - https://docs.openshift.com/container-platform/4.8/rest_api/extension_apis/mutatingwebhookconfiguration-admissionregistration-k8s-io-v1.html
 
 * Location in archive: config/mutatingwebhookconfigurations
+* Id in config: clusterconfig/mutating_webhook_configurations
 * Since versions:
   * 4.7.40+
   * 4.8.24+
@@ -542,7 +546,7 @@ The Kubernetes api https://github.com/openshift/client-go/blob/master/network/cl
 Response is an array of netNamespaces. Netnamespace contains Name, EgressIPs and NetID attributes.
 
 * Location in archive: config/netnamespaces
-* Id in config: netnamespaces
+* Id in config: clusterconfig/netnamespaces
 * Since versions:
   * 4.6.20+
   * 4.7+
@@ -556,7 +560,7 @@ Response see https://docs.openshift.com/container-platform/4.9/rest_api/node_api
 
 * Location in archive: config/nodes/logs/
 * See: docs/insights-archive-sample/config/nodes/logs
-* Id in config: node_logs
+* Id in config: clusterconfig/node_logs
 * Since versions:
   * 4.10+
 
@@ -569,7 +573,7 @@ The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernete
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core
 
 * Location in archive: config/node/
-* Id in config: nodes
+* Id in config: clusterconfig/nodes
 
 
 ## OLMOperators
@@ -582,7 +586,7 @@ Each OLM operator (in the list) contains following data:
 
 * See: docs/insights-archive-sample/config/olm_operators
 * Location of in archive: config/olm_operators
-* Id in config: olm_operators
+* Id in config: clusterconfig/olm_operators
 * Since versions:
   * 4.7+
 
@@ -599,6 +603,7 @@ Response see:
       https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 
 * Location in archive: config/pod/{namespace-name}/logs/{pod-name}/errors.log
+* Id in config: clusterconfig/openshift_apiserver_operator_logs
 
 
 ## OpenshiftAuthenticationLogs
@@ -612,6 +617,7 @@ Response see:
         https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 
 * Location in archive: config/pod/openshift-authentication/logs/{pod-name}/errors.log
+* Id in config: clusterconfig/openshift_authentication_logs
 * Since versions:
   * 4.7+
 
@@ -625,6 +631,7 @@ API Reference:
   https://github.com/openshift/cluster-logging-operator/blob/master/pkg/apis/logging/v1/clusterlogging_types.go
 
 * Location in archive: config/logging/<namespace>/<name>.json
+* Id in config: clusterconfig/openshift_logging
 * Since versions:
   * 4.9+
 
@@ -649,6 +656,7 @@ Response see:
        https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 
 * Location in archive: config/pod/openshift-sdn/logs/{pod-name}/errors.log
+* Id in config: clusterconfig/openshift_sdn_controller_logs
 * Since versions:
   * 4.6.21+
   * 4.7+
@@ -668,6 +676,7 @@ Response see:
          https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 
 * Location in archive: config/pod/openshift-sdn/logs/{pod-name}/errors.log
+* Id in config: clusterconfig/openshift_sdn_logs
 * Since versions:
   * 4.6.19+
   * 4.7+
@@ -684,7 +693,7 @@ Resource API: podnetworkconnectivitychecks.controlplane.operator.openshift.io/v1
 Docs for relevant types: https://pkg.go.dev/github.com/openshift/api/operatorcontrolplane/v1alpha1
 
 * Location in archive: config/podnetworkconnectivitychecks.json
-* Id in config: pod_network_connectivity_checks
+* Id in config: clusterconfig/pod_network_connectivity_checks
 * Since versions:
   * 4.8+
 
@@ -694,6 +703,7 @@ Docs for relevant types: https://pkg.go.dev/github.com/openshift/api/operatorcon
 collects pod definition from pods that are firing one of the configured alerts.
 
 * Location in archive: conditional/namespaces/<namespace>/pods/<pod>/<pod>.json
+* Id in config: conditional/pod_definition
 * Since versions:
   * 4.11+
 
@@ -707,7 +717,7 @@ Response see https://docs.okd.io/latest/rest_api/policy_apis/poddisruptionbudget
 
 * Location in archive: config/pdbs/
 * See: docs/insights-archive-sample/config/pdbs
-* Id in config: pdbs
+* Id in config: clusterconfig/pdbs
 * Since versions:
   * 4.4.30+
   * 4.5.34+
@@ -722,7 +732,7 @@ The Kubernetes API https://github.com/kubernetes/client-go/blob/v12.0.0/kubernet
 
 * Location in archive: config/psp_names.json
 * See: docs/insights-archive-sample/config/psp_names.json
-* Id in config: psps
+* Id in config: clusterconfig/psps
 * Since versions:
   * 4.7.33+
   * 4.8.12+
@@ -741,6 +751,7 @@ Relevant OpenShift API docs:
   - https://pkg.go.dev/github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
 
 * Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
+* Id in config: clusterconfig/sap_config
 * Since versions:
   * 4.6.20+
   * 4.7+
@@ -751,6 +762,7 @@ Relevant OpenShift API docs:
 collects `datahubs.installers.datahub.sap.com` resources from SAP/SDI clusters.
 
 * Location in archive: customresources/installers.datahub.sap.com/datahubs/<namespace>/<name>.json
+* Id in config: clusterconfig/sap_datahubs
 * Since versions:
   * 4.7.5+
   * 4.8+
@@ -770,6 +782,7 @@ Relevant Kubernetes API docs:
   - https://pkg.go.dev/k8s.io/client-go/dynamic
 
 * Location in archive: config/pod/{namespace}/{pod-name}.json
+* Id in config: clusterconfig/sap_pods
 * Since versions:
   * 4.6.24+
   * 4.7.5+
@@ -790,6 +803,7 @@ Response see:
        https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 
 * Location in archive: config/pod/{namespace}/logs/{pod-name}/errors.log
+* Id in config: clusterconfig/sap_license_management_logs
 * Since versions:
   * 4.6.25+
   * 4.7.5+
@@ -808,6 +822,7 @@ Response see:
         https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 
 * Location in archive: config/pod/openshift-kube-scheduler/logs/{pod-name}/messages.log
+* Id in config: clusterconfig/scheduler_logs
 * Since versions:
   * 4.10+
 
@@ -834,7 +849,7 @@ Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.ht
 
 * Location of serviceaccounts in archive: config/serviceaccounts
 * See: docs/insights-archive-sample/config/serviceaccounts
-* Id in config: service_accounts
+* Id in config: clusterconfig/service_accounts
 * Since versions:
   * 4.5.34+
   * 4.6.20+
@@ -847,7 +862,7 @@ gathers the alerts that have been silenced.
 
 * Location in archive: config/silenced_alerts
 * See: docs/insights-archive-sample/config/silenced_alerts
-* Id in config: silenced_alerts
+* Id in config: clusterconfig/silenced_alerts
 * Since version:
   * 4.10+
 
@@ -858,7 +873,7 @@ gathers the Prometheus TSDB status.
 
 * Location in archive: config/tsdb
 * See: docs/insights-archive-sample/config/metrics
-* Id in config: tsdb_status
+* Id in config: clusterconfig/tsdb_status
 * Since version:
    * 4.10+
 
@@ -870,6 +885,7 @@ Relevant OpenShift API docs:
   - https://docs.openshift.com/container-platform/4.8/rest_api/extension_apis/validatingwebhookconfiguration-admissionregistration-k8s-io-v1.html
 
 * Location in archive: config/validatingwebhookconfigurations
+* Id in config: clusterconfig/validating_webhook_configurations
 * Since versions:
   * 4.7.40+
   * 4.8.24+
@@ -883,7 +899,7 @@ collects summarized info about the workloads on a cluster
 in a generic fashion
 
 * Location in archive: config/workload_info
-* Id in config: workload_info
+* Id in config: workloads/workload_info
 * Since versions:
   * 4.8+
 

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -398,6 +398,7 @@ Response see:
 
 * Location in archive: config/pod/openshift-kube-controller-manager/logs/{pod-name}/errors.log
 * Since versions:
+  * 4.10.6
   * 4.11+
 
 

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -48,8 +48,6 @@ func Test_Controller_Run(t *testing.T) {
 	// 2 sec delay, 5 gatherers + metadata
 	stopCh = make(chan struct{})
 	go c.Run(stopCh, 2*time.Second)
-	time.Sleep(100 * time.Millisecond)
-	assert.Len(t, mockRecorder.Records, 0)
 	time.Sleep(2 * time.Second)
 	stopCh <- struct{}{}
 	assert.Len(t, mockRecorder.Records, 6)
@@ -74,10 +72,8 @@ func Test_Controller_periodicTrigger(t *testing.T) {
 	c.configurator.Config().Interval = 1 * time.Second
 	stopCh := make(chan struct{})
 	go c.periodicTrigger(stopCh)
-	time.Sleep(1100 * time.Millisecond)
-	assert.Len(t, mockRecorder.Records, 6)
-	// 2. interval
-	time.Sleep(1100 * time.Millisecond)
+	// 2 intervals
+	time.Sleep(2200 * time.Millisecond)
 	stopCh <- struct{}{}
 	assert.Len(t, mockRecorder.Records, 12)
 	mockRecorder.Reset()

--- a/pkg/gatherers/clusterconfig/authentications.go
+++ b/pkg/gatherers/clusterconfig/authentications.go
@@ -18,7 +18,7 @@ import (
 //
 // * Location in archive: config/authentication/
 // * See: docs/insights-archive-sample/config/authentication
-// * Id in config: authentication
+// * Id in config: clusterconfig/authentication
 func (g *Gatherer) GatherClusterAuthentication(ctx context.Context) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/certificate_signing_requests.go
+++ b/pkg/gatherers/clusterconfig/certificate_signing_requests.go
@@ -33,7 +33,7 @@ const csrGatherLimit = 5000
 //     https://docs.openshift.com/container-platform/4.3/rest_api/index.html#certificatesigningrequestlist-v1beta1certificates
 //
 // * Location in archive: config/certificatesigningrequests/
-// * Id in config: certificate_signing_requests
+// * Id in config: clusterconfig/certificate_signing_requests
 // * Since versions:
 //   * 4.3.25+
 //   * 4.4.12+

--- a/pkg/gatherers/clusterconfig/config_maps.go
+++ b/pkg/gatherers/clusterconfig/config_maps.go
@@ -29,7 +29,7 @@ import (
 // * Location in archive: config/configmaps/{namespace-name}/{configmap-name}/
 // * Location in older versions: config/configmaps/{configmap-name}/
 // * See: docs/insights-archive-sample/config/configmaps
-// * Id in config: config_maps
+// * Id in config: clusterconfig/config_maps
 // * Since versions:
 //   * 4.3.25+
 //   * 4.4.6+

--- a/pkg/gatherers/clusterconfig/container_images.go
+++ b/pkg/gatherers/clusterconfig/container_images.go
@@ -34,7 +34,7 @@ const (
 // Specifically, the age of pods, the set of running images and the container names are collected.
 //
 // * Location in archive: config/running_containers.json
-// * Id in config: container_images
+// * Id in config: clusterconfig/container_images
 // * Since versions:
 //   * 4.5.33+
 //   * 4.6.16+

--- a/pkg/gatherers/clusterconfig/container_runtime_configs.go
+++ b/pkg/gatherers/clusterconfig/container_runtime_configs.go
@@ -21,7 +21,7 @@ import (
 //    https://docs.okd.io/latest/rest_api/machine_apis/containerruntimeconfig-machineconfiguration-openshift-io-v1.html
 //
 // * Location in archive: config/containerruntimeconfigs/
-// * Id in config: container_runtime_configs
+// * Id in config: clusterconfig/container_runtime_configs
 // * Since versions:
 //   * 4.6.18+
 //   * 4.7+

--- a/pkg/gatherers/clusterconfig/cost_management_metrics_configs.go
+++ b/pkg/gatherers/clusterconfig/cost_management_metrics_configs.go
@@ -13,7 +13,7 @@ import (
 
 // GatherCostManagementMetricsConfigs collects CostManagementMetricsConfigs definitions.
 // * Location in archive: config/cost_management_metrics_configs/<name>.json
-// * Id in config: cost_management_metrics_configs
+// * Id in config: clusterconfig/cost_management_metrics_configs
 // * Since versions:
 //   * 4.8.27+
 //   * 4.9.13+

--- a/pkg/gatherers/clusterconfig/custom_resource_definitions.go
+++ b/pkg/gatherers/clusterconfig/custom_resource_definitions.go
@@ -21,7 +21,7 @@ import (
 // The CRD sizes above are in the raw (uncompressed) state.
 //
 // * Location in archive: config/crd/
-// * Id in config: crds
+// * Id in config: clusterconfig/crds
 func (g *Gatherer) GatherCRD(ctx context.Context) ([]record.Record, []error) {
 	crdClient, err := apixv1.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/dvo_metrics.go
+++ b/pkg/gatherers/clusterconfig/dvo_metrics.go
@@ -38,7 +38,7 @@ var (
 //
 // * Location in archive: config/dvo_metrics
 // * See: docs/insights-archive-sample/config/dvo_metrics
-// * Id in config: dvo_metrics
+// * Id in config: clusterconfig/dvo_metrics
 // * Since version:
 //   - 4.10
 func (g *Gatherer) GatherDVOMetrics(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/feature_gates.go
+++ b/pkg/gatherers/clusterconfig/feature_gates.go
@@ -18,7 +18,7 @@ import (
 //
 // * Location in archive: config/featuregate.json
 // * See: docs/insights-archive-sample/config/featuregate.json
-// * Id in config: feature_gates
+// * Id in config: clusterconfig/feature_gates
 func (g *Gatherer) GatherClusterFeatureGates(ctx context.Context) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/host_subnets.go
+++ b/pkg/gatherers/clusterconfig/host_subnets.go
@@ -17,7 +17,7 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#hostsubnet-v1-network-openshift-io
 //
 // * Location in archive: config/hostsubnet/
-// * Id in config: host_subnets
+// * Id in config: clusterconfig/host_subnets
 // * Since versions:
 //   * 4.4.29+
 //   * 4.5.15+

--- a/pkg/gatherers/clusterconfig/image.go
+++ b/pkg/gatherers/clusterconfig/image.go
@@ -16,7 +16,7 @@ import (
 // Response see https://docs.openshift.com/container-platform/latest/rest_api/config_apis/image-config-openshift-io-v1.html#image-config-openshift-io-v1
 //
 // * Location in archive: config/image.json
-// * Id in config: image
+// * Id in config: clusterconfig/image
 // * Since versions:
 //   * 4.11+
 func (g *Gatherer) GatherClusterImage(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/image_pruners.go
+++ b/pkg/gatherers/clusterconfig/image_pruners.go
@@ -18,7 +18,7 @@ import (
 //
 // * Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/imagepruner/cluster.json
 // * Location in older versions: config/imagepruner.json
-// * Id in config: image_pruners
+// * Id in config: clusterconfig/image_pruners
 func (g *Gatherer) GatherClusterImagePruner(ctx context.Context) ([]record.Record, []error) {
 	registryClient, err := imageregistryv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/image_registries.go
+++ b/pkg/gatherers/clusterconfig/image_registries.go
@@ -28,7 +28,7 @@ var lacAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
 //
 // * Location in archive: config/clusteroperator/imageregistry.operator.openshift.io/config/cluster.json
 // * Location in older versions: config/imageregistry.json
-// * Id in config: image_registries
+// * Id in config: clusterconfig/image_registries
 // * Since versions:
 //   * 4.3.40+
 //   * 4.4.12+

--- a/pkg/gatherers/clusterconfig/infrastructures.go
+++ b/pkg/gatherers/clusterconfig/infrastructures.go
@@ -19,7 +19,7 @@ import (
 //
 // * Location in archive: config/infrastructure/
 // * See: docs/insights-archive-sample/config/infrastructure
-// * Id in config: infrastructures
+// * Id in config: clusterconfig/infrastructures
 func (g *Gatherer) GatherClusterInfrastructure(ctx context.Context) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/ingresses.go
+++ b/pkg/gatherers/clusterconfig/ingresses.go
@@ -18,7 +18,7 @@ import (
 //
 // * Location in archive: config/ingress.json
 // * See: docs/insights-archive-sample/config/ingress.json
-// * Id in config: ingress
+// * Id in config: clusterconfig/ingress
 func (g *Gatherer) GatherClusterIngress(ctx context.Context) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/install_plans.go
+++ b/pkg/gatherers/clusterconfig/install_plans.go
@@ -44,7 +44,7 @@ type InstallPlanAnonymizer struct {
 // The Operators-Framework api https://github.com/operator-framework/api/blob/master/pkg/operators/v1alpha1/installplan_types.go#L26
 //
 // * Location in archive: config/installplans/
-// * Id in config: install_plans
+// * Id in config: clusterconfig/install_plans
 // * Since versions:
 //   * 4.5.33+
 //   * 4.6.16+

--- a/pkg/gatherers/clusterconfig/jaeger_cr.go
+++ b/pkg/gatherers/clusterconfig/jaeger_cr.go
@@ -17,7 +17,7 @@ var limit = 5
 // installed in the cluster
 //
 // * Location in archive: config/jaegertracing.io/
-// * Id in config: jaegers
+// * Id in config: clusterconfig/jaegers
 // * Since versions:
 //   * 4.10+
 func (g *Gatherer) GatherJaegerCR(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/kube_controller_manager_logs.go
+++ b/pkg/gatherers/clusterconfig/kube_controller_manager_logs.go
@@ -21,6 +21,7 @@ import (
 //
 // * Location in archive: config/pod/openshift-kube-controller-manager/logs/{pod-name}/errors.log
 // * Since versions:
+//   * 4.10.6
 //   * 4.11+
 func (g *Gatherer) GatherKubeControllerManagerLogs(ctx context.Context) ([]record.Record, []error) {
 	containersFilter := common.LogContainersFilter{

--- a/pkg/gatherers/clusterconfig/machine_autoscaler.go
+++ b/pkg/gatherers/clusterconfig/machine_autoscaler.go
@@ -19,7 +19,7 @@ import (
 //       https://docs.openshift.com/container-platform/4.7/rest_api/autoscale_apis/machineautoscaler-autoscaling-openshift-io-v1beta1.html#machineautoscaler-autoscaling-openshift-io-v1beta1
 //
 // * Location in archive: config/machineautoscalers/{namespace}/{machineautoscaler-name}.json
-// * Id in config: machine_autoscalers
+// * Id in config: clusterconfig/machine_autoscalers
 // * Since versions:
 //   * 4.8+
 func (g *Gatherer) GatherMachineAutoscalers(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/machine_config_pools.go
+++ b/pkg/gatherers/clusterconfig/machine_config_pools.go
@@ -21,7 +21,7 @@ import (
 //     https://docs.okd.io/latest/rest_api/machine_apis/machineconfigpool-machineconfiguration-openshift-io-v1.html
 //
 // * Location in archive: config/machineconfigpools/
-// * Id in config: machine_config_pools
+// * Id in config: clusterconfig/machine_config_pools
 // * Since versions:
 //   * 4.5.33+
 //   * 4.6+

--- a/pkg/gatherers/clusterconfig/machine_configs.go
+++ b/pkg/gatherers/clusterconfig/machine_configs.go
@@ -20,7 +20,7 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.7/rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.html
 //
 // * Location in archive: config/machineconfigs/<name>.json
-// * Id in config: machine_configs
+// * Id in config: clusterconfig/machine_configs
 // * Since versions:
 //   * 4.8.5+
 //   * 4.9+

--- a/pkg/gatherers/clusterconfig/machine_healthcheck.go
+++ b/pkg/gatherers/clusterconfig/machine_healthcheck.go
@@ -19,7 +19,7 @@ import (
 //       https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machinehealthcheck-v1beta1-machine-openshift-io
 //
 // * Location in archive: config/machinehealthchecks
-// * Id in config: machine_healthchecks
+// * Id in config: clusterconfig/machine_healthchecks
 // * Since versions:
 //   * 4.8+
 func (g *Gatherer) GatherMachineHealthCheck(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/machine_sets.go
+++ b/pkg/gatherers/clusterconfig/machine_sets.go
@@ -23,7 +23,7 @@ import (
 //       https://docs.openshift.com/container-platform/4.3/rest_api/index.html#machineset-v1beta1-machine-openshift-io
 //
 // * Location in archive: machinesets/
-// * Id in config: machine_sets
+// * Id in config: clusterconfig/machine_sets
 // * Since versions:
 //   * 4.4.29+
 //   * 4.5.15+

--- a/pkg/gatherers/clusterconfig/mutatingwebhookconfigurations.go
+++ b/pkg/gatherers/clusterconfig/mutatingwebhookconfigurations.go
@@ -19,6 +19,7 @@ import (
 //   - https://docs.openshift.com/container-platform/4.8/rest_api/extension_apis/mutatingwebhookconfiguration-admissionregistration-k8s-io-v1.html
 //
 // * Location in archive: config/mutatingwebhookconfigurations
+// * Id in config: clusterconfig/mutating_webhook_configurations
 // * Since versions:
 //   * 4.7.40+
 //   * 4.8.24+

--- a/pkg/gatherers/clusterconfig/netnamespaces.go
+++ b/pkg/gatherers/clusterconfig/netnamespaces.go
@@ -23,7 +23,7 @@ type netNamespace struct {
 // Response is an array of netNamespaces. Netnamespace contains Name, EgressIPs and NetID attributes.
 //
 // * Location in archive: config/netnamespaces
-// * Id in config: netnamespaces
+// * Id in config: clusterconfig/netnamespaces
 // * Since versions:
 //   * 4.6.20+
 //   * 4.7+

--- a/pkg/gatherers/clusterconfig/networks.go
+++ b/pkg/gatherers/clusterconfig/networks.go
@@ -18,7 +18,7 @@ import (
 //
 // * Location in archive: config/network/
 // * See: docs/insights-archive-sample/config/network
-// * Id in config: networks
+// * Id in config: clusterconfig/networks
 func (g *Gatherer) GatherClusterNetwork(ctx context.Context) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/node_logs.go
+++ b/pkg/gatherers/clusterconfig/node_logs.go
@@ -25,7 +25,7 @@ import (
 //
 // * Location in archive: config/nodes/logs/
 // * See: docs/insights-archive-sample/config/nodes/logs
-// * Id in config: node_logs
+// * Id in config: clusterconfig/node_logs
 // * Since versions:
 //   * 4.10+
 func (g *Gatherer) GatherNodeLogs(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/nodes.go
+++ b/pkg/gatherers/clusterconfig/nodes.go
@@ -20,7 +20,7 @@ import (
 // Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#nodelist-v1core
 //
 // * Location in archive: config/node/
-// * Id in config: nodes
+// * Id in config: clusterconfig/nodes
 func (g *Gatherer) GatherNodes(ctx context.Context) ([]record.Record, []error) {
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/oauths.go
+++ b/pkg/gatherers/clusterconfig/oauths.go
@@ -18,7 +18,7 @@ import (
 //
 // * Location in archive: config/oauth/
 // * See: docs/insights-archive-sample/config/oauth
-// * Id in config: oauths
+// * Id in config: clusterconfig/oauths
 func (g *Gatherer) GatherClusterOAuth(ctx context.Context) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/olm_operators.go
+++ b/pkg/gatherers/clusterconfig/olm_operators.go
@@ -44,7 +44,7 @@ type csvRef struct {
 //
 // * See: docs/insights-archive-sample/config/olm_operators
 // * Location of in archive: config/olm_operators
-// * Id in config: olm_operators
+// * Id in config: clusterconfig/olm_operators
 // * Since versions:
 //   * 4.7+
 func (g *Gatherer) GatherOLMOperators(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/openshift_apiserver_operator_logs.go
+++ b/pkg/gatherers/clusterconfig/openshift_apiserver_operator_logs.go
@@ -19,6 +19,7 @@ import (
 //       https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 //
 // * Location in archive: config/pod/{namespace-name}/logs/{pod-name}/errors.log
+// * Id in config: clusterconfig/openshift_apiserver_operator_logs
 func (g *Gatherer) GatherOpenShiftAPIServerOperatorLogs(ctx context.Context) ([]record.Record, []error) {
 	containersFilter := common.LogContainersFilter{
 		Namespace:     "openshift-apiserver-operator",

--- a/pkg/gatherers/clusterconfig/openshift_authentication_logs.go
+++ b/pkg/gatherers/clusterconfig/openshift_authentication_logs.go
@@ -18,6 +18,7 @@ import (
 //         https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 //
 // * Location in archive: config/pod/openshift-authentication/logs/{pod-name}/errors.log
+// * Id in config: clusterconfig/openshift_authentication_logs
 // * Since versions:
 //   * 4.7+
 func (g *Gatherer) GatherOpenshiftAuthenticationLogs(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/openshift_logging.go
+++ b/pkg/gatherers/clusterconfig/openshift_logging.go
@@ -19,6 +19,7 @@ import (
 //   https://github.com/openshift/cluster-logging-operator/blob/master/pkg/apis/logging/v1/clusterlogging_types.go
 //
 // * Location in archive: config/logging/<namespace>/<name>.json
+// * Id in config: clusterconfig/openshift_logging
 // * Since versions:
 //   * 4.9+
 func (g *Gatherer) GatherOpenshiftLogging(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/openshift_sdn_controller_logs.go
+++ b/pkg/gatherers/clusterconfig/openshift_sdn_controller_logs.go
@@ -28,6 +28,7 @@ import (
 //        https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 //
 // * Location in archive: config/pod/openshift-sdn/logs/{pod-name}/errors.log
+// * Id in config: clusterconfig/openshift_sdn_controller_logs
 // * Since versions:
 //   * 4.6.21+
 //   * 4.7+

--- a/pkg/gatherers/clusterconfig/openshift_sdn_logs.go
+++ b/pkg/gatherers/clusterconfig/openshift_sdn_logs.go
@@ -22,6 +22,7 @@ import (
 //          https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 //
 // * Location in archive: config/pod/openshift-sdn/logs/{pod-name}/errors.log
+// * Id in config: clusterconfig/openshift_sdn_logs
 // * Since versions:
 //   * 4.6.19+
 //   * 4.7+

--- a/pkg/gatherers/clusterconfig/operators.go
+++ b/pkg/gatherers/clusterconfig/operators.go
@@ -43,7 +43,7 @@ type clusterOperatorResource struct {
 // * Location of operators in archive: config/clusteroperator/
 // * Location of operators related resources in older versions: config/clusteroperator/{kind}-{name}
 // * See: docs/insights-archive-sample/config/clusteroperator
-// * Id in config: operators
+// * Id in config: clusterconfig/operators
 // * Spec config for CO resources since versions:
 //   * 4.6.16+
 //   * 4.7+

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -57,7 +57,7 @@ var stackTraceRegex = regexp.MustCompile(`\.go:\d+\s\+0x`)
 // * Location of pod container previous logs:
 //   config/pod/{namespace}/logs/{pod}/{container}_previous.log
 // * Location of events in archive: events/
-// * Id in config: operators_pods_and_events
+// * Id in config: clusterconfig/operators_pods_and_events
 // * Spec config for CO resources since versions:
 //   * 4.6.16+
 //   * 4.7+

--- a/pkg/gatherers/clusterconfig/pod_disruption_budgets.go
+++ b/pkg/gatherers/clusterconfig/pod_disruption_budgets.go
@@ -21,7 +21,7 @@ const (
 //
 // * Location in archive: config/pdbs/
 // * See: docs/insights-archive-sample/config/pdbs
-// * Id in config: pdbs
+// * Id in config: clusterconfig/pdbs
 // * Since versions:
 //   * 4.4.30+
 //   * 4.5.34+

--- a/pkg/gatherers/clusterconfig/pod_network_connectivity_checks.go
+++ b/pkg/gatherers/clusterconfig/pod_network_connectivity_checks.go
@@ -21,7 +21,7 @@ import (
 // Docs for relevant types: https://pkg.go.dev/github.com/openshift/api/operatorcontrolplane/v1alpha1
 //
 // * Location in archive: config/podnetworkconnectivitychecks.json
-// * Id in config: pod_network_connectivity_checks
+// * Id in config: clusterconfig/pod_network_connectivity_checks
 // * Since versions:
 //   * 4.8+
 func (g *Gatherer) GatherPNCC(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/pod_security_policies.go
+++ b/pkg/gatherers/clusterconfig/pod_security_policies.go
@@ -14,7 +14,7 @@ import (
 //
 // * Location in archive: config/psp_names.json
 // * See: docs/insights-archive-sample/config/psp_names.json
-// * Id in config: psps
+// * Id in config: clusterconfig/psps
 // * Since versions:
 //   * 4.7.33+
 //   * 4.8.12+

--- a/pkg/gatherers/clusterconfig/proxies.go
+++ b/pkg/gatherers/clusterconfig/proxies.go
@@ -19,7 +19,7 @@ import (
 //
 // * Location in archive: config/proxy.json
 // * See: docs/insights-archive-sample/config/proxy.json
-// * Id in config: proxies
+// * Id in config: clusterconfig/proxies
 func (g *Gatherer) GatherClusterProxy(ctx context.Context) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/recent_metrics.go
+++ b/pkg/gatherers/clusterconfig/recent_metrics.go
@@ -34,7 +34,7 @@ const (
 //
 // * Location in archive: config/metrics
 // * See: docs/insights-archive-sample/config/metrics
-// * Id in config: metrics
+// * Id in config: clusterconfig/metrics
 // * Since version:
 //   - "etcd_object_counts": 4.3+
 //   - "cluster_installer": 4.3+

--- a/pkg/gatherers/clusterconfig/sap_config.go
+++ b/pkg/gatherers/clusterconfig/sap_config.go
@@ -24,6 +24,7 @@ import (
 //   - https://pkg.go.dev/github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
 //
 // * Location in archive: config/securitycontentconstraint/, config/clusterrolebinding/
+// * Id in config: clusterconfig/sap_config
 // * Since versions:
 //   * 4.6.20+
 //   * 4.7+

--- a/pkg/gatherers/clusterconfig/sap_datahubs.go
+++ b/pkg/gatherers/clusterconfig/sap_datahubs.go
@@ -14,6 +14,7 @@ import (
 // GatherSAPDatahubs collects `datahubs.installers.datahub.sap.com` resources from SAP/SDI clusters.
 //
 // * Location in archive: customresources/installers.datahub.sap.com/datahubs/<namespace>/<name>.json
+// * Id in config: clusterconfig/sap_datahubs
 // * Since versions:
 //   * 4.7.5+
 //   * 4.8+

--- a/pkg/gatherers/clusterconfig/sap_pods.go
+++ b/pkg/gatherers/clusterconfig/sap_pods.go
@@ -28,6 +28,7 @@ import (
 //   - https://pkg.go.dev/k8s.io/client-go/dynamic
 //
 // * Location in archive: config/pod/{namespace}/{pod-name}.json
+// * Id in config: clusterconfig/sap_pods
 // * Since versions:
 //   * 4.6.24+
 //   * 4.7.5+

--- a/pkg/gatherers/clusterconfig/sap_vsystem_iptables_logs.go
+++ b/pkg/gatherers/clusterconfig/sap_vsystem_iptables_logs.go
@@ -27,6 +27,7 @@ import (
 //        https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 //
 // * Location in archive: config/pod/{namespace}/logs/{pod-name}/errors.log
+// * Id in config: clusterconfig/sap_license_management_logs
 // * Since versions:
 //   * 4.6.25+
 //   * 4.7.5+

--- a/pkg/gatherers/clusterconfig/scheduler.go
+++ b/pkg/gatherers/clusterconfig/scheduler.go
@@ -61,6 +61,7 @@ func gatherSchedulerInfo(
 //         https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 //
 // * Location in archive: config/pod/openshift-kube-scheduler/logs/{pod-name}/messages.log
+// * Id in config: clusterconfig/scheduler_logs
 // * Since versions:
 //   * 4.10+
 func (g *Gatherer) GatherSchedulerLogs(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/service_accounts.go
+++ b/pkg/gatherers/clusterconfig/service_accounts.go
@@ -27,7 +27,7 @@ const maxServiceAccountsLimit = 1000
 //
 // * Location of serviceaccounts in archive: config/serviceaccounts
 // * See: docs/insights-archive-sample/config/serviceaccounts
-// * Id in config: service_accounts
+// * Id in config: clusterconfig/service_accounts
 // * Since versions:
 //   * 4.5.34+
 //   * 4.6.20+

--- a/pkg/gatherers/clusterconfig/silenced_alerts.go
+++ b/pkg/gatherers/clusterconfig/silenced_alerts.go
@@ -14,7 +14,7 @@ import (
 //
 // * Location in archive: config/silenced_alerts
 // * See: docs/insights-archive-sample/config/silenced_alerts
-// * Id in config: silenced_alerts
+// * Id in config: clusterconfig/silenced_alerts
 // * Since version:
 //   * 4.10+
 func (g *Gatherer) GatherSilencedAlerts(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/tsdb_status.go
+++ b/pkg/gatherers/clusterconfig/tsdb_status.go
@@ -14,7 +14,7 @@ import (
 //
 // * Location in archive: config/tsdb
 // * See: docs/insights-archive-sample/config/metrics
-// * Id in config: tsdb_status
+// * Id in config: clusterconfig/tsdb_status
 // * Since version:
 //    * 4.10+
 func (g *Gatherer) GatherTSDBStatus(ctx context.Context) ([]record.Record, []error) {

--- a/pkg/gatherers/clusterconfig/validatingwebhookconfigurations.go
+++ b/pkg/gatherers/clusterconfig/validatingwebhookconfigurations.go
@@ -19,6 +19,7 @@ import (
 //   - https://docs.openshift.com/container-platform/4.8/rest_api/extension_apis/validatingwebhookconfiguration-admissionregistration-k8s-io-v1.html
 //
 // * Location in archive: config/validatingwebhookconfigurations
+// * Id in config: clusterconfig/validating_webhook_configurations
 // * Since versions:
 //   * 4.7.40+
 //   * 4.8.24+

--- a/pkg/gatherers/clusterconfig/version.go
+++ b/pkg/gatherers/clusterconfig/version.go
@@ -31,7 +31,7 @@ import (
 // * Location of events in archive: events/
 // * Location of cluster ID: config/id
 // * See: docs/insights-archive-sample/config/id
-// * Id in config: version
+// * Id in config: clusterconfig/version
 func (g *Gatherer) GatherClusterVersion(ctx context.Context) ([]record.Record, []error) {
 	gatherConfigClient, err := configv1client.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/conditional/gather_api_request_count.go
+++ b/pkg/gatherers/conditional/gather_api_request_count.go
@@ -27,6 +27,7 @@ type APIRequestCount struct {
 //   - alert_name string - name of the firing alert
 //
 // * Location in archive: conditional/alerts/<alert_name>/api_request_counts.json
+// * Id in config: conditional/api_request_counts_of_resource_from_alert
 // * Since versions:
 //   * 4.10+
 func (g *Gatherer) BuildGatherAPIRequestCounts(paramsInterface interface{}) (gatherers.GatheringClosure, error) {

--- a/pkg/gatherers/conditional/gather_containers_logs.go
+++ b/pkg/gatherers/conditional/gather_containers_logs.go
@@ -16,7 +16,7 @@ import (
 // BuildGatherContainersLogs collects either current or previous containers logs for pods firing one of the configured alerts.
 //
 // * Location in archive: conditional/namespaces/<namespace>/pods/<pod>/containers/<container>/<logs|logs-previous>/last-<tail length>-lines.log
-// * Id in config: containers_logs
+// * Id in config: conditional/containers_logs
 // * Since versions:
 //   * 4.10+
 func (g *Gatherer) BuildGatherContainersLogs(paramsInterface interface{}) (gatherers.GatheringClosure, error) { // nolint: dupl

--- a/pkg/gatherers/conditional/gather_image_stream_definitions_of_namespace.go
+++ b/pkg/gatherers/conditional/gather_image_stream_definitions_of_namespace.go
@@ -21,6 +21,7 @@ import (
 //   https://docs.openshift.com/container-platform/4.7/rest_api/image_apis/imagestream-image-openshift-io-v1.html#apisimage-openshift-iov1namespacesnamespaceimagestreams
 //
 // * Location in archive: conditional/namespaces/{namespace}/imagestreams/{name}
+// * Id in config: conditional/image_streams_of_namespace
 // * Since versions:
 //   * 4.9+
 func (g *Gatherer) BuildGatherImageStreamsOfNamespace(paramsInterface interface{}) (gatherers.GatheringClosure, error) {

--- a/pkg/gatherers/conditional/gather_logs_of_namespace.go
+++ b/pkg/gatherers/conditional/gather_logs_of_namespace.go
@@ -22,6 +22,7 @@ import (
 //          https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
 //
 // * Location in archive: conditional/namespaces/{namespace}/pods/{pod_name}/containers/{container_name}/logs/last-{n}-lines.log
+// * Id in config: conditional/logs_of_namespace
 // * Since versions:
 //   * 4.9+
 func (g *Gatherer) BuildGatherLogsOfNamespace(paramsInterface interface{}) (gatherers.GatheringClosure, error) {

--- a/pkg/gatherers/conditional/gather_pod_definition.go
+++ b/pkg/gatherers/conditional/gather_pod_definition.go
@@ -16,6 +16,7 @@ import (
 // BuildGatherPodDefinition collects pod definition from pods that are firing one of the configured alerts.
 //
 // * Location in archive: conditional/namespaces/<namespace>/pods/<pod>/<pod>.json
+// * Id in config: conditional/pod_definition
 // * Since versions:
 //   * 4.11+
 func (g *Gatherer) BuildGatherPodDefinition(paramsInterface interface{}) (gatherers.GatheringClosure, error) { // nolint: dupl

--- a/pkg/gatherers/workloads/workloads_info.go
+++ b/pkg/gatherers/workloads/workloads_info.go
@@ -42,7 +42,7 @@ const (
 // in a generic fashion
 //
 // * Location in archive: config/workload_info
-// * Id in config: workload_info
+// * Id in config: workloads/workload_info
 // * Since versions:
 //   * 4.8+
 func (g *Gatherer) GatherWorkloadInfo(ctx context.Context) ([]record.Record, []error) {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This changes the id of the particular gatherers to include the more general gatherer name so that these names can be used when someone will want to disable some of the gatherers - see https://github.com/openshift/enhancements/pull/1037#discussion_r838249884

This also avoids the data race in our tests (when `go test -race ./...`)

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data 

## Documentation
<!-- Are these changes reflected in documentation? -->
Update of `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
No new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
