### PR TITLE
Bug 2072842: Namespaces with overlapping UIDs - do not store UID ranges

### DIFF
--- a/docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json
+++ b/docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json
@@ -1,36 +1,16 @@
 [
     [
-        {
-            "namespace": "test-2",
-            "uid_range": "1000670000/10000"
-        },
-        {
-            "namespace": "test-3",
-            "uid_range": "1000670000/7000"
-        },
-        {
-            "namespace": "test-5",
-            "uid_range": "1000676000/2000"
-        }
+        "openshift",
+        "test-1",
+        "test-2"
     ],
     [
-        {
-            "namespace": "test-4",
-            "uid_range": "1000679000/2000"
-        },
-        {
-            "namespace": "test-2",
-            "uid_range": "1000670000/10000"
-        }
+        "openshift-ingress-canary",
+        "test-3"
     ],
     [
-        {
-            "namespace": "test-6",
-            "uid_range": "1000710000/10000"
-        },
-        {
-            "namespace": "test-7",
-            "uid_range": "1000715000/10000"
-        }
+        "test-4",
+        "test-5",
+        "test-6"
     ]
 ]

--- a/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids.go
+++ b/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids.go
@@ -154,21 +154,12 @@ func (ss SetOfNamespaceSets) BothOverlap(n1, n2 namespaceWithRange) (NamespaceSe
 	return nil, false
 }
 
-type namespace struct {
-	Namespace string `json:"namespace"`
-	Range     string `json:"uid_range"`
-}
-
 func (ss SetOfNamespaceSets) Marshal(ctx context.Context) ([]byte, error) {
-	result := make([][]namespace, 0, len(ss))
+	result := make([][]string, 0, len(ss))
 	for _, set := range ss {
-		var overlapping []namespace
+		var overlapping []string
 		for s := range set {
-			n := namespace{
-				Namespace: s.name,
-				Range:     s.uidRange.String(),
-			}
-			overlapping = append(overlapping, n)
+			overlapping = append(overlapping, s.name)
 		}
 		result = append(result, overlapping)
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Minor followup for the https://github.com/openshift/insights-operator/pull/604

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
Updated
- `docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

No update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No update

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2072842
https://access.redhat.com/solutions/???
