### PR TITLE
[release-4.9] Bug 2076903: Gather namespace names with overlapping UI…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -475,6 +475,20 @@ Relevant OpenShift API docs:
   * 4.10+
 
 
+## NamespacesWithOverlappingUIDs
+
+gathers namespaces with overlapping UID ranges
+
+The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/namespace.go
+Response is an array of arrays of namespaces with overlapping UIDs. Each namespace is represented by its name and the UID range value
+from the "openshift.io/sa.scc.uid-range" annotation
+
+* Location in archive: config/namespaces_with_overlapping_uids
+* Id in config: clusterconfig/overlapping_namespace_uids
+* Since versions:
+  * 4.11+
+
+
 ## NetNamespace
 
 collects NetNamespaces networking information

--- a/docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json
+++ b/docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json
@@ -1,0 +1,16 @@
+[
+    [
+        "openshift",
+        "test-1",
+        "test-2"
+    ],
+    [
+        "openshift-ingress-canary",
+        "test-3"
+    ],
+    [
+        "test-4",
+        "test-5",
+        "test-6"
+    ]
+]

--- a/pkg/authorizer/clusterauthorizer/clusterauthorizer_test.go
+++ b/pkg/authorizer/clusterauthorizer/clusterauthorizer_test.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/openshift/insights-operator/pkg/config"
 	"golang.org/x/net/http/httpproxy"
+
+	"github.com/openshift/insights-operator/pkg/config"
 )
 
 // nonCachedProxyFromEnvironment creates Proxier if Proxy is set. It uses always fresh Env
