### PR TITLE
Console helm metrics

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -511,6 +511,7 @@ Gathered metrics:
   cluster_installer
   vsphere_node_hw_version_total
   namespace CPU and memory usage
+  console_helm_installs_total
   followed by at most 1000 lines of ALERTS metric
 
 * Location in archive: config/metrics
@@ -524,6 +525,7 @@ Gathered metrics:
   - "namespace:container_memory_usage_bytes:sum": 4.5+
   - "virt_platform metric": 4.6.34+, 4.7.16+, 4.8+
   - "vsphere_node_hw_version_total": 4.7.11+, 4.8+
+  - "console_helm_installs_total": 4.11+
 
 
 ## MutatingWebhookConfigurations

--- a/pkg/gatherers/clusterconfig/recent_metrics.go
+++ b/pkg/gatherers/clusterconfig/recent_metrics.go
@@ -30,6 +30,7 @@ const (
 //   cluster_installer
 //   vsphere_node_hw_version_total
 //   namespace CPU and memory usage
+//   console_helm_installs_total
 //   followed by at most 1000 lines of ALERTS metric
 //
 // * Location in archive: config/metrics
@@ -43,6 +44,7 @@ const (
 //   - "namespace:container_memory_usage_bytes:sum": 4.5+
 //   - "virt_platform metric": 4.6.34+, 4.7.16+, 4.8+
 //   - "vsphere_node_hw_version_total": 4.7.11+, 4.8+
+//   - "console_helm_installs_total": 4.11+
 func (g *Gatherer) GatherMostRecentMetrics(ctx context.Context) ([]record.Record, []error) {
 	metricsRESTClient, err := rest.RESTClientFor(g.metricsGatherKubeConfig)
 	if err != nil {
@@ -61,6 +63,7 @@ func gatherMostRecentMetrics(ctx context.Context, metricsClient rest.Interface) 
 		Param("match[]", "namespace:container_memory_usage_bytes:sum").
 		Param("match[]", "vsphere_node_hw_version_total").
 		Param("match[]", "virt_platform").
+		Param("match[]", "console_helm_installs_total").
 		DoRaw(ctx)
 	if err != nil {
 		klog.Errorf("Unable to retrieve most recent metrics: %v", err)


### PR DESCRIPTION
We would like to add "console_helm_installs_total" metric created at the time of Installing a chart from Openshift Developer Console gathered by Insights Operator so that we can take decisions from that data. In order to achieve this i have modified gatherMostRecentMetrics method and updated the docs.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->