### PR TITLE
Bug 2077851: Fix vendoring of the build-machinery-go

### DIFF
--- a/pkg/dependencymagnet/docs.go
+++ b/pkg/dependencymagnet/docs.go
@@ -3,5 +3,5 @@ package dependencymagnet
 // required for gomod to pull in packages.
 // this is a dependency magnet to make it easier to pull in the build-machinery.  We want a single import to pull all of it in.
 import (
-	_ "github.com/openshift/build-machinery-go/make"
+	_ "github.com/openshift/build-machinery-go"
 )

--- a/vendor/github.com/openshift/build-machinery-go/Makefile
+++ b/vendor/github.com/openshift/build-machinery-go/Makefile
@@ -1,0 +1,61 @@
+SHELL :=/bin/bash
+all: verify
+.PHONY: all
+
+makefiles :=$(wildcard ./make/*.example.mk)
+examples :=$(wildcard ./make/examples/*/Makefile.test)
+
+# $1 - makefile name relative to ./make/ folder
+# $2 - target
+# $3 - output folder
+# We need to change dir to the final makefile directory or relative paths won't match.
+# Dynamic values are replaced with "<redacted_for_diff>" so we can do diff against checkout versions.
+# Avoid comparing local paths by stripping the prefix.
+# Delete lines referencing temporary files and directories
+# Unify make error output between versions
+# Ignore old cp errors on centos7
+# Ignore different make output with `-k` option
+define update-makefile-log
+mkdir -p "$(3)"
+set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) 2>&1 | \
+   sed 's/\.\(buildDate\|versionFromGit\|commitFromGit\|gitTreeState\)="[^"]*" /.\1="<redacted_for_diff>" /g' | \
+   sed -E 's~/[^ ]*/(github.com/openshift/build-machinery-go/[^ ]*)~/\1~g' | \
+   sed '/\/tmp\/tmp./d' | \
+   sed '/git checkout -b/d' | \
+   sed -E 's~^[<> ]*((\+\+\+|\-\-\-) \./(testing/)?manifests/.*.yaml).*~\1~' | \
+   sed -E 's/^(make\[2\]: \*\*\* \[).*: (.*\] Error 1)/\1\2/' | \
+   grep -v 'are the same file' | \
+   grep -E -v -e '^make\[2\]: Target `.*'"'"' not remade because of errors\.$$' | \
+   tee "$(3)"/"$(notdir $(1))"$(subst ..,.,.$(2).log)
+
+endef
+
+
+# $1 - makefile name relative to ./make/ folder
+# $2 - target
+# $3 - output folder
+define check-makefile-log
+$(call update-makefile-log,$(1),$(2),$(3))
+diff -N "$(1)$(subst ..,.,.$(2).log)" "$(3)/$(notdir $(1))$(subst ..,.,.$(2).log)"
+
+endef
+
+update-makefiles:
+	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(dir $(f))))
+	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(dir $(f))))
+.PHONY: update-makefiles
+
+verify-makefiles: tmp_dir:=$(shell mktemp -d)
+verify-makefiles:
+	$(foreach f,$(makefiles),$(call check-makefile-log,$(f),help,$(tmp_dir)/$(dir $(f))))
+	$(foreach f,$(examples),$(call check-makefile-log,$(f),,$(tmp_dir)/$(dir $(f))))
+.PHONY: verify-makefiles
+
+verify: verify-makefiles
+.PHONY: verify
+
+update: update-makefiles
+.PHONY: update
+
+
+include ./make/targets/help.mk

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - sttts
+  - mfojtik
+  - soltysh
+  - 2uasimojo
+approvers:
+  - sttts
+  - mfojtik
+  - soltysh

--- a/vendor/github.com/openshift/build-machinery-go/README.md
+++ b/vendor/github.com/openshift/build-machinery-go/README.md
@@ -1,0 +1,44 @@
+# library-go/build-machinery-go
+These are the building blocks for this and many of our other repositories to share code for Makefiles, helper scripts and other build related machinery.
+
+## Makefiles
+`make/` directory contains several predefined makefiles `(*.mk)` to choose from and include one of them as a base in your final `Makefile`. These are the predefined flows providing you with e.g. `build`, `test` or `verify` targets. To start with it is recommended you base Makefile on the corresponding `*.example.mk` using copy&paste.
+
+As some advanced targets are generated, every Makefile contains `make help` target listing all the available ones. All of the "example" makefiles have a corresponding `.help` file listing all the targets available there.
+
+Also for advanced use and if none of the predefined flows doesn't fit your needs, you can compose the flow from modules in similar way to how the predefined flows do,  
+
+### Golang
+Standard makefile for building pure Golang projects.
+ - [make/golang.mk](make/golang.mk)
+ - [make/golang.example.mk](make/golang.example.mk)
+ - [make/golang.example.mk.help](make/golang.example.mk.help)
+
+### Default
+Standard makefile for OpenShift Golang projects. 
+
+Extends [#Golang]().
+
+ - [make/default.mk](make/default.mk)
+ - [make/default.example.mk](make/default.example.mk)
+ - [make/default.example.mk.help](make/default.example.mk.help)
+
+### Operator
+Standard makefile for OpenShift Golang projects. 
+
+Extends [#Default]().
+
+ - [make/operator.mk](make/operator.mk)
+ - [make/operator.example.mk](make/operator.example.mk)
+ - [make/operator.example.mk.help](make/operator.example.mk.help)
+
+
+## Scripts
+`scripts` contain more complicated logic that is used in some make targets.
+
+## Contributing
+### Updating generated files
+We track the log output from the makefile tests to make sure any change is visible and can be audited. Unfortunately due to subtle linux tooling differences in distributions and versions, `make update` may not get you the exact output as the CI. To avoid it, just run the command in the same container as CI:   
+```
+podman run -it --rm --pull=always -v $( pwd ):/go/src/$( go list -m ) --workdir=/go/src/$( go list -m ) registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.15-openshift-4.7 make update
+```

--- a/vendor/github.com/openshift/build-machinery-go/doc.go
+++ b/vendor/github.com/openshift/build-machinery-go/doc.go
@@ -1,0 +1,14 @@
+// required for gomod to pull in packages.
+
+package alpha_build_machinery
+
+// this is a dependency magnet to make it easier to pull in the build-machinery.  We want a single import to pull all of it in.
+import (
+	_ "github.com/openshift/build-machinery-go/make"
+	_ "github.com/openshift/build-machinery-go/make/lib"
+	_ "github.com/openshift/build-machinery-go/make/targets"
+	_ "github.com/openshift/build-machinery-go/make/targets/golang"
+	_ "github.com/openshift/build-machinery-go/make/targets/openshift"
+	_ "github.com/openshift/build-machinery-go/make/targets/openshift/operator"
+	_ "github.com/openshift/build-machinery-go/scripts"
+)

--- a/vendor/github.com/openshift/build-machinery-go/go.mod
+++ b/vendor/github.com/openshift/build-machinery-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/build-machinery-go
+
+go 1.13

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,6 +117,7 @@ github.com/openshift/api/pkg/serialization
 github.com/openshift/api/security/v1
 # github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3
 ## explicit
+github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib
 github.com/openshift/build-machinery-go/make/targets


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is fixing the vendoring (`make vendor` and `go mod vendor`)
## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->
No docs updates

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

NO new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
