### PR TITLE
Bug 2072842: Gather namespace names with overlapping UIDs

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -539,6 +539,20 @@ Relevant OpenShift API docs:
   * 4.10+
 
 
+## NamespacesWithOverlappingUIDs
+
+gathers namespaces with overlapping UID ranges
+
+The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/namespace.go
+Response is an array of arrays of namespaces with overlapping UIDs. Each namespace is represented by its name and the UID range value
+from the "openshift.io/sa.scc.uid-range" annotation
+
+* Location in archive: config/namespaces_with_overlapping_uids
+* Id in config: clusterconfig/overlapping_namespace_uids
+* Since versions:
+  * 4.11+
+
+
 ## NetNamespace
 
 collects NetNamespaces networking information

--- a/docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json
+++ b/docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json
@@ -1,0 +1,36 @@
+[
+    [
+        {
+            "namespace": "test-2",
+            "uid_range": "1000670000/10000"
+        },
+        {
+            "namespace": "test-3",
+            "uid_range": "1000670000/7000"
+        },
+        {
+            "namespace": "test-5",
+            "uid_range": "1000676000/2000"
+        }
+    ],
+    [
+        {
+            "namespace": "test-4",
+            "uid_range": "1000679000/2000"
+        },
+        {
+            "namespace": "test-2",
+            "uid_range": "1000670000/10000"
+        }
+    ],
+    [
+        {
+            "namespace": "test-6",
+            "uid_range": "1000710000/10000"
+        },
+        {
+            "namespace": "test-7",
+            "uid_range": "1000715000/10000"
+        }
+    ]
+]

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -78,6 +78,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"silenced_alerts":                   (*Gatherer).GatherSilencedAlerts,
 	"image":                             (*Gatherer).GatherClusterImage,
 	"kube_controller_manager_logs":      (*Gatherer).GatherKubeControllerManagerLogs,
+	"overlapping_namespace_uids":        (*Gatherer).GatherNamespacesWithOverlappingUIDs,
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids.go
+++ b/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids.go
@@ -1,0 +1,180 @@
+package clusterconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+type uidRange struct {
+	starting int64
+	length   int64
+}
+
+type namespaceWithRange struct {
+	name string
+	uidRange
+}
+
+// IsOverlappingWith checks if the UIDRange is overlapping with the provided one
+func (u *uidRange) IsOverlappingWith(r uidRange) bool {
+	uSum := u.starting + u.length
+	rSum := r.starting + r.length
+	return (uSum > r.starting && uSum <= rSum) || (rSum > u.starting && rSum <= uSum)
+}
+
+func (u *uidRange) String() string {
+	return fmt.Sprintf("%d/%d", u.starting, u.length)
+}
+
+// GatherNamespacesWithOverlappingUIDs gathers namespaces with overlapping UID ranges
+//
+// The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/namespace.go
+// Response is an array of arrays of namespaces with overlapping UIDs. Each namespace is represented by its name and the UID range value
+// from the "openshift.io/sa.scc.uid-range" annotation
+//
+// * Location in archive: config/namespaces_with_overlapping_uids
+// * Id in config: clusterconfig/overlapping_namespace_uids
+// * Since versions:
+//   * 4.11+
+func (g *Gatherer) GatherNamespacesWithOverlappingUIDs(ctx context.Context) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherNamespacesWithOverlappingUIDs(ctx, gatherKubeClient.CoreV1())
+}
+
+func gatherNamespacesWithOverlappingUIDs(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
+	nsList, err := coreClient.Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, []error{err}
+	}
+	var namespaces []namespaceWithRange
+	var errs []error
+	for i := range nsList.Items {
+		ns := nsList.Items[i]
+		uidRangeString := ns.Annotations["openshift.io/sa.scc.uid-range"]
+		r, err := uidStringToRange(uidRangeString)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't read uid range of the %s namespace", ns.Name))
+			continue
+		}
+		namespaces = append(namespaces, namespaceWithRange{ns.Name, *r})
+	}
+	var resultSet SetOfNamespaceSets
+	for i := range namespaces {
+		n1 := namespaces[i]
+		// remove first i+1 elements from the slice so that we don't iterate over them again
+		remainingNs := namespaces[i+1:]
+		for j := range remainingNs {
+			n2 := remainingNs[j]
+			if n1.IsOverlappingWith(n2.uidRange) {
+				if es, ok := resultSet.BothOverlap(n1, n2); ok {
+					es.Insert(n1, n2)
+				} else {
+					s := NewSet()
+					s.Insert(n1, n2)
+					resultSet = append(resultSet, s)
+				}
+			}
+		}
+	}
+	return []record.Record{{
+		Name: "config/namespaces_with_overlapping_uids",
+		Item: resultSet,
+	}}, errs
+}
+
+// uidStringToRange converts string UID range to `UIDRange` type
+func uidStringToRange(s string) (*uidRange, error) {
+	values := strings.Split(s, "/")
+	starting, err := strconv.Atoi(values[0])
+	if err != nil {
+		return nil, err
+	}
+	rge, err := strconv.Atoi(values[1])
+	if err != nil {
+		return nil, err
+	}
+	return &uidRange{
+		starting: int64(starting),
+		length:   int64(rge),
+	}, nil
+}
+
+type NamespaceSet map[namespaceWithRange]struct{}
+
+// NewSet creates a set of namesapces from a list of values.
+func NewSet(namespaces ...namespaceWithRange) NamespaceSet {
+	ns := NamespaceSet{}
+	ns.Insert(namespaces...)
+	return ns
+}
+
+// Insert adds namespaces to the set.
+func (ns NamespaceSet) Insert(namespaces ...namespaceWithRange) NamespaceSet {
+	for _, n := range namespaces {
+		ns[n] = struct{}{}
+	}
+	return ns
+}
+
+// BothOverlap checks if the namespaces n1 and n2 are overlapping
+// with all ranges in the set
+func (ns NamespaceSet) BothOverlap(n1, n2 namespaceWithRange) bool {
+	if len(ns) == 0 {
+		return false
+	}
+	for k := range ns {
+		if !n1.IsOverlappingWith(k.uidRange) || !n2.IsOverlappingWith(k.uidRange) {
+			return false
+		}
+	}
+	return true
+}
+
+type SetOfNamespaceSets []NamespaceSet
+
+// BothOverlap tries to find a NamespaceSet where all the members overlap with n1 and n2
+func (ss SetOfNamespaceSets) BothOverlap(n1, n2 namespaceWithRange) (NamespaceSet, bool) {
+	for _, set := range ss {
+		if set.BothOverlap(n1, n2) {
+			return set, true
+		}
+	}
+	return nil, false
+}
+
+type namespace struct {
+	Namespace string `json:"namespace"`
+	Range     string `json:"uid_range"`
+}
+
+func (ss SetOfNamespaceSets) Marshal(ctx context.Context) ([]byte, error) {
+	result := make([][]namespace, 0, len(ss))
+	for _, set := range ss {
+		var overlapping []namespace
+		for s := range set {
+			n := namespace{
+				Namespace: s.name,
+				Range:     s.uidRange.String(),
+			}
+			overlapping = append(overlapping, n)
+		}
+		result = append(result, overlapping)
+	}
+	return json.Marshal(result)
+}
+
+func (ss SetOfNamespaceSets) GetExtension() string {
+	return "json"
+}