@@ -84,9 +85,9 @@ func Test_Proxy(tt *testing.T) {
 	for _, tcase := range testCases {
 		tc := tcase
 		tt.Run(tc.Name, func(t *testing.T) {
-			// do not use parallel here
 			for k, v := range tc.EnvValues {
-				defer SafeRestoreEnv(k)()
+				// do not use parallel here
+				defer SafeRestoreEnv(k)() // nolint: gocritic
 				// nil will indicate the need to unset Env
 				if v != nil {
 					vv := v.(string)

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -94,25 +94,22 @@ func CollectAndRecordGatherer(
 		}
 
 		for _, err := range result.Errs {
-			errStr := fmt.Sprintf(
+			errStr := fmt.Errorf(
 				"gatherer %v's function %v failed with error: %v",
-				gathererName, result.FunctionName, err,
-			)
-
+				gathererName, result.FunctionName, err)
 			if result.IgnoreErrors {
 				klog.Error(errStr)
 			} else {
-				errs = append(errs, fmt.Errorf(errStr))
+				errs = append(errs, errStr)
 			}
 		}
 		recordedRecs := 0
 		for _, r := range result.Records {
 			if err := rec.Record(r); err != nil {
-				recErr := fmt.Errorf(
+				result.Errs = append(result.Errs, fmt.Errorf(
 					"unable to record gatherer %v function %v' result %v because of error: %v",
 					gathererName, result.FunctionName, r.Name, err,
-				)
-				result.Errs = append(result.Errs, recErr)
+				))
 				continue
 			}
 			recordedRecs++

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -91,6 +91,7 @@ var gatheringFunctions = map[string]gatheringFunction{
 	"mutating_webhook_configurations":   failableFunc((*Gatherer).GatherMutatingWebhookConfigurations),
 	"cost_management_metrics_configs":   failableFunc((*Gatherer).GatherCostManagementMetricsConfigs),
 	"kube_controller_manager_logs":      failableFunc((*Gatherer).GatherKubeControllerManagerLogs),
+	"overlapping_namespace_uids":        failableFunc((*Gatherer).GatherNamespacesWithOverlappingUIDs),
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/install_plans_test.go
+++ b/pkg/gatherers/clusterconfig/install_plans_test.go
@@ -58,45 +58,47 @@ func Test_InstallPlans_Gather(t *testing.T) {
 			var client *dynamicfake.FakeDynamicClient
 			coreClient := kubefake.NewSimpleClientset()
 			for _, file := range test.testfiles {
-				f, err := os.Open(file)
-				if err != nil {
-					t.Fatal("test failed to read installplan data", err)
-				}
-				defer f.Close()
-				installplancontent, err := io.ReadAll(f)
-				if err != nil {
-					t.Fatal("error reading test data file", err)
-				}
+				func() {
+					f, err := os.Open(file)
+					if err != nil {
+						t.Fatal("test failed to read installplan data", err)
+					}
+					defer f.Close()
+					installplancontent, err := io.ReadAll(f)
+					if err != nil {
+						t.Fatal("error reading test data file", err)
+					}
 
-				decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
-				installplan := &unstructured.Unstructured{}
+					decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+					installplan := &unstructured.Unstructured{}
 
-				_, _, err = decUnstructured.Decode(installplancontent, nil, installplan)
-				if err != nil {
-					t.Fatal("unable to decode", err)
-				}
-				gv, _ := schema.ParseGroupVersion(installplan.GetAPIVersion())
-				gvr := schema.GroupVersionResource{Version: gv.Version, Group: gv.Group, Resource: "installplans"}
-				ns, _, err := unstructured.NestedString(installplan.Object, "metadata", "namespace")
-				if err != nil {
-					t.Fatal("unable to read ns ", err)
-				}
-				_, err = coreClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
-				if errors.IsNotFound(err) {
-					_, err = coreClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
-				}
-				if err != nil {
-					t.Fatal("unable to create ns fake ", err)
-				}
-				if client == nil {
-					client = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
-						gvr: "InstallPlansList",
-					})
-				}
-				_, err = client.Resource(gvr).Namespace(ns).Create(context.Background(), installplan, metav1.CreateOptions{})
-				if err != nil {
-					t.Fatal("unable to create installplan fake ", err)
-				}
+					_, _, err = decUnstructured.Decode(installplancontent, nil, installplan)
+					if err != nil {
+						t.Fatal("unable to decode", err)
+					}
+					gv, _ := schema.ParseGroupVersion(installplan.GetAPIVersion())
+					gvr := schema.GroupVersionResource{Version: gv.Version, Group: gv.Group, Resource: "installplans"}
+					ns, _, err := unstructured.NestedString(installplan.Object, "metadata", "namespace")
+					if err != nil {
+						t.Fatal("unable to read ns ", err)
+					}
+					_, err = coreClient.CoreV1().Namespaces().Get(context.Background(), ns, metav1.GetOptions{})
+					if errors.IsNotFound(err) {
+						_, err = coreClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{})
+					}
+					if err != nil {
+						t.Fatal("unable to create ns fake ", err)
+					}
+					if client == nil {
+						client = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+							gvr: "InstallPlansList",
+						})
+					}
+					_, err = client.Resource(gvr).Namespace(ns).Create(context.Background(), installplan, metav1.CreateOptions{})
+					if err != nil {
+						t.Fatal("unable to create installplan fake ", err)
+					}
+				}()
 			}
 			ctx := context.Background()
 			records, errs := gatherInstallPlans(ctx, client, coreClient.CoreV1())

--- a/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids.go
+++ b/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids.go
@@ -1,0 +1,171 @@
+package clusterconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+type uidRange struct {
+	starting int64
+	length   int64
+}
+
+type namespaceWithRange struct {
+	name string
+	uidRange
+}
+
+// IsOverlappingWith checks if the UIDRange is overlapping with the provided one
+func (u uidRange) IsOverlappingWith(r uidRange) bool {
+	uSum := u.starting + u.length
+	rSum := r.starting + r.length
+	return (uSum > r.starting && uSum <= rSum) || (rSum > u.starting && rSum <= uSum)
+}
+
+func (u uidRange) String() string {
+	return fmt.Sprintf("%d/%d", u.starting, u.length)
+}
+
+// GatherNamespacesWithOverlappingUIDs gathers namespaces with overlapping UID ranges
+//
+// The Kubernetes api https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/namespace.go
+// Response is an array of arrays of namespaces with overlapping UIDs. Each namespace is represented by its name and the UID range value
+// from the "openshift.io/sa.scc.uid-range" annotation
+//
+// * Location in archive: config/namespaces_with_overlapping_uids
+// * Id in config: clusterconfig/overlapping_namespace_uids
+// * Since versions:
+//   * 4.11+
+func (g *Gatherer) GatherNamespacesWithOverlappingUIDs(ctx context.Context) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherNamespacesWithOverlappingUIDs(ctx, gatherKubeClient.CoreV1())
+}
+
+func gatherNamespacesWithOverlappingUIDs(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
+	nsList, err := coreClient.Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, []error{err}
+	}
+	var namespaces []namespaceWithRange
+	var errs []error
+	for i := range nsList.Items {
+		ns := nsList.Items[i]
+		uidRangeString := ns.Annotations["openshift.io/sa.scc.uid-range"]
+		r, err := uidStringToRange(uidRangeString)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("can't read uid range of the %s namespace", ns.Name))
+			continue
+		}
+		namespaces = append(namespaces, namespaceWithRange{ns.Name, *r})
+	}
+	var resultSet SetOfNamespaceSets
+	for i := range namespaces {
+		n1 := namespaces[i]
+		// remove first i+1 elements from the slice so that we don't iterate over them again
+		remainingNs := namespaces[i+1:]
+		for j := range remainingNs {
+			n2 := remainingNs[j]
+			if n1.IsOverlappingWith(n2.uidRange) {
+				if es, ok := resultSet.BothOverlap(n1, n2); ok {
+					es.Insert(n1, n2)
+				} else {
+					s := NewSet()
+					s.Insert(n1, n2)
+					resultSet = append(resultSet, s)
+				}
+			}
+		}
+	}
+	return []record.Record{{
+		Name: "config/namespaces_with_overlapping_uids",
+		Item: resultSet,
+	}}, errs
+}
+
+// uidStringToRange converts string UID range to `UIDRange` type
+func uidStringToRange(s string) (*uidRange, error) {
+	values := strings.Split(s, "/")
+	starting, err := strconv.Atoi(values[0])
+	if err != nil {
+		return nil, err
+	}
+	rge, err := strconv.Atoi(values[1])
+	if err != nil {
+		return nil, err
+	}
+	return &uidRange{
+		starting: int64(starting),
+		length:   int64(rge),
+	}, nil
+}
+
+type NamespaceSet map[namespaceWithRange]struct{}
+
+// NewSet creates a set of namesapces from a list of values.
+func NewSet(namespaces ...namespaceWithRange) NamespaceSet {
+	ns := NamespaceSet{}
+	ns.Insert(namespaces...)
+	return ns
+}
+
+// Insert adds namespaces to the set.
+func (ns NamespaceSet) Insert(namespaces ...namespaceWithRange) NamespaceSet {
+	for _, n := range namespaces {
+		ns[n] = struct{}{}
+	}
+	return ns
+}
+
+// BothOverlap checks if the namespaces n1 and n2 are overlapping
+// with all ranges in the set
+func (ns NamespaceSet) BothOverlap(n1, n2 namespaceWithRange) bool {
+	if len(ns) == 0 {
+		return false
+	}
+	for k := range ns {
+		if !n1.IsOverlappingWith(k.uidRange) || !n2.IsOverlappingWith(k.uidRange) {
+			return false
+		}
+	}
+	return true
+}
+
+type SetOfNamespaceSets []NamespaceSet
+
+// BothOverlap tries to find a NamespaceSet where all the members overlap with n1 and n2
+func (ss SetOfNamespaceSets) BothOverlap(n1, n2 namespaceWithRange) (NamespaceSet, bool) {
+	for _, set := range ss {
+		if set.BothOverlap(n1, n2) {
+			return set, true
+		}
+	}
+	return nil, false
+}
+
+func (ss SetOfNamespaceSets) Marshal(ctx context.Context) ([]byte, error) {
+	result := make([][]string, 0, len(ss))
+	for _, set := range ss {
+		var overlapping []string
+		for s := range set {
+			overlapping = append(overlapping, s.name)
+		}
+		result = append(result, overlapping)
+	}
+	return json.Marshal(result)
+}
+
+func (ss SetOfNamespaceSets) GetExtension() string {
+	return "json"
+}

