### PR TITLE
create new permanent clusteroperator conditions for SCA &

### DIFF
--- a/manifests/08-prometheus_rule.yaml
+++ b/manifests/08-prometheus_rule.yaml
@@ -25,7 +25,7 @@ spec:
         description: 'Simple content access (SCA) is not enabled. Once enabled, Insights Operator can automatically import the SCA certificates from Red Hat OpenShift Cluster Manager making it easier to use the content provided by your Red Hat subscriptions when creating container images. See https://docs.openshift.com/container-platform/latest/cicd/builds/running-entitled-builds.html for more information.'
         summary: Simple content access certificates are not available.
       expr: |
-       max_over_time(cluster_operator_conditions{name="insights", condition="SCANotAvailable", reason="NotFound"}[5m]) == 1
+       max_over_time(cluster_operator_conditions{name="insights", condition="SCAAvailable", reason="NotFound", status="False"}[5m]) == 1
       for: 5m
       labels:
         severity: info

--- a/manifests/08-prometheus_rule.yaml
+++ b/manifests/08-prometheus_rule.yaml
@@ -25,7 +25,7 @@ spec:
         description: 'Simple content access (SCA) is not enabled. Once enabled, Insights Operator can automatically import the SCA certificates from Red Hat OpenShift Cluster Manager making it easier to use the content provided by your Red Hat subscriptions when creating container images. See https://docs.openshift.com/container-platform/latest/cicd/builds/running-entitled-builds.html for more information.'
         summary: Simple content access certificates are not available.
       expr: |
-       max_over_time(cluster_operator_conditions{name="insights", condition="SCAAvailable", reason="NotFound", status="False"}[5m]) == 1
+       max_over_time(cluster_operator_conditions{name="insights", condition="SCAAvailable", reason="NotFound"}[5m]) == 0
       for: 5m
       labels:
         severity: info

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -24,7 +24,7 @@ type Controller struct {
 	configurator configobserver.Configurator
 	recorder     recorder.FlushInterface
 	gatherers    []gatherers.Interface
-	statuses     map[string]*controllerstatus.Simple
+	statuses     map[string]controllerstatus.StatusController
 	anonymizer   *anonymization.Anonymizer
 }
 
