### PR TITLE
Gather & store firing alerts in JSON too

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -24,6 +24,18 @@ Params is of type AlertIsFiringConditionParams:
   * 4.10+
 
 
+## ActiveAlerts
+
+gathers active alerts from the Alertmanager API V2 in the JSON format.
+Alert data is also still included in the [GatherMostRecentMetrics](#mostrecentmetrics) gatherer.
+
+* Location in archive: config/alerts.json
+* See: docs/insights-archive-sample/config/alerts.json
+* Id in config: active_alerts
+* Since version:
+  * 4.12+
+
+
 ## CRD
 
 collects the specified Custom Resource Definitions.

--- a/docs/insights-archive-sample/config/alerts.json
+++ b/docs/insights-archive-sample/config/alerts.json
@@ -1,0 +1,203 @@
+[
+    {
+        "labels": {
+            "alertname": "TargetDown",
+            "job": "telemeter-client",
+            "namespace": "openshift-monitoring",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "service": "telemeter-client",
+            "severity": "warning"
+        },
+        "annotations": {
+            "description": "100% of the telemeter-client/telemeter-client targets in openshift-monitoring namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support.",
+            "summary": "Some targets were not reachable from the monitoring server for an extended period of time."
+        },
+        "endsAt": "2022-01-05T09:07:46.565Z",
+        "startsAt": "2022-01-04T10:10:46.565Z",
+        "updatedAt": "2022-01-05T09:03:46.572Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    },
+    {
+        "labels": {
+            "alertname": "ClusterVersionOperatorDown",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "severity": "critical"
+        },
+        "annotations": {
+            "description": "The operator may be down or disabled. The cluster will not be kept up to date and upgrades will not be possible. Inspect the openshift-cluster-version namespace for events or changes to the cluster-version-operator deployment or pods to diagnose and repair.  For more information refer to https://console-openshift-console.apps.testing.tremes.03.01.2022.ccxdev.devshift.net/k8s/cluster/projects/openshift-cluster-version.",
+            "summary": "Cluster version operator has disappeared from Prometheus target discovery."
+        },
+        "endsAt": "2022-01-05T09:07:16.272Z",
+        "startsAt": "2022-01-04T14:49:16.272Z",
+        "updatedAt": "2022-01-05T09:03:16.274Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    },
+    {
+        "labels": {
+            "alertname": "TargetDown",
+            "job": "grafana",
+            "namespace": "openshift-monitoring",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "service": "grafana",
+            "severity": "warning"
+        },
+        "annotations": {
+            "description": "100% of the grafana/grafana targets in openshift-monitoring namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support.",
+            "summary": "Some targets were not reachable from the monitoring server for an extended period of time."
+        },
+        "endsAt": "2022-01-05T09:07:46.565Z",
+        "startsAt": "2022-01-04T10:10:46.565Z",
+        "updatedAt": "2022-01-05T09:03:46.572Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    },
+    {
+        "labels": {
+            "alertname": "TargetDown",
+            "job": "prometheus-k8s-thanos-sidecar",
+            "namespace": "openshift-monitoring",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "service": "prometheus-k8s-thanos-sidecar",
+            "severity": "warning"
+        },
+        "annotations": {
+            "description": "100% of the prometheus-k8s-thanos-sidecar/prometheus-k8s-thanos-sidecar targets in openshift-monitoring namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support.",
+            "summary": "Some targets were not reachable from the monitoring server for an extended period of time."
+        },
+        "endsAt": "2022-01-05T09:07:46.565Z",
+        "startsAt": "2022-01-04T10:10:46.565Z",
+        "updatedAt": "2022-01-05T09:03:46.572Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    },
+    {
+        "labels": {
+            "alertname": "TargetDown",
+            "job": "prometheus-k8s",
+            "namespace": "openshift-monitoring",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "service": "prometheus-k8s",
+            "severity": "warning"
+        },
+        "annotations": {
+            "description": "100% of the prometheus-k8s/prometheus-k8s targets in openshift-monitoring namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support.",
+            "summary": "Some targets were not reachable from the monitoring server for an extended period of time."
+        },
+        "endsAt": "2022-01-05T09:07:46.565Z",
+        "startsAt": "2022-01-04T10:10:46.565Z",
+        "updatedAt": "2022-01-05T09:03:46.572Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    },
+    {
+        "labels": {
+            "alertname": "Watchdog",
+            "namespace": "openshift-monitoring",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "severity": "none"
+        },
+        "annotations": {
+            "description": "This is an alert meant to ensure that the entire alerting pipeline is functional.\nThis alert is always firing, therefore it should always be firing in Alertmanager\nand always fire against a receiver. There are integrations with various notification\nmechanisms that send a notification when this alert is not firing. For example the\n\"DeadMansSnitch\" integration in PagerDuty.\n",
+            "summary": "An alert that should always be firing to certify that Alertmanager is working properly."
+        },
+        "endsAt": "2022-01-05T09:07:46.042Z",
+        "startsAt": "2022-01-03T10:14:16.042Z",
+        "updatedAt": "2022-01-05T09:03:46.045Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    },
+    {
+        "labels": {
+            "alertname": "TargetDown",
+            "job": "alertmanager-main",
+            "namespace": "openshift-monitoring",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "service": "alertmanager-main",
+            "severity": "warning"
+        },
+        "annotations": {
+            "description": "100% of the alertmanager-main/alertmanager-main targets in openshift-monitoring namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support.",
+            "summary": "Some targets were not reachable from the monitoring server for an extended period of time."
+        },
+        "endsAt": "2022-01-05T09:07:16.565Z",
+        "startsAt": "2022-01-04T10:10:46.565Z",
+        "updatedAt": "2022-01-05T09:03:16.571Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    },
+    {
+        "labels": {
+            "alertname": "AlertmanagerClusterDown",
+            "namespace": "openshift-monitoring",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "service": "alertmanager-main",
+            "severity": "warning"
+        },
+        "annotations": {
+            "description": "100% of Alertmanager instances within the  cluster have been up for less than half of the last 5m.",
+            "summary": "Half or more of the Alertmanager instances within the same cluster are down."
+        },
+        "endsAt": "2022-01-05T09:07:39.955Z",
+        "startsAt": "2022-01-04T10:03:09.955Z",
+        "updatedAt": "2022-01-05T09:03:39.958Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    },
+    {
+        "labels": {
+            "alertname": "TargetDown",
+            "job": "thanos-querier",
+            "namespace": "openshift-monitoring",
+            "openshift_io_alert_source": "platform",
+            "prometheus": "openshift-monitoring/k8s",
+            "service": "thanos-querier",
+            "severity": "warning"
+        },
+        "annotations": {
+            "description": "100% of the thanos-querier/thanos-querier targets in openshift-monitoring namespace have been unreachable for more than 15 minutes. This may be a symptom of network connectivity issues, down nodes, or failures within these components. Assess the health of the infrastructure and nodes running these targets and then contact support.",
+            "summary": "Some targets were not reachable from the monitoring server for an extended period of time."
+        },
+        "endsAt": "2022-01-05T09:07:46.565Z",
+        "startsAt": "2022-01-04T10:10:46.565Z",
+        "updatedAt": "2022-01-05T09:03:46.570Z",
+        "status": {
+            "inhibitedBy": [],
+            "silencedBy": [],
+            "state": "active"
+        }
+    }
+]

--- a/pkg/gatherers/clusterconfig/active_alerts.go
+++ b/pkg/gatherers/clusterconfig/active_alerts.go
@@ -1,0 +1,71 @@
+package clusterconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// alertLimit is the maximal number of recorded alerts
+	alertLimit = 1000
+)
+
+// we could use e.g https://pkg.go.dev/github.com/prometheus/alertmanager@v0.23.0/api/v2/models#GettableAlert,
+// but this allows us to control what attributes we want to include in the alert definition
+type alert struct {
+	Labels      map[string]string      `json:"labels"`
+	Annotations map[string]string      `json:"annotations"`
+	EndsAt      string                 `json:"endsAt"`
+	StartsAt    string                 `json:"startsAt"`
+	UpdatedAt   string                 `json:"updatedAt"`
+	Status      map[string]interface{} `json:"status"`
+}
+
+// GatherActiveAlerts gathers active alerts from the Alertmanager API V2 in the JSON format.
+// Alert data is also still included in the [GatherMostRecentMetrics](#mostrecentmetrics) gatherer.
+//
+// * Location in archive: config/alerts.json
+// * See: docs/insights-archive-sample/config/alerts.json
+// * Id in config: active_alerts
+// * Since version:
+//   * 4.12+
+func (g *Gatherer) GatherActiveAlerts(ctx context.Context) ([]record.Record, []error) {
+	alertsRESTClient, err := rest.RESTClientFor(g.alertsGatherKubeConfig)
+	if err != nil {
+		klog.Warningf("Unable to load alerts client, no alerts will be collected: %v", err)
+		return nil, nil
+	}
+
+	return gatherActiveAlerts(ctx, alertsRESTClient)
+}
+
+func gatherActiveAlerts(ctx context.Context, alertsClient rest.Interface) ([]record.Record, []error) {
+	alertsData, err := alertsClient.Get().AbsPath("api/v2/alerts").Param("active", "true").DoRaw(ctx)
+	if err != nil {
+		klog.Errorf("Unable to retrieve most recent alerts: %v", err)
+		return nil, []error{err}
+	}
+
+	var alerts []alert
+	err = json.Unmarshal(alertsData, &alerts)
+	if err != nil {
+		klog.Errorf("Unable to unmarshall alerts data: %v", err)
+		return nil, []error{err}
+	}
+	var errs []error
+	if len(alerts) > alertLimit {
+		originalCount := len(alerts)
+		alerts = alerts[:alertLimit]
+		errs = append(errs, fmt.Errorf("alert limit %d was exceeded! There were %d alerts", alertLimit, originalCount))
+	}
+	records := []record.Record{
+		{Name: "config/alerts", Item: record.JSONMarshaller{Object: alerts}},
+	}
+
+	return records, errs
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -82,6 +82,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"kube_controller_manager_logs":      (*Gatherer).GatherKubeControllerManagerLogs,
 	"overlapping_namespace_uids":        (*Gatherer).GatherNamespacesWithOverlappingUIDs,
 	"support_secret":                    (*Gatherer).GatherSupportSecret,
+	"active_alerts":                     (*Gatherer).GatherActiveAlerts,
 }
 
 func New(


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This adds new gatherer for gathering firing/active Prometheus alerts in JSON format as well. The original [recent metrics gatherer](https://github.com/openshift/insights-operator/blob/master/pkg/gatherers/clusterconfig/recent_metrics.go) still continues to gather the alerts (not in JSON) as well, but this can be removed in the future and we will keep the data only in JSON.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/alerts.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-6037
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
