### PR TITLE
WIP: chore(manifests): adding insights capability annotations

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
     workload.openshift.io/allowed: "management"
+    capability.openshift.io/name: insights
   labels:
     openshift.io/cluster-monitoring: "true"
     name: openshift-insights

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   kind: ClusterRole
   name: system:auth-delegator
@@ -23,6 +24,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
@@ -31,7 +33,6 @@ subjects:
     namespace: openshift-insights
     name: operator
 ---
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -40,6 +41,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 rules:
   # allow the operator to update cluster operator status
   - apiGroups:
@@ -74,7 +76,6 @@ rules:
       - namespaces
     verbs:
       - get
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -85,6 +86,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   kind: Role
   name: monitoring-alertmanager-edit
@@ -92,9 +94,7 @@ subjects:
   - kind: ServiceAccount
     namespace: openshift-insights
     name: operator
-
 ---
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -104,6 +104,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   kind: ClusterRole
   name: insights-operator
@@ -111,7 +112,6 @@ subjects:
   - kind: ServiceAccount
     namespace: openshift-insights
     name: operator
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -121,6 +121,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 rules:
   - apiGroups:
       - ""
@@ -272,6 +273,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   kind: ClusterRole
   name: insights-operator-gather
@@ -279,7 +281,6 @@ subjects:
   - kind: ServiceAccount
     namespace: openshift-insights
     name: gather
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -289,6 +290,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   kind: ClusterRole
   name: cluster-reader
@@ -307,6 +309,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 rules:
   - apiGroups:
       - ""
@@ -328,6 +331,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   kind: Role
   name: insights-operator
@@ -335,7 +339,6 @@ subjects:
   - kind: ServiceAccount
     name: operator
     namespace: openshift-insights
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -346,6 +349,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 rules:
   - apiGroups:
       - ""
@@ -371,6 +375,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   kind: Role
   name: insights-operator
@@ -388,6 +393,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 rules:
   - apiGroups:
       - ''
@@ -410,6 +416,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 subjects:
   - kind: ServiceAccount
     name: operator
@@ -427,6 +434,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 rules:
   - apiGroups:
       - ''
@@ -449,6 +457,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 subjects:
   - kind: ServiceAccount
     name: operator

--- a/manifests/03-prometheus_role.yaml
+++ b/manifests/03-prometheus_role.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 rules:
 - apiGroups:
   - ""

--- a/manifests/03-prometheus_rolebinding.yaml
+++ b/manifests/03-prometheus_rolebinding.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/04-proxy-cert-configmap.yaml
+++ b/manifests/04-proxy-cert-configmap.yaml
@@ -8,5 +8,6 @@ metadata:
     release.openshift.io/create-only: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"

--- a/manifests/04-service-ca-configmap.yaml
+++ b/manifests/04-service-ca-configmap.yaml
@@ -9,3 +9,4 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights

--- a/manifests/04-serviceaccount.yaml
+++ b/manifests/04-serviceaccount.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -17,3 +18,4 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights

--- a/manifests/05-service.yaml
+++ b/manifests/05-service.yaml
@@ -7,6 +7,7 @@ metadata:
     service.alpha.openshift.io/serving-cert-secret-name: openshift-insights-serving-cert
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    capability.openshift.io/name: insights
   labels:
     app: insights-operator
   name: metrics

--- a/manifests/06-deployment-ibm-cloud-managed.yaml
+++ b/manifests/06-deployment-ibm-cloud-managed.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: insights-operator
     include.release.openshift.io/ibm-cloud-managed: "true"
+    capability.openshift.io/name: insights
   name: insights-operator
   namespace: openshift-insights
 spec:
@@ -17,6 +18,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        capability.openshift.io/name: insights
       labels:
         app: insights-operator
     spec:

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
 spec:
   strategy:
     type: Recreate
@@ -18,6 +19,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        capability.openshift.io/name: insights
       labels:
         app: insights-operator
     spec:

--- a/manifests/07-cluster-operator.yaml
+++ b/manifests/07-cluster-operator.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    capability.openshift.io/name: insights
 spec: {}
 status:
   versions:

--- a/manifests/07-servicemonitor.yaml
+++ b/manifests/07-servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    capability.openshift.io/name: insights
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/08-prometheus_rule.yaml
+++ b/manifests/08-prometheus_rule.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: insights
   name: insights-prometheus-rules
   namespace: openshift-insights
 spec:
@@ -29,4 +30,3 @@ spec:
       for: 5m
       labels:
         severity: info
-        


### PR DESCRIPTION
This is basically #646; I just want to see how presubmits work before openshift/api#1212 and later land, while the cluster-version operator doesn't know about the new capability.  And #646 is a draft, so no presubmits there yet.