### PR TITLE
OCPBUGS-499: fix: order conditions by type to limit un-needed updates

### DIFF
--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -1,6 +1,8 @@
 package status
 
 import (
+	"sort"
+
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -101,10 +103,15 @@ func (c *conditions) findCondition(condition configv1.ClusterStatusConditionType
 	return nil
 }
 
+// entries returns a sorted list of status conditions from the mapped values.
+// The list is sorted by  by type ClusterStatusConditionType to ensure consistent ordering for deep equal checks.
 func (c *conditions) entries() []configv1.ClusterOperatorStatusCondition {
 	var res []configv1.ClusterOperatorStatusCondition
 	for _, v := range c.entryMap {
 		res = append(res, v)
 	}
+	sort.SliceStable(res, func(i, j int) bool {
+		return string(res[i].Type) < string(res[j].Type)
+	})
 	return res
 }

--- a/pkg/controller/status/conditions_test.go
+++ b/pkg/controller/status/conditions_test.go
@@ -52,6 +52,49 @@ func Test_conditions_entries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Condition array is always sorted by type",
+			fields: fields{entryMap: map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition{
+				configv1.OperatorProgressing: {
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+				configv1.OperatorAvailable: {
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+				configv1.OperatorDegraded: {
+					Type:               configv1.OperatorDegraded,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+			}},
+			want: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+				{
+					Type:               configv1.OperatorDegraded,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+				{
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,6 +103,9 @@ func Test_conditions_entries(t *testing.T) {
 			}
 			got := c.entries()
 			assert.ElementsMatchf(t, got, tt.want, "entries() = %v, want %v", got, tt.want)
+			for i, expected := range tt.want {
+				assert.Equal(t, expected, got[i])
+			}
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: ehila <ehila@redhat.com>

<!-- Short description of the PR. What does it do? -->
Sorts the conditions array to avoid un-needed updates cluster operator status field

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
N/A
## Documentation
<!-- Are these changes reflected in documentation? -->
N/A
## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/status/conditions_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->
N/A
## Changelog
<!-- Was changelog updated? -->
N/A
## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/TRT-481
