### PR TITLE
Bug 2079315: Gather ODF config data

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -652,6 +652,19 @@ API Reference:
 * Since versions:
   * 4.9+
 
+## OpenshiftStorage
+
+collects `storageclusters.ocs.openshift.io` resources
+from Openshift Data Foundation Stack.
+
+API Reference:
+  https://github.com/red-hat-storage/ocs-operator/blob/main/api/v1/storagecluster_types.go
+
+* Location in archive: config/storage/<namespace>/<name>.json
+* Id in config: clusterconfig/openshift_storage
+* Since versions:
+  * 4.11+
+
 
 ## OpenshiftSDNControllerLogs
 

--- a/docs/insights-archive-sample/config/storage/openshift-storage/ocs-storagecluster.json
+++ b/docs/insights-archive-sample/config/storage/openshift-storage/ocs-storagecluster.json
@@ -1,0 +1,156 @@
+{
+    "apiVersion": "ocs.openshift.io/v1",
+    "kind": "StorageCluster",
+    "metadata": {
+        "annotations": {
+            "storagesystem.odf.openshift.io/watched-by": "ocs-storagecluster-storagesystem",
+            "uninstall.ocs.openshift.io/cleanup-policy": "delete",
+            "uninstall.ocs.openshift.io/mode": "graceful"
+        },
+        "creationTimestamp": "2022-02-24T05:31:35Z",
+        "finalizers": ["storagecluster.ocs.openshift.io"],
+        "generation": 4,
+        "name": "ocs-storagecluster",
+        "namespace": "openshift-storage",
+        "ownerReferences": [
+            {
+                "apiVersion": "odf.openshift.io/v1alpha1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "StorageSystem",
+                "name": "ocs-storagecluster-storagesystem",
+                "uid": "395e3b8f-37ad-4ddb-af67-b2a7d3324ae9"
+            }
+        ],
+        "resourceVersion": "56661474",
+        "uid": "a0bfbbc1-0d25-4a8a-806d-cc42e6183a39"
+    },
+    "spec": {
+        "arbiter": {},
+        "encryption": { "kms": {} },
+        "externalStorage": {},
+        "managedResources": {
+            "cephBlockPools": {},
+            "cephConfig": {},
+            "cephDashboard": {},
+            "cephFilesystems": {},
+            "cephObjectStoreUsers": {},
+            "cephObjectStores": {}
+        },
+        "mirroring": {},
+        "nodeTopologies": {},
+        "storageDeviceSets": [
+            {
+                "config": {},
+                "count": 1,
+                "dataPVCTemplate": {
+                    "metadata": {},
+                    "spec": {
+                        "accessModes": ["ReadWriteOnce"],
+                        "resources": { "requests": { "storage": "512Gi" } },
+                        "storageClassName": "thin",
+                        "volumeMode": "Block"
+                    },
+                    "status": {}
+                },
+                "name": "ocs-deviceset-thin",
+                "placement": {},
+                "portable": true,
+                "preparePlacement": {},
+                "replica": 3,
+                "resources": {}
+            }
+        ],
+        "version": "4.9.0"
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastHeartbeatTime": "2022-04-26T12:41:51Z",
+                "lastTransitionTime": "2022-04-26T06:38:23Z",
+                "message": "Reconcile completed successfully",
+                "reason": "ReconcileCompleted",
+                "status": "True",
+                "type": "ReconcileComplete"
+            },
+            {
+                "lastHeartbeatTime": "2022-04-26T12:41:51Z",
+                "lastTransitionTime": "2022-02-24T05:40:14Z",
+                "message": "Reconcile completed successfully",
+                "reason": "ReconcileCompleted",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "lastHeartbeatTime": "2022-04-26T12:41:51Z",
+                "lastTransitionTime": "2022-03-22T06:29:53Z",
+                "message": "Reconcile completed successfully",
+                "reason": "ReconcileCompleted",
+                "status": "False",
+                "type": "Progressing"
+            },
+            {
+                "lastHeartbeatTime": "2022-04-26T12:41:51Z",
+                "lastTransitionTime": "2022-02-24T05:31:36Z",
+                "message": "Reconcile completed successfully",
+                "reason": "ReconcileCompleted",
+                "status": "False",
+                "type": "Degraded"
+            },
+            {
+                "lastHeartbeatTime": "2022-04-26T12:41:51Z",
+                "lastTransitionTime": "2022-02-28T08:21:42Z",
+                "message": "Reconcile completed successfully",
+                "reason": "ReconcileCompleted",
+                "status": "True",
+                "type": "Upgradeable"
+            }
+        ],
+        "failureDomain": "rack",
+        "failureDomainKey": "topology.rook.io/rack",
+        "failureDomainValues": ["rack0", "rack1", "rack2"],
+        "images": {
+            "ceph": {
+                "actualImage": "registry.redhat.io/rhceph/rhceph-5-rhel8@sha256:2296c19fbd3a0be84d6030dff789ce3e79b38cc30c39f45913aec97967b65cce",
+                "desiredImage": "registry.redhat.io/rhceph/rhceph-5-rhel8@sha256:2296c19fbd3a0be84d6030dff789ce3e79b38cc30c39f45913aec97967b65cce"
+            },
+            "noobaaCore": {
+                "actualImage": "registry.redhat.io/odf4/mcg-core-rhel8@sha256:b0726c457b0fda796014b2743910ad12130a60be361796c90479e8954d8bfe99",
+                "desiredImage": "registry.redhat.io/odf4/mcg-core-rhel8@sha256:b0726c457b0fda796014b2743910ad12130a60be361796c90479e8954d8bfe99"
+            },
+            "noobaaDB": {
+                "actualImage": "registry.redhat.io/rhel8/postgresql-12@sha256:da0b8d525b173ef472ff4c71fae60b396f518860d6313c4f3287b844aab6d622",
+                "desiredImage": "registry.redhat.io/rhel8/postgresql-12@sha256:da0b8d525b173ef472ff4c71fae60b396f518860d6313c4f3287b844aab6d622"
+            }
+        },
+        "nodeTopologies": {
+            "labels": {
+                "kubernetes.io/hostname": [
+                    "perf6-fhz82-ocs-5q98p",
+                    "perf6-fhz82-ocs-jnmf4",
+                    "perf6-fhz82-ocs-kbbc4"
+                ],
+                "topology.rook.io/rack": ["rack0", "rack1", "rack2"]
+            }
+        },
+        "phase": "Ready",
+        "relatedObjects": [
+            {
+                "apiVersion": "ceph.rook.io/v1",
+                "kind": "CephCluster",
+                "name": "ocs-storagecluster-cephcluster",
+                "namespace": "openshift-storage",
+                "resourceVersion": "56661470",
+                "uid": "221d739b-d2d9-4cd9-864d-59da7c766fcb"
+            },
+            {
+                "apiVersion": "noobaa.io/v1alpha1",
+                "kind": "NooBaa",
+                "name": "noobaa",
+                "namespace": "openshift-storage",
+                "resourceVersion": "29319336",
+                "uid": "62c1c608-ef52-4b90-b6c5-cd60490d3dc9"
+            }
+        ]
+    }
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -66,6 +66,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"pod_network_connectivity_checks":   (*Gatherer).GatherPNCC,
 	"machine_autoscalers":               (*Gatherer).GatherMachineAutoscalers,
 	"openshift_logging":                 (*Gatherer).GatherOpenshiftLogging,
