### PR TITLE
Bug 2081997: Fix the clusteroperator conditions values when IO is

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -62,3 +62,7 @@ func (c *controllerStatus) reset() {
 func (c *controllerStatus) isHealthy() bool {
 	return !c.hasStatus(ErrorStatus)
 }
+
+func (c *controllerStatus) isDisabled() bool {
+	return c.hasStatus(DisabledStatus)
+}


### PR DESCRIPTION
disabled

<!-- Short description of the PR. What does it do? -->
Fix for clusteroperator conditions when the operator is disabled

**Steps to reproduce the original problem:**

- make IO degraded - e.g by changing the upload endpoint to some non-existing URL
- make IO disabled - by removing `cloud.openshift.com` token from the`pull-secret` 
- IO is still degraded (and other CO conditions are wrong as well), but it should not be

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

This will require a new integration test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2081997
https://access.redhat.com/solutions/???
