### PR TITLE
Remove Bugzilla references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,5 +42,4 @@ Yes/No
 <!-- What are related references for this PR? -->
 
 https://issues.redhat.com/browse/???
-https://bugzilla.redhat.com/show_bug.cgi?id=???
 https://access.redhat.com/solutions/???

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ See [STYLEGUIDE](STYLEGUIDE.md) for file format and coding style guide.
 # Support
 
 Insights Operator is part of Red Hat OpenShift Container Platform. For product-related issues, please
-file a ticket [in Red Hat Bugzilla](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&component=Insights%20Operator) for "Insights Operator" component.
+file a ticket in [Red Hat JIRA](https://issues.redhat.com/secure/CreateIssue.jspa?pid=12332330&issuetype=1) for "Insights Operator" component.
 
 # License
 


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This removes references to Bugzilla, because OCP now uses JIRA.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://bugzilla.redhat.com/show_bug.cgi?id=???
https://access.redhat.com/solutions/???
