### PR TITLE
[release-4.10] Bug 2081844: Fix the clusteroperator conditions values…

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -61,3 +61,7 @@ func (c *controllerStatus) reset() {
 func (c *controllerStatus) isHealthy() bool {
 	return !c.hasStatus(ErrorStatus)
 }
+
+func (c *controllerStatus) isDisabled() bool {
+	return c.hasStatus(DisabledStatus)
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Backport of the https://github.com/openshift/insights-operator/pull/618

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data
## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
This requires a new (or/and backport) integration test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2081844
https://access.redhat.com/solutions/???