+	"openshift_storage":                 (*Gatherer).GatherOpenshiftStorage,
 	"jaegers":                           (*Gatherer).GatherJaegerCR,
 	"validating_webhook_configurations": (*Gatherer).GatherValidatingWebhookConfigurations,
 	"mutating_webhook_configurations":   (*Gatherer).GatherMutatingWebhookConfigurations,

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -49,6 +49,9 @@ var (
 	openshiftLoggingResource = schema.GroupVersionResource{
 		Group: "logging.openshift.io", Version: "v1", Resource: "clusterloggings",
 	}
+	openshiftStorageResource = schema.GroupVersionResource{
+		Group: "ocs.openshift.io", Version: "v1", Resource: "storageclusters",
+	}
 
 	jaegerResource = schema.GroupVersionResource{
 		Group: "jaegertracing.io", Version: "v1", Resource: "jaegers",

--- a/pkg/gatherers/clusterconfig/openshift_logging.go
+++ b/pkg/gatherers/clusterconfig/openshift_logging.go
@@ -1,3 +1,4 @@
+//nolint: dupl
 package clusterconfig
 
 import (

--- a/pkg/gatherers/clusterconfig/openshift_logging_test.go
+++ b/pkg/gatherers/clusterconfig/openshift_logging_test.go
@@ -1,3 +1,4 @@
+//nolint: dupl
 package clusterconfig
 
 import (

--- a/pkg/gatherers/clusterconfig/openshift_storage.go
+++ b/pkg/gatherers/clusterconfig/openshift_storage.go
@@ -1,0 +1,53 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// GatherOpenshiftStorage collects `storageclusters.ocs.openshift.io` resources
+// from Openshift Data Foundation Stack.
+//
+// API Reference:
+//   https://github.com/red-hat-storage/ocs-operator/blob/main/api/v1/storagecluster_types.go
+//
+// * Location in archive: config/storage/<namespace>/<name>.json
+// * Id in config: clusterconfig/openshift_storage
+// * Since versions:
+//   * 4.11+
+func (g *Gatherer) GatherOpenshiftStorage(ctx context.Context) ([]record.Record, []error) {
+	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherOpenshiftStorage(ctx, gatherDynamicClient)
+}
+
+func gatherOpenshiftStorage(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	loggingResourceList, err := dynamicClient.Resource(openshiftStorageResource).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		klog.V(2).Infof("Unable to list %s resource due to: %s", openshiftStorageResource, err)
+		return nil, []error{err}
+	}
+
+	var records []record.Record
+	for i := range loggingResourceList.Items {
+		item := loggingResourceList.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("config/storage/%s/%s", item.GetNamespace(), item.GetName()),
+			Item: record.ResourceMarshaller{Resource: &item},
+		})
+	}
+	return records, nil
+}

--- a/pkg/gatherers/clusterconfig/openshift_storage.go
+++ b/pkg/gatherers/clusterconfig/openshift_storage.go
@@ -32,7 +32,7 @@ func (g *Gatherer) GatherOpenshiftStorage(ctx context.Context) ([]record.Record,
 }
 
 func gatherOpenshiftStorage(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
-	loggingResourceList, err := dynamicClient.Resource(openshiftStorageResource).List(ctx, metav1.ListOptions{})
+	storageResourceList, err := dynamicClient.Resource(openshiftStorageResource).List(ctx, metav1.ListOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -42,8 +42,8 @@ func gatherOpenshiftStorage(ctx context.Context, dynamicClient dynamic.Interface
 	}
 
 	var records []record.Record
-	for i := range loggingResourceList.Items {
-		item := loggingResourceList.Items[i]
+	for i := range storageResourceList.Items {
+		item := storageResourceList.Items[i]
 		records = append(records, record.Record{
 			Name: fmt.Sprintf("config/storage/%s/%s", item.GetNamespace(), item.GetName()),
 			Item: record.ResourceMarshaller{Resource: &item},

--- a/pkg/gatherers/clusterconfig/openshift_storage.go
+++ b/pkg/gatherers/clusterconfig/openshift_storage.go
@@ -1,3 +1,4 @@
+//nolint: dupl
 package clusterconfig
 
 import (

--- a/pkg/gatherers/clusterconfig/openshift_storage_test.go
+++ b/pkg/gatherers/clusterconfig/openshift_storage_test.go
@@ -1,3 +1,4 @@
+//nolint: dupl
 package clusterconfig
 
 import (

--- a/pkg/gatherers/clusterconfig/openshift_storage_test.go
+++ b/pkg/gatherers/clusterconfig/openshift_storage_test.go
@@ -1,0 +1,84 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func Test_GatherOpenshiftStorage(t *testing.T) {
+	var openshiftStorageYAML = `
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+`
+	type args struct {
+		ctx           context.Context
+		dynamicClient dynamic.Interface
+	}
+
+	tests := []struct {
+		name          string
+		args          args
+		totalRecords  int
+		recordName    string
+		expectedError error
+	}{
+		{
+			name: "check for storagecluster resource",
+			args: args{
+				ctx: context.TODO(),
+				dynamicClient: dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+					openshiftStorageResource: "StorageClusterList",
+				}),
+			},
+			totalRecords:  1,
+			recordName:    "config/storage/openshift-storage/ocs-storagecluster",
+			expectedError: nil,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+			testOpenshiftStorageResource := &unstructured.Unstructured{}
+
+			_, _, err := decUnstructured.Decode([]byte(openshiftStorageYAML), nil, testOpenshiftStorageResource)
+			if err != nil {
+				t.Fatal("unable to decode storagecluster ", err)
+			}
+			_, err = tt.args.dynamicClient.
+				Resource(openshiftStorageResource).
+				Namespace("openshift-storage").
+				Create(context.Background(), testOpenshiftStorageResource, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("unable to create fake resource %s", err)
+			}
+
+			records, errs := gatherOpenshiftStorage(tt.args.ctx, tt.args.dynamicClient)
+			if len(errs) > 0 {
+				if errs[0].Error() != tt.expectedError.Error() {
+					t.Fatalf("unexpected errors: %v", errs[0].Error())
+				}
+			}
+			if len(records) != tt.totalRecords {
+				t.Errorf("gatherOpenshiftStorage() got = %v, want %v", len(records), tt.totalRecords)
+			}
+			if records[0].Name != tt.recordName {
+				t.Errorf("gatherOpenshiftStorage() name = %v, want %v ", records[0].Name, tt.recordName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR adds the collection of the ODF StorageCluster CR. If ODF is installed, there should be exactly one instance of this CR.
This PR follows the existing example of openshift-logging gathering.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
[YES](https://github.com/mulbc/insights-operator/blob/add-ODF-config-gathering/docs/insights-archive-sample/config/storage/openshift-storage/ocs-storagecluster.json)

## Documentation
<!-- Are these changes reflected in documentation? -->
[YES](https://github.com/mulbc/insights-operator/blob/add-ODF-config-gathering/docs/gathered-data.md#openshiftstorage)

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
[openshift_storage_test.go](https://github.com/mulbc/insights-operator/blob/add-ODF-config-gathering/pkg/gatherers/clusterconfig/openshift_storage_test.go)

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->
Not yet - need advise on this

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No breaking changes expected, new feature

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-7908
