### PR TITLE
OCPBUGS-1068: fix alert namespace label

### DIFF
--- a/manifests/10-prometheus_rule.yaml
+++ b/manifests/10-prometheus_rule.yaml
@@ -17,19 +17,21 @@ spec:
         description: 'Insights operator is disabled. In order to enable Insights and benefit from recommendations specific to your cluster, please follow steps listed in the documentation: https://docs.openshift.com/container-platform/latest/support/remote_health_monitoring/enabling-remote-health-reporting.html'
         summary: Insights operator is disabled.
       expr: |
-       cluster_operator_conditions{name="insights", condition="Disabled"} == 1
+       max without (job, pod, service, instance) (cluster_operator_conditions{name="insights", condition="Disabled"} == 1)
       for: 5m
       labels:
         severity: info
+        namespace: openshift-insights
     - alert: SimpleContentAccessNotAvailable
       annotations:
         description: 'Simple content access (SCA) is not enabled. Once enabled, Insights Operator can automatically import the SCA certificates from Red Hat OpenShift Cluster Manager making it easier to use the content provided by your Red Hat subscriptions when creating container images. See https://docs.openshift.com/container-platform/latest/cicd/builds/running-entitled-builds.html for more information.'
         summary: Simple content access certificates are not available.
       expr: |
-       max_over_time(cluster_operator_conditions{name="insights", condition="SCAAvailable", reason="NotFound"}[5m]) == 0
+       max without (job, pod, service, instance) (max_over_time(cluster_operator_conditions{name="insights", condition="SCAAvailable", reason="NotFound"}[5m]) == 0)
       for: 5m
       labels:
         severity: info
+        namespace: openshift-insights
     - alert: InsightsRecommendationActive
       annotations:
         summary: An Insights recommendation is active for this cluster.


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Our `InsightsDisabled` and `SimpleContentAccessNotAvailable` alerts don't set the `namespace` level and thus they end up with the CVO namespace label, because they are based on metrics from the CVO.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-1068
https://access.redhat.com/solutions/???
