### PR TITLE
Implement insights report updating in the insightsoperators.operator.openshift.io resource

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -8,7 +8,7 @@ endpoint: https://console.redhat.com/api/ingress/v1/upload
 conditionalGathererEndpoint: https://console.redhat.com/api/gathering/gathering_rules
 impersonate: system:serviceaccount:openshift-insights:gather
 pull_report:
-  endpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports
+  endpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports?get_disabled=true
   delay: "60s"
   timeout: "3000s"
   min_retry: "30s"

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -147,7 +147,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	// know any previous last reported time
 	go uploader.Run(ctx)
 
-	reportGatherer := insightsreport.New(insightsClient, configObserver, uploader)
+	reportGatherer := insightsreport.New(insightsClient, configObserver, uploader, operatorClient.InsightsOperators())
 	statusReporter.AddSources(reportGatherer)
 	go reportGatherer.Run(ctx)
 

--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -265,6 +265,9 @@ func (c *Controller) updateInsightsMetrics(report types.SmartProxyReport) {
 	activeRecommendations := []types.InsightsRecommendation{}
 
 	for _, rule := range report.Data {
+		if rule.Disabled {
+			continue
+		}
 		switch rule.TotalRisk {
 		case 1:
 			low++
@@ -277,9 +280,6 @@ func (c *Controller) updateInsightsMetrics(report types.SmartProxyReport) {
 		}
 
 		if c.configurator.Config().DisableInsightsAlerts {
-			continue
-		}
-		if rule.Disabled {
 			continue
 		}
 		errorKeyStr, err := extractErrorKeyFromRuleData(rule)

--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -324,11 +325,12 @@ func (c *Controller) updateOperatorStatusCR(report types.SmartProxyReport) error
 			klog.Error("Unable to extract recommandation's error key: %v", err)
 			continue
 		}
+		ruleIDStr := strings.TrimSuffix(string(rule.RuleID), ".report")
 		healthCheck := v1.HealthCheck{
 			Description: rule.Description,
 			TotalRisk:   int32(rule.TotalRisk),
 			State:       v1.HealthCheckEnabled,
-			AdvisorURI:  fmt.Sprintf("https://console.redhat.com/openshift/insights/advisor/recommendations/%s%%7C%s", rule.RuleID, errorKey),
+			AdvisorURI:  fmt.Sprintf("https://console.redhat.com/openshift/insights/advisor/recommendations/%s%%7C%s", ruleIDStr, errorKey),
 		}
 
 		if rule.Disabled {

--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -322,7 +322,7 @@ func (c *Controller) updateOperatorStatusCR(report types.SmartProxyReport) error
 	for _, rule := range report.Data {
 		errorKey, err := extractErrorKeyFromRuleData(rule)
 		if err != nil {
-			klog.Error("Unable to extract recommandation's error key: %v", err)
+			klog.Error("Unable to extract recommendation's error key: %v", err)
 			continue
 		}
 		ruleIDStr := strings.TrimSuffix(string(rule.RuleID), ".report")

--- a/pkg/insights/insightsreport/insightsreport_test.go
+++ b/pkg/insights/insightsreport/insightsreport_test.go
@@ -1,0 +1,67 @@
+package insightsreport
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/insights/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_extractErrorKeyFromRuleData(t *testing.T) {
+	testRuleID := "test-rule-id"
+	tests := []struct {
+		name             string
+		ruleResponse     types.RuleWithContentResponse
+		expectedErrorKey string
+		expectedError    error
+	}{
+		{
+			name: "Valid Rule response with some error key",
+			ruleResponse: types.RuleWithContentResponse{
+				TemplateData: map[string]interface{}{
+					"error_key": "ccx_rules_ocp.external.rules.empty_prometheus_db_volume.report",
+				},
+			},
+			expectedErrorKey: "ccx_rules_ocp.external.rules.empty_prometheus_db_volume.report",
+			expectedError:    nil,
+		},
+		{
+			name: "Rule response with empty TemplateData",
+			ruleResponse: types.RuleWithContentResponse{
+				RuleID:       types.RuleID(testRuleID),
+				TemplateData: nil,
+			},
+			expectedErrorKey: "",
+			expectedError:    fmt.Errorf("unable to convert the TemplateData of rule \"%s\" in an Insights report to a map", testRuleID),
+		},
+		{
+			name: "Rule response with wrong TemplateData",
+			ruleResponse: types.RuleWithContentResponse{
+				RuleID: types.RuleID(testRuleID),
+				TemplateData: map[string]interface{}{
+					"no_error_key": "lorem ipsum",
+				},
+			},
+			expectedErrorKey: "",
+			expectedError:    fmt.Errorf("TemplateData of rule \"%s\" does not contain error_key", testRuleID),
+		},
+		{
+			name: "Rule response with wrong error_key type",
+			ruleResponse: types.RuleWithContentResponse{
+				RuleID: types.RuleID(testRuleID),
+				TemplateData: map[string]interface{}{
+					"error_key": 1,
+				},
+			},
+			expectedErrorKey: "",
+			expectedError:    fmt.Errorf("The error_key of TemplateData of rule \"%s\" is not a string", testRuleID),
+		},
+	}
+
+	for _, tt := range tests {
+		errorKey, err := extractErrorKeyFromRuleData(tt.ruleResponse)
+		assert.Equal(t, tt.expectedErrorKey, errorKey)
+		assert.Equal(t, tt.expectedError, err)
+	}
+}

--- a/pkg/insights/types/types.go
+++ b/pkg/insights/types/types.go
@@ -22,7 +22,6 @@ type ReportResponseMeta struct {
 // RuleWithContentResponse represents a single rule in the response of /report endpoint
 type RuleWithContentResponse struct {
 	RuleID          RuleID      `json:"rule_id"`
-	ErrorKey        ErrorKey    `json:"-"`
 	CreatedAt       string      `json:"created_at"`
 	Description     string      `json:"description"`
 	Generic         string      `json:"details"`


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This implements the `insightsReport` part in the status of the new `insightsoperator.operator.openshift.io` CRD. When there are some active recommendations (including disabled ones) in a cluster then you should be able to see them in the output of `oc get insightsoperators.operator.openshift.io cluster -o yaml`

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

No docs

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/insights/insightsreport/insightsreport_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-8871
https://issues.redhat.com/browse/CCXDEV-7397
https://access.redhat.com/solutions/???
