### PR TITLE
make cluster version condition more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ build: ## Compiles the insights operator
 
 .PHONY: build-debug
 build-debug: ## Compiles the insights operator in debug mode
-	go build $(GO_BUILD_FLAGS) -gcflags="all=-N -l" \
+	go build -gcflags="all=-N -l" \
 		-o ./bin/insights-operator ./cmd/insights-operator
 
 ## --------------------------------------

--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -349,6 +349,7 @@ func Test_CollectAndRecordGatherer_Panic(t *testing.T) {
 	assert.EqualError(t, err, `function "panic" panicked`)
 	assert.Len(t, functionReports, 2)
 	functionReports[0].Duration = 0
+	functionReports[1].Duration = 0
 	assert.ElementsMatch(t, functionReports, []GathererFunctionReport{
 		{
 			FuncName: "mock_gatherer/panic",

--- a/pkg/gatherers/conditional/conditional_gatherer.go
+++ b/pkg/gatherers/conditional/conditional_gatherer.go
@@ -286,13 +286,16 @@ func (g *Gatherer) updateAlertsCache(ctx context.Context, metricsClient rest.Int
 }
 
 func (g *Gatherer) updateVersionCache(ctx context.Context, configClient configv1client.ConfigV1Interface) error {
+	const logPrefix = "conditional gatherer: "
+	klog.Info(logPrefix + "updating version cache for conditional gatherer")
+
 	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
 	g.clusterVersion = clusterVersion.Status.Desired.Version
-
+	klog.Infof(logPrefix+"cluster version is '%v'", g.clusterVersion)
 	return nil
 }
 

--- a/pkg/gatherers/conditional/conditional_gatherer.go
+++ b/pkg/gatherers/conditional/conditional_gatherer.go
@@ -239,8 +239,7 @@ func (g *Gatherer) updateCache(ctx context.Context) {
 }
 
 func (g *Gatherer) updateAlertsCache(ctx context.Context, metricsClient rest.Interface) error {
-	const logPrefix = "conditional gatherer: "
-	klog.Info(logPrefix + "updating alerts cache for conditional gatherer")
+	klog.Info("updating alerts cache for conditional gatherer")
 
 	g.firingAlerts = make(map[string][]AlertLabels)
 
@@ -268,15 +267,15 @@ func (g *Gatherer) updateAlertsCache(ctx context.Context, metricsClient rest.Int
 	for _, result := range response.Data.Results {
 		alertName, found := result.Labels["alertname"]
 		if !found {
-			klog.Errorf(`%v label "alertname"" was not found in the result: %v`, logPrefix, result)
+			klog.Errorf(`label "alertname" was not found in the result: %v`, result)
 			continue
 		}
 		alertState, found := result.Labels["alertstate"]
 		if !found {
-			klog.Errorf(`%v label "alertstate"" was not found in the result: %v`, logPrefix, result)
+			klog.Errorf(`label "alertstate" was not found in the result: %v`, result)
 			continue
 		}
-		klog.Infof(`%v alert "%v" has state "%v"`, logPrefix, alertName, alertState)
+		klog.Infof(`alert "%v" has state "%v"`, alertName, alertState)
 		if alertState == "firing" {
 			g.firingAlerts[alertName] = append(g.firingAlerts[alertName], result.Labels)
 		}
@@ -286,8 +285,7 @@ func (g *Gatherer) updateAlertsCache(ctx context.Context, metricsClient rest.Int
 }
 
 func (g *Gatherer) updateVersionCache(ctx context.Context, configClient configv1client.ConfigV1Interface) error {
-	const logPrefix = "conditional gatherer: "
-	klog.Info(logPrefix + "updating version cache for conditional gatherer")
+	klog.Info("updating version cache for conditional gatherer")
 
 	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if err != nil {
@@ -295,7 +293,7 @@ func (g *Gatherer) updateVersionCache(ctx context.Context, configClient configv1
 	}
 
 	g.clusterVersion = clusterVersion.Status.Desired.Version
-	klog.Infof(logPrefix+"cluster version is '%v'", g.clusterVersion)
+	klog.Infof("cluster version is '%v'", g.clusterVersion)
 	return nil
 }
 

--- a/pkg/gatherers/conditional/conditional_gatherer_test.go
+++ b/pkg/gatherers/conditional/conditional_gatherer_test.go
@@ -218,11 +218,19 @@ func Test_Gatherer_doesClusterVersionMatch(t *testing.T) {
 
 	for _, testCase := range []testCase{
 		{
-			expectedVersion: "4.8.x",
-			shouldMatch:     true,
+			expectedVersion: "4",
+			shouldMatch:     false,
+		},
+		{
+			expectedVersion: "4.8",
+			shouldMatch:     false,
 		},
 		{
 			expectedVersion: "4.8.0",
+			shouldMatch:     true,
+		},
+		{
+			expectedVersion: "4.8.x",
 			shouldMatch:     true,
 		},
 		{

--- a/pkg/gatherers/conditional/conditional_gatherer_test.go
+++ b/pkg/gatherers/conditional/conditional_gatherer_test.go
@@ -241,13 +241,25 @@ func Test_Gatherer_doesClusterVersionMatch(t *testing.T) {
 			expectedVersion: ">1.0.0 <2.0.0 || >=3.0.0",
 			shouldMatch:     true,
 		},
+		{
+			expectedVersion: "4.8.0-0.nightly-2021-06-13-101614",
+			shouldMatch:     true,
+		},
+		{
+			expectedVersion: "4.8.0-0.ci-2021-06-13-101614",
+			shouldMatch:     false,
+		},
+		{
+			expectedVersion: "4.8.0-1.nightly-2021-06-13-101614",
+			shouldMatch:     false,
+		},
 	} {
 		doesMatch, err := gatherer.doesClusterVersionMatch(testCase.expectedVersion)
 		if err != nil {
 			assert.Error(t, err)
 		}
 
-		assert.Equal(t, testCase.shouldMatch, doesMatch)
+		assert.Equalf(t, testCase.shouldMatch, doesMatch, "test case is '%v'", testCase)
 	}
 }
 

--- a/pkg/gatherers/conditional/conditions.go
+++ b/pkg/gatherers/conditional/conditions.go
@@ -100,14 +100,19 @@ func (g *Gatherer) doesClusterVersionMatch(expectedVersionExpression string) (bo
 		return false, err
 	}
 
+	shortClusterVersion, err := semver.Parse(g.clusterVersion)
+	if err != nil {
+		return false, err
+	}
+
+	// ignore everything after the first three numbers for the short version
+	shortClusterVersion.Pre = nil
+	shortClusterVersion.Build = nil
+
 	expectedRange, err := semver.ParseRange(expectedVersionExpression)
 	if err != nil {
 		return false, err
 	}
 
-	// ignore everything after the first three numbers
-	clusterVersion.Pre = nil
-	clusterVersion.Build = nil
-
-	return expectedRange(clusterVersion), nil
+	return expectedRange(clusterVersion) || expectedRange(shortClusterVersion), nil
 }

--- a/pkg/gatherers/conditional/conditions_test.go
+++ b/pkg/gatherers/conditional/conditions_test.go
@@ -1,0 +1,53 @@
+package conditional
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_areAllConditionsSatisfied(t *testing.T) {
+	g := &Gatherer{
+		firingAlerts:   map[string][]AlertLabels{},
+		clusterVersion: "",
+	}
+	expectedVersion := "4.11.0-0.nightly-2022-05-25-193227"
+	conditions := []ConditionWithParams{
+		{
+			Type:  "alert_is_firing",
+			Alert: &AlertConditionParams{Name: "APIRemovedInNextEUSReleaseInUse"},
+		},
+		{
+			Type: "cluster_version_matches",
+			ClusterVersionMatches: &ClusterVersionMatchesConditionParams{
+				Version: expectedVersion,
+			},
+		},
+	}
+
+	// no conditions are satisfied
+	ok, err := g.areAllConditionsSatisfied(conditions)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	// only one condition is satisfied
+	g.firingAlerts["APIRemovedInNextEUSReleaseInUse"] = []AlertLabels{}
+	g.clusterVersion = "4.9.0"
+	ok, err = g.areAllConditionsSatisfied(conditions)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	// still one condition
+	g.firingAlerts = map[string][]AlertLabels{}
+	g.clusterVersion = expectedVersion
+	ok, err = g.areAllConditionsSatisfied(conditions)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	// finally both
+	g.firingAlerts["APIRemovedInNextEUSReleaseInUse"] = []AlertLabels{}
+	g.clusterVersion = expectedVersion
+	ok, err = g.areAllConditionsSatisfied(conditions)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/pkg/gatherers/conditional/gather_containers_logs.go
+++ b/pkg/gatherers/conditional/gather_containers_logs.go
@@ -116,7 +116,7 @@ func (g *Gatherer) gatherContainersLogs(
 		)
 		if err != nil {
 			newErr := fmt.Errorf("unable to get container logs: %v", err)
-			klog.Warningln(newErr.Error())
+			klog.Warning(newErr.Error())
 			errs = append(errs, newErr)
 		}
 


### PR DESCRIPTION
Fixes a bug with conditional gatherer integration tests

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No changes

## Documentation
<!-- Are these changes reflected in documentation? -->

No changes

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/conditional/conditional_gatherer_test.go`
- `pkg/gatherers/conditional/conditions_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

No new data was collected

## Changelog
<!-- Was changelog updated? -->

No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