--- a/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids.go
+++ b/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids.go
@@ -25,13 +25,13 @@ type namespaceWithRange struct {
 }
 
 // IsOverlappingWith checks if the UIDRange is overlapping with the provided one
-func (u *uidRange) IsOverlappingWith(r uidRange) bool {
+func (u uidRange) IsOverlappingWith(r uidRange) bool {
 	uSum := u.starting + u.length
 	rSum := r.starting + r.length
 	return (uSum > r.starting && uSum <= rSum) || (rSum > u.starting && rSum <= uSum)
 }
 
-func (u *uidRange) String() string {
+func (u uidRange) String() string {
 	return fmt.Sprintf("%d/%d", u.starting, u.length)
 }
 

--- a/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids_test.go
+++ b/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids_test.go
@@ -1,0 +1,351 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_RangeIsOverlapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		r1       uidRange
+		r2       uidRange
+		expected bool
+	}{
+		{
+			name: "Same ranges",
+			r1: uidRange{
+				starting: 1000680000,
+				length:   10000,
+			},
+			r2: uidRange{
+				starting: 1000680000,
+				length:   10000,
+			},
+			expected: true,
+		},
+		{
+			name: "Different ranges",
+			r1: uidRange{
+				starting: 1000680000,
+				length:   10000,
+			},
+			r2: uidRange{
+				starting: 1000690000,
+				length:   10000,
+			},
+			expected: false,
+		},
+		{
+			name: "Overlapping ranges 1",
+			r1: uidRange{
+				starting: 1000680000,
+				length:   10000,
+			},
+			r2: uidRange{
+				starting: 1000689000,
+				length:   10000,
+			},
+			expected: true,
+		},
+		{
+			name: "Overlapping ranges 2",
+			r1: uidRange{
+				starting: 1000710000,
+				length:   10000,
+			},
+			r2: uidRange{
+				starting: 1000705000,
+				length:   8000,
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := test.r1.IsOverlappingWith(test.r2)
+			assert.Equal(t, test.expected, r)
+		})
+	}
+}
+
+func Test_GatherNamespacesWithOverlappingUIDs(t *testing.T) { //nolint: funlen
+	tests := []struct {
+		name           string
+		namespaces     []*v1.Namespace
+		expectedResult SetOfNamespaceSets
+		errors         []error
+	}{
+		{
+			name: "No overlapping namespaces",
+			namespaces: []*v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "10000/1000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "11000/1000",
+						},
+					},
+				},
+			},
+			expectedResult: SetOfNamespaceSets(nil),
+			errors:         []error(nil),
+		},
+		{
+			name: "Overlapping namespaces and one wrong annotation value",
+			namespaces: []*v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "10000/2000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "not a range",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "11000/1000",
+						},
+					},
+				},
+			},
+			expectedResult: SetOfNamespaceSets{
+				NewSet(namespaceWithRange{
+					name: "test-1",
+					uidRange: uidRange{
+						starting: 10000,
+						length:   2000,
+					},
+				}, namespaceWithRange{
+					name: "test-3",
+					uidRange: uidRange{
+						starting: 11000,
+						length:   1000,
+					},
+				}),
+			},
+			errors: []error{fmt.Errorf("can't read uid range of the test-2 namespace")},
+		},
+		{
+			name: "Some overlapping pairs",
+			namespaces: []*v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000697000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000690000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000700000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-5",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000800000/10000",
+						},
+					},
+				},
+			},
+			expectedResult: SetOfNamespaceSets{
+				NewSet(namespaceWithRange{
+					name: "test-1",
+					uidRange: uidRange{
+						starting: 1000697000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-2",
+					uidRange: uidRange{
+						starting: 1000690000,
+						length:   10000,
+					},
+				}),
+				NewSet(namespaceWithRange{
+					name: "test-1",
+					uidRange: uidRange{
+						starting: 1000697000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-3",
+					uidRange: uidRange{
+						starting: 1000700000,
+						length:   10000,
+					},
+				}),
+			},
+			errors: []error(nil),
+		},
+		{
+			name: "Three overlapping namespaces and some other sets",
+			namespaces: []*v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000670000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000695000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000690000/8000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-4",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000700000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-5",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000697000/2000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-6",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000740000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-7",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000735000/10000",
+						},
+					},
+				},
+			},
+			expectedResult: SetOfNamespaceSets{
+				NewSet(namespaceWithRange{
+					name: "test-2",
+					uidRange: uidRange{
+						starting: 1000695000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-3",
+					uidRange: uidRange{
+						starting: 1000690000,
+						length:   8000,
+					},
+				}, namespaceWithRange{
+					name: "test-5",
+					uidRange: uidRange{
+						starting: 1000697000,
+						length:   2000,
+					},
+				}),
+				NewSet(namespaceWithRange{
+					name: "test-2",
+					uidRange: uidRange{
+						starting: 1000695000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-4",
+					uidRange: uidRange{
+						starting: 1000700000,
+						length:   10000,
+					},
+				}),
+				NewSet(namespaceWithRange{
+					name: "test-6",
+					uidRange: uidRange{
+						starting: 1000740000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-7",
+					uidRange: uidRange{
+						starting: 1000735000,
+						length:   10000,
+					},
+				}),
+			},
+			errors: []error(nil),
+		},
+	}
+
+	corev1I := kubefake.NewSimpleClientset().CoreV1()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// create all the testing namespaces
+			for _, n := range test.namespaces {
+				_, err := corev1I.Namespaces().Create(context.TODO(), n, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			recs, errs := gatherNamespacesWithOverlappingUIDs(context.Background(), corev1I)
+			assert.EqualValues(t, test.errors, errs)
+			assert.Len(t, recs, 1)
+			assert.EqualValues(t, test.expectedResult, recs[0].Item)
+
+			// delete all the testing namespaces
+			for _, n := range test.namespaces {
+				err := corev1I.Namespaces().Delete(context.TODO(), n.Name, metav1.DeleteOptions{})
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This adds a new gatherer finding namespaces with overlapping UID ranges. The UID range is obtained from the `openshift.io/sa.scc.uid-range` annotation and examples of the overlapping and non-overlapping ranges are:

- 1000670000/10000 and 1000675000/10000 **are overlapping**
- 1000670000/10000 and 1000680000/10000 **are not overlapping**
For more details see https://issues.redhat.com/browse/CCXDEV-7821

**Steps to reproduce:**

- create some namespaces in your cluster (and make some of them with overlapping UIDs)
- you can use following yaml to create the namespaces:
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    openshift.io/description: ""
    openshift.io/display-name: ""
    openshift.io/requester: kube:admin
    openshift.io/sa.scc.uid-range: 1000600000/10000
  labels:
    kubernetes.io/metadata.name: test-1
  name: test-1
spec:
```
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    openshift.io/description: ""
    openshift.io/display-name: ""
    openshift.io/requester: kube:admin
    openshift.io/sa.scc.uid-range: 1000700000/10000
  labels:
    kubernetes.io/metadata.name: test-2
  name: test-2
spec:
```
```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    openshift.io/description: ""
    openshift.io/display-name: ""
    openshift.io/requester: kube:admin
    openshift.io/sa.scc.uid-range: 1000620000/7000
  labels:
    kubernetes.io/metadata.name: test-3
  name: test-3
spec:
```


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
