### PR TITLE
OCPBUGS-439: update the DVO metrics gatherer

### DIFF
--- a/docs/conditional-gatherer/README.md
+++ b/docs/conditional-gatherer/README.md
@@ -94,7 +94,7 @@ echo '{
 4. Wait for the alert to fire:
 ```bash
 export PROMETHEUS_HOST=$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath='{@.spec.host}')
-export INSECURE_PROMETHEUS_TOKEN=$(oc get secret $(oc get sa prometheus-k8s -n openshift-monitoring -o json | jq .secrets[0].name | tr --delete \") -n openshift-monitoring -o json | jq .metadata.annotations.\"openshift.io/token-secret.value\")
+export INSECURE_PROMETHEUS_TOKEN=$(oc get secret $(oc get sa prometheus-k8s -n openshift-monitoring -o json | jq .secrets[0].name | tr --delete \") -n openshift-monitoring -o json | jq .metadata.annotations.\"openshift.io/token-secret.value\" | tr --delete \")
 curl -g -s -k -H 'Cache-Control: no-cache' -H "Authorization: Bearer $INSECURE_PROMETHEUS_TOKEN" "https://$PROMETHEUS_HOST/api/v1/query" --data-urlencode 'query=ALERTS{alertstate="firing",alertname="SamplesImagestreamImportFailing"}' | jq ".data.result[]"
 ```
 

--- a/pkg/cmd/start/receiver.go
+++ b/pkg/cmd/start/receiver.go
@@ -20,7 +20,7 @@ func NewReceiver() *cobra.Command {
 		Use:   "start-receiver",
 		Short: "Start a listener that accepts and logs uploaded content",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return http.ListenAndServe(listen, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			return http.ListenAndServe(listen, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) { // nolint: gosec
 				klog.Infof("Handling %s", req.URL.Path)
 				contentType := req.Header.Get("Content-Type")
 				if len(contentType) == 0 {

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -158,7 +158,7 @@ func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (*insightscli
 		if isNotArchiveFile(fileInfo) {
 			continue
 		}
-		if !fileInfo.ModTime().After(since) {
+		if fileInfo.ModTime().Before(since) {
 			continue
 		}
 		recentFiles = append(recentFiles, file.Name())


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
The DVO metrics gatherer relied on the `deployment-validation-operator` namespace name, which is not very convenient, because it can be installed elsewhere.

Steps to verify:
1. Install the `deployment-validation-operator` through the OperatorHub (it will be installed in the `openshift-operators` namespace).
2. Create manually the metrics service for the DVO. You can use [this definition](https://github.com/app-sre/deployment-validation-operator/blob/330a67b6c64462673343c8a0d4f30fe91c5ecac9/deploy/openshift/service.yaml). This should be fixed with the https://issues.redhat.com/browse/DVO-60
3. Create some new namespace and deploy something (e.g the default httpd example) without the resource limits specified. This is required to introduce some DVO checks to be reported. 
4. Run IO gathering and check that the DVO metrics are gathered.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-439
https://access.redhat.com/solutions/???