@@ -36,11 +36,11 @@ func New(
 	listGatherers []gatherers.Interface,
 	anonymizer *anonymization.Anonymizer,
 ) *Controller {
-	statuses := make(map[string]*controllerstatus.Simple)
+	statuses := make(map[string]controllerstatus.StatusController)
 
 	for _, gatherer := range listGatherers {
 		gathererName := gatherer.GetName()
-		statuses[gathererName] = &controllerstatus.Simple{Name: fmt.Sprintf("periodic-%s", gathererName)}
+		statuses[gathererName] = controllerstatus.New(fmt.Sprintf("periodic-%s", gathererName))
 	}
 
 	return &Controller{
@@ -52,13 +52,13 @@ func New(
 	}
 }
 
-func (c *Controller) Sources() []controllerstatus.Interface {
+func (c *Controller) Sources() []controllerstatus.StatusController {
 	keys := make([]string, 0, len(c.statuses))
 	for key := range c.statuses {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
-	sources := make([]controllerstatus.Interface, 0, len(keys))
+	sources := make([]controllerstatus.StatusController, 0, len(keys))
 	for _, key := range keys {
 		sources = append(sources, c.statuses[key])
 	}

--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -12,11 +12,10 @@ const (
 	InsightsUploadDegraded configv1.ClusterStatusConditionType = "UploadDegraded"
 	// InsightsDownloadDegraded defines the condition type (when set to True) when the Insights report can't be successfully downloaded
 	InsightsDownloadDegraded configv1.ClusterStatusConditionType = "InsightsDownloadDegraded"
-	// SCANotAvailable is a condition type providing info about unsuccessful SCA pull attempt from the OCM API
-	SCANotAvailable configv1.ClusterStatusConditionType = "SCANotAvailable"
-	// ClusterTransferFailed is a condition type providing info about unsuccessful pull attempt of the ClusterTransfer from the OCM API
-	// or unsuccessful pull-secret update
-	ClusterTransferFailed configv1.ClusterStatusConditionType = "ClusterTransferFailed"
+	// ClusterTransferAvailable is a condition type providing info about ClusterTransfer controller status
+	ClusterTransferAvailable configv1.ClusterStatusConditionType = "ClusterTransferAvailable"
+	// SCAAvailable is a condition type providing info about SCA controller status
+	SCAAvailable configv1.ClusterStatusConditionType = "SCAAvailable"
 )
 
 type conditionsMap map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition
@@ -26,7 +25,7 @@ type conditions struct {
 }
 
 func newConditions(cos *configv1.ClusterOperatorStatus, time metav1.Time) *conditions {
-	entries := map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition{
+	entries := map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition{ // nolint: dupl
 		configv1.OperatorAvailable: {
 			Type:               configv1.OperatorAvailable,
 			Status:             configv1.ConditionUnknown,
@@ -41,6 +40,18 @@ func newConditions(cos *configv1.ClusterOperatorStatus, time metav1.Time) *condi
 		},
 		configv1.OperatorDegraded: {
 			Type:               configv1.OperatorDegraded,
+			Status:             configv1.ConditionUnknown,
+			LastTransitionTime: time,
+			Reason:             "",
+		},
+		SCAAvailable: {
+			Type:               SCAAvailable,
+			Status:             configv1.ConditionUnknown,
+			LastTransitionTime: time,
+			Reason:             "",
+		},
+		ClusterTransferAvailable: {
+			Type:               ClusterTransferAvailable,
 			Status:             configv1.ConditionUnknown,
 			LastTransitionTime: time,
 			Reason:             "",

--- a/pkg/controller/status/conditions_test.go
+++ b/pkg/controller/status/conditions_test.go
@@ -377,7 +377,7 @@ func Test_conditions_setCondition(t *testing.T) {
 	}
 }
 
-func Test_newConditions(t *testing.T) {
+func Test_newConditions(t *testing.T) { // nolint: funlen
 	time := metav1.Now()
 
 	type args struct {
@@ -396,7 +396,7 @@ func Test_newConditions(t *testing.T) {
 				time: time,
 			},
 			want: &conditions{
-				entryMap: map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition{
+				entryMap: map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition{ // nolint: dupl
 					configv1.OperatorAvailable: {
 						Type:               configv1.OperatorAvailable,
 						Status:             configv1.ConditionUnknown,
@@ -411,6 +411,18 @@ func Test_newConditions(t *testing.T) {
 					},
 					configv1.OperatorDegraded: {
 						Type:               configv1.OperatorDegraded,
+						Status:             configv1.ConditionUnknown,
+						LastTransitionTime: time,
+						Reason:             "",
+					},
+					SCAAvailable: {
+						Type:               SCAAvailable,
+						Status:             configv1.ConditionUnknown,
+						LastTransitionTime: time,
+						Reason:             "",
+					},
+					ClusterTransferAvailable: {
+						Type:               ClusterTransferAvailable,
 						Status:             configv1.ConditionUnknown,
 						LastTransitionTime: time,
 						Reason:             "",
@@ -454,6 +466,18 @@ func Test_newConditions(t *testing.T) {
 						LastTransitionTime: time,
 						Reason:             "degraded reason",
 						Message:            "degraded message",
+					},
+					SCAAvailable: {
+						Type:               SCAAvailable,
+						Status:             configv1.ConditionUnknown,
+						LastTransitionTime: time,
+						Reason:             "",
+					},
+					ClusterTransferAvailable: {
+						Type:               ClusterTransferAvailable,
+						Status:             configv1.ConditionUnknown,
+						LastTransitionTime: time,
+						Reason:             "",
 					},
 				},
 			},

--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -1,12 +1,10 @@
 package status
 
 const (
-	DisabledStatus        = "disabled"
-	UploadStatus          = "upload"
-	DownloadStatus        = "download"
-	ErrorStatus           = "error"
-	SCAPullStatus         = "scaPullStatus"
-	ClusterTransferStatus = "clusterTransferStatus"
+	DisabledStatus = "disabled"
+	UploadStatus   = "upload"
+	DownloadStatus = "download"
+	ErrorStatus    = "error"
 )
 
 type controllerStatus struct {

--- a/pkg/controllerstatus/controllerstatus_test.go
+++ b/pkg/controllerstatus/controllerstatus_test.go
@@ -1,0 +1,126 @@
+package controllerstatus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_StatusController_Basic(t *testing.T) {
+	testCtrl := New("test-controller")
+	assert.Equal(t, "test-controller", testCtrl.Name())
+	summary, ready := testCtrl.CurrentStatus()
+	assert.False(t, ready, "controller should not be ready")
+	assert.False(t, summary.Healthy, "controller should not be healthy")
+	assert.Equal(t, 0, summary.Count)
+	assert.True(t, summary.LastTransitionTime.IsZero())
+
+	updatedSummary := Summary{
+		Operation:          Operation{Name: "testing", HTTPStatusCode: 200},
+		Healthy:            true,
+		LastTransitionTime: time.Now(),
+		Reason:             "UpdatedOK1",
+		Message:            "testing status controller",
+	}
+
+	testCtrl.UpdateStatus(updatedSummary)
+	firstUpdatedSummary, ready := testCtrl.CurrentStatus()
+	assert.True(t, ready, "controller should be ready after status updated")
+	assert.True(t, firstUpdatedSummary.Healthy, "controller should be healthy after status updated")
+	assert.Equal(t, 1, firstUpdatedSummary.Count)
+	assert.Equal(t, OperationName("testing"), firstUpdatedSummary.Operation.Name)
+	assert.False(t, firstUpdatedSummary.LastTransitionTime.IsZero())
+
+	updatedSummary2 := Summary{
+		Operation:          Operation{Name: "testing2", HTTPStatusCode: 200},
+		Healthy:            true,
+		LastTransitionTime: time.Now(),
+		Reason:             "UpdatedOK1",
+		Message:            "testing status controller",
+	}
+	time.Sleep(10 * time.Millisecond)
+	testCtrl.UpdateStatus(updatedSummary2)
+	secondUpdatedSummary, ready := testCtrl.CurrentStatus()
+	assert.True(t, ready, "controller should be ready after status updated")
+	assert.True(t, secondUpdatedSummary.Healthy, "controller should be healthy after status updated")
+	assert.Equal(t, 2, secondUpdatedSummary.Count)
+	// LastTransition time should not change and same for the operation name
+	assert.Equal(t, OperationName("testing"), secondUpdatedSummary.Operation.Name)
+	assert.Equal(t, firstUpdatedSummary.LastTransitionTime, secondUpdatedSummary.LastTransitionTime)
+}
+
+func Test_StatusController_ChangingStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		ctrl           StatusController
+		firstStatus    Summary
+		secondStatus   Summary
+		expectedStatus Summary
+	}{
+		{
+			name: "From healthy status to unhealthy",
+			ctrl: New("test-controller-2"),
+			firstStatus: Summary{
+				Operation:          Operation{Name: "testing", HTTPStatusCode: 200},
+				Healthy:            true,
+				LastTransitionTime: time.Now(),
+				Reason:             "UpdatedOK1",
+				Message:            "testing status",
+			},
+			secondStatus: Summary{
+				Operation:          Operation{Name: "testing2", HTTPStatusCode: 403},
+				Healthy:            false,
+				LastTransitionTime: time.Now(),
+				Reason:             "Failed",
+				Message:            "Something went wrong",
+			},
+			expectedStatus: Summary{
+				Operation: Operation{Name: "testing2", HTTPStatusCode: 403},
+				Healthy:   false,
+				Reason:    "Failed",
+				Message:   "Something went wrong",
+				Count:     1,
+			},
+		},
+		{
+			name: "From healthy status to healthy but different reason",
+			ctrl: New("test-controller-3"),
+			firstStatus: Summary{
+				Operation:          Operation{Name: "testing1", HTTPStatusCode: 200},
+				Healthy:            true,
+				LastTransitionTime: time.Now(),
+				Reason:             "UpdatedOK1",
+				Message:            "testing status",
+			},
+			secondStatus: Summary{
+				Operation:          Operation{Name: "testing2", HTTPStatusCode: 202},
+				Healthy:            true,
+				LastTransitionTime: time.Now(),
+				Reason:             "UpdatedOK2",
+				Message:            "testing status2",
+			},
+			expectedStatus: Summary{
+				Operation: Operation{Name: "testing2", HTTPStatusCode: 202},
+				Healthy:   true,
+				Reason:    "UpdatedOK2",
+				Message:   "testing status2",
+				Count:     1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.ctrl.UpdateStatus(tt.firstStatus)
+			tt.ctrl.UpdateStatus(tt.secondStatus)
+			currentStatus, _ := tt.ctrl.CurrentStatus()
+			assert.Equal(t, tt.expectedStatus.Operation, currentStatus.Operation)
+			assert.Equal(t, tt.expectedStatus.Healthy, currentStatus.Healthy)
+			assert.Equal(t, tt.expectedStatus.Reason, currentStatus.Reason)
+			assert.Equal(t, tt.expectedStatus.Message, currentStatus.Message)
+			assert.Equal(t, tt.secondStatus.LastTransitionTime, currentStatus.LastTransitionTime)
+			assert.True(t, tt.firstStatus.LastTransitionTime.Before(currentStatus.LastTransitionTime))
+		})
+	}
+}

--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -20,7 +20,7 @@ import (
 
 // Controller gathers the report from Smart Proxy
 type Controller struct {
-	controllerstatus.Simple
+	controllerstatus.StatusController
 
 	configurator          configobserver.Configurator
 	client                *insightsclient.Client
@@ -76,7 +76,7 @@ func init() {
 // New initializes and returns a Gatherer
 func New(client *insightsclient.Client, configurator configobserver.Configurator, reporter InsightsReporter) *Controller {
 	return &Controller{
-		Simple:                controllerstatus.Simple{Name: "insightsreport"},
+		StatusController:      controllerstatus.New("insightsreport"),
 		configurator:          configurator,
 		client:                client,
 		archiveUploadReporter: reporter.ArchiveUploaded(),
@@ -100,7 +100,7 @@ func (c *Controller) PullSmartProxy() (bool, error) {
 	klog.V(4).Info("Retrieving report")
 	resp, err := c.client.RecvReport(ctx, reportEndpoint)
 	if authorizer.IsAuthorizationError(err) {
-		c.Simple.UpdateStatus(controllerstatus.Summary{
+		c.StatusController.UpdateStatus(controllerstatus.Summary{
 			Operation: controllerstatus.DownloadingReport,
 			Reason:    "NotAuthorized",
 			Message:   fmt.Sprintf("Auth rejected for downloading latest report: %v", err),
@@ -119,7 +119,7 @@ func (c *Controller) PullSmartProxy() (bool, error) {
 		return true, ie
 	} else if err != nil {
 		klog.Errorf("Unexpected error retrieving the report: %s", err)
-		c.Simple.UpdateStatus(controllerstatus.Summary{
+		c.StatusController.UpdateStatus(controllerstatus.Summary{
 			Operation: controllerstatus.DownloadingReport,
 			Reason:    "UnexpectedError",
 			Message:   fmt.Sprintf("Failed to download the latest report: %v", err),
@@ -151,7 +151,7 @@ func (c *Controller) PullSmartProxy() (bool, error) {
 	// we want to increment the metric only in case of download of a new report
 	c.client.IncrementRecvReportMetric(resp.StatusCode)
 	c.LastReport = reportResponse.Report
-	c.Simple.UpdateStatus(controllerstatus.Summary{Healthy: true})
+	c.StatusController.UpdateStatus(controllerstatus.Summary{Healthy: true})
 	return true, nil
 }
 
@@ -193,7 +193,7 @@ func (c *Controller) RetrieveReport() {
 
 			firstPullDone = true
 			if retryCounter >= retryThreshold {
-				c.Simple.UpdateStatus(controllerstatus.Summary{
+				c.StatusController.UpdateStatus(controllerstatus.Summary{
 					Operation: controllerstatus.DownloadingReport,
 					Reason:    "NotAvailable",
 					Message:   fmt.Sprintf("Couldn't download the latest report: %v", err),
@@ -242,7 +242,7 @@ func (c *Controller) RetrieveReport() {
 
 // Run goroutine code for gathering the reports from Smart Proxy
 func (c *Controller) Run(ctx context.Context) {
-	c.Simple.UpdateStatus(controllerstatus.Summary{Healthy: true})
+	c.StatusController.UpdateStatus(controllerstatus.Summary{Healthy: true})
 	klog.V(2).Info("Starting report retriever")
 	klog.V(2).Infof("Initial config: %v", c.configurator.Config())
 

--- a/pkg/ocm/clustertransfer/cluster_transfer_test.go
+++ b/pkg/ocm/clustertransfer/cluster_transfer_test.go
@@ -141,7 +141,12 @@ func Test_ClusterTransfer_RequestDataAndUpdateSecret(t *testing.T) {
 			ctController.requestDataAndUpdateSecret(mockConfig.Conf.OCMConfig.ClusterTransferEndpoint)
 			summary, ok := ctController.CurrentStatus()
 			assert.True(t, ok, "unexpected summary")
-			assert.EqualValues(t, tt.expectedSummary, summary)
+			assert.Equal(t, tt.expectedSummary.Operation, summary.Operation)
+			assert.Equal(t, tt.expectedSummary.Healthy, summary.Healthy)
+			assert.Equal(t, tt.expectedSummary.Count, summary.Count)
+			assert.Equal(t, tt.expectedSummary.Reason, summary.Reason)
+			assert.Equal(t, tt.expectedSummary.Message, summary.Message)
+			assert.True(t, tt.expectedSummary.LastTransitionTime.Before(summary.LastTransitionTime))
 
 			// check pull-secret value
 			expectedPSData, err := loadDataFromFile(tt.updatedPullSecretDataFilePath)

--- a/pkg/ocm/const.go
+++ b/pkg/ocm/const.go
@@ -1,0 +1,7 @@
+package ocm
+
+const (
+	// OCMAPIFailureCountThreshold defines how many unsuccessful responses from the OCM API in a row is tolerated
+	// before the operator is marked as Degraded
+	OCMAPIFailureCountThreshold = 5
+)


### PR DESCRIPTION
ClusterTransfer controllers

<!-- Short description of the PR. What does it do? -->
This creates new permanent clusteroperator conditions for the `SimpleContentAccess` and `ClusterTransfer` controller

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

The conditions will be documented in the README in a followup task

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
Added
- `pkg/controllerstatus/controllerstatus_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
