### PR TITLE
[release-4.9] Bug 2083467: Fix the clusteroperator conditions values …

### DIFF
--- a/pkg/controller/status/status.go
+++ b/pkg/controller/status/status.go
@@ -267,7 +267,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			})
 		}
 
-		if len(errorMessage) > 0 {
+		if len(errorMessage) > 0 && len(disabledReason) == 0 {
 			klog.V(4).Infof("The operator has some internal errors: %s", errorMessage)
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:               configv1.OperatorDegraded,
@@ -284,7 +284,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			})
 		}
 
-		if len(uploadErrorReason) > 0 {
+		if len(uploadErrorReason) > 0 && len(disabledReason) == 0 {
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:               UploadDegraded,
 				Status:             configv1.ConditionTrue,
@@ -296,7 +296,7 @@ func (c *Controller) merge(existing *configv1.ClusterOperator) *configv1.Cluster
 			removeOperatorStatusCondition(&existing.Status.Conditions, UploadDegraded)
 		}
 
-		if len(downloadReason) > 0 {
+		if len(downloadReason) > 0 && len(disabledReason) == 0 {
 			setOperatorStatusCondition(&existing.Status.Conditions, configv1.ClusterOperatorStatusCondition{
 				Type:               InsightsDownloadDegraded,
 				Status:             configv1.ConditionTrue,


### PR DESCRIPTION
…when IO is degraded

<!-- Short description of the PR. What does it do? -->
4.9 backport of the https://github.com/openshift/insights-operator/pull/619

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=2083467
https://access.redhat.com/solutions/???