--- a/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids_test.go
+++ b/pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids_test.go
@@ -1,0 +1,351 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_RangeIsOverlapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		r1       uidRange
+		r2       uidRange
+		expected bool
+	}{
+		{
+			name: "Same ranges",
+			r1: uidRange{
+				starting: 1000680000,
+				length:   10000,
+			},
+			r2: uidRange{
+				starting: 1000680000,
+				length:   10000,
+			},
+			expected: true,
+		},
+		{
+			name: "Different ranges",
+			r1: uidRange{
+				starting: 1000680000,
+				length:   10000,
+			},
+			r2: uidRange{
+				starting: 1000690000,
+				length:   10000,
+			},
+			expected: false,
+		},
+		{
+			name: "Overlapping ranges 1",
+			r1: uidRange{
+				starting: 1000680000,
+				length:   10000,
+			},
+			r2: uidRange{
+				starting: 1000689000,
+				length:   10000,
+			},
+			expected: true,
+		},
+		{
+			name: "Overlapping ranges 2",
+			r1: uidRange{
+				starting: 1000710000,
+				length:   10000,
+			},
+			r2: uidRange{
+				starting: 1000705000,
+				length:   8000,
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := test.r1.IsOverlappingWith(test.r2)
+			assert.Equal(t, test.expected, r)
+		})
+	}
+}
+
+func Test_GatherNamespacesWithOverlappingUIDs(t *testing.T) { //nolint: funlen
+	tests := []struct {
+		name           string
+		namespaces     []*v1.Namespace
+		expectedResult SetOfNamespaceSets
+		errors         []error
+	}{
+		{
+			name: "No overlapping namespaces",
+			namespaces: []*v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "10000/1000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "11000/1000",
+						},
+					},
+				},
+			},
+			expectedResult: SetOfNamespaceSets(nil),
+			errors:         []error(nil),
+		},
+		{
+			name: "Overlapping namespaces and one wrong annotation value",
+			namespaces: []*v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "10000/2000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "not a range",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "11000/1000",
+						},
+					},
+				},
+			},
+			expectedResult: SetOfNamespaceSets{
+				NewSet(namespaceWithRange{
+					name: "test-1",
+					uidRange: uidRange{
+						starting: 10000,
+						length:   2000,
+					},
+				}, namespaceWithRange{
+					name: "test-3",
+					uidRange: uidRange{
+						starting: 11000,
+						length:   1000,
+					},
+				}),
+			},
+			errors: []error{fmt.Errorf("can't read uid range of the test-2 namespace")},
+		},
+		{
+			name: "Some overlapping pairs",
+			namespaces: []*v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000697000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000690000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000700000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-5",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000800000/10000",
+						},
+					},
+				},
+			},
+			expectedResult: SetOfNamespaceSets{
+				NewSet(namespaceWithRange{
+					name: "test-1",
+					uidRange: uidRange{
+						starting: 1000697000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-2",
+					uidRange: uidRange{
+						starting: 1000690000,
+						length:   10000,
+					},
+				}),
+				NewSet(namespaceWithRange{
+					name: "test-1",
+					uidRange: uidRange{
+						starting: 1000697000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-3",
+					uidRange: uidRange{
+						starting: 1000700000,
+						length:   10000,
+					},
+				}),
+			},
+			errors: []error(nil),
+		},
+		{
+			name: "Three overlapping namespaces and some other sets",
+			namespaces: []*v1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-1",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000670000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-2",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000695000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-3",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000690000/8000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-4",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000700000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-5",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000697000/2000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-6",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000740000/10000",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-7",
+						Annotations: map[string]string{
+							"openshift.io/sa.scc.uid-range": "1000735000/10000",
+						},
+					},
+				},
+			},
+			expectedResult: SetOfNamespaceSets{
+				NewSet(namespaceWithRange{
+					name: "test-2",
+					uidRange: uidRange{
+						starting: 1000695000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-3",
+					uidRange: uidRange{
+						starting: 1000690000,
+						length:   8000,
+					},
+				}, namespaceWithRange{
+					name: "test-5",
+					uidRange: uidRange{
+						starting: 1000697000,
+						length:   2000,
+					},
+				}),
+				NewSet(namespaceWithRange{
+					name: "test-2",
+					uidRange: uidRange{
+						starting: 1000695000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-4",
+					uidRange: uidRange{
+						starting: 1000700000,
+						length:   10000,
+					},
+				}),
+				NewSet(namespaceWithRange{
+					name: "test-6",
+					uidRange: uidRange{
+						starting: 1000740000,
+						length:   10000,
+					},
+				}, namespaceWithRange{
+					name: "test-7",
+					uidRange: uidRange{
+						starting: 1000735000,
+						length:   10000,
+					},
+				}),
+			},
+			errors: []error(nil),
+		},
+	}
+
+	corev1I := kubefake.NewSimpleClientset().CoreV1()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// create all the testing namespaces
+			for _, n := range test.namespaces {
+				_, err := corev1I.Namespaces().Create(context.TODO(), n, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+			recs, errs := gatherNamespacesWithOverlappingUIDs(context.Background(), corev1I)
+			assert.EqualValues(t, test.errors, errs)
+			assert.Len(t, recs, 1)
+			assert.EqualValues(t, test.expectedResult, recs[0].Item)
+
+			// delete all the testing namespaces
+			for _, n := range test.namespaces {
+				err := corev1I.Namespaces().Delete(context.TODO(), n.Name, metav1.DeleteOptions{})
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/gatherers/conditional/validation.go
+++ b/pkg/gatherers/conditional/validation.go
@@ -39,7 +39,7 @@ func validateGatheringRules(gatheringRules []GatheringRule) []error {
 	if !result.Valid() {
 		var errs []error
 		for _, err := range result.Errors() {
-			errs = append(errs, fmt.Errorf(err.String()))
+			errs = append(errs, fmt.Errorf("%s", err.String()))
 		}
 
 		return errs


### PR DESCRIPTION
…Ds (#605)

<!-- Short description of the PR. What does it do? -->
This is 4.9 backport of the https://github.com/openshift/insights-operator/pull/609

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/namespaces_with_overlapping_uids.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/namespaces_with_overlapping_uids_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2076903
https://access.redhat.com/solutions/???
