### PR TITLE
OCPBUGS-959: manifests/02-namespace: Explicitly clear run-level label

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -11,4 +11,5 @@ metadata:
     capability.openshift.io/name: Insights
   labels:
     openshift.io/cluster-monitoring: "true"
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
     name: openshift-insights


### PR DESCRIPTION
The label was dropped back in:

```console
$ git --no-pager log -1 --oneline 75f34c7a944e20904d48949a3bd9b1f9496252c0
75f34c7a manifests: Remove run-level, insights operator does not need it
```

That landed between 4.2 and 4.3:

```console
$ git --no-pager grep openshift.io/run-level origin/release-4.2 -- manifests
origin/release-4.2:manifests/02-namespace.yaml:    openshift.io/run-level: "1"
$ git --no-pager grep openshift.io/run-level origin/release-4.3 -- manifests
...no hits...
```

So clusters which were born in 4.1 or 4.2 may have the old label still in place.  This commit clears it like openshift/cluster-version-operator@539e944920 (openshift/cluster-version-operator#623), so the cluster-version operator will clear the stale label.

## Categories

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)