### PR TITLE
AUTH-133: manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/06-deployment-ibm-cloud-managed.yaml
+++ b/manifests/06-deployment-ibm-cloud-managed.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app: insights-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - args:
         - start
@@ -38,6 +42,10 @@ spec:
           value: 0.0.1-snapshot
         image: quay.io/openshift/origin-insights-operator:latest
         name: insights-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         ports:
         - containerPort: 8443
           name: https

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         app: insights-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: operator
       priorityClassName: system-cluster-critical
       nodeSelector:
@@ -56,6 +60,10 @@ spec:
           optional: true
       containers:
       - name: insights-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         image: quay.io/openshift/origin-insights-operator:latest
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-insights/deployments/insights-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"insights-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabili
ties (container \"insights-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"insights-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"insights-op
erator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 