### PR TITLE
OCPBUGS-13930: feat(containers_logs): allows filter by specific container

### DIFF
--- a/pkg/gatherers/clusterconfig/gather_kube_controller_manager_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_kube_controller_manager_logs.go
@@ -38,7 +38,7 @@ import (
 // ### Changes
 // None
 func (g *Gatherer) GatherKubeControllerManagerLogs(ctx context.Context) ([]record.Record, []error) {
-	containersFilter := common.LogContainersFilter{
+	containersFilter := &common.LogResourceFilter{
 		Namespace:                "openshift-kube-controller-manager",
 		LabelSelector:            "app=kube-controller-manager",
 		ContainerNameRegexFilter: "kube-controller-manager",
@@ -65,8 +65,8 @@ func (g *Gatherer) GatherKubeControllerManagerLogs(ctx context.Context) ([]recor
 	return records, nil
 }
 
-func getKubeControllerManagerLogsMessagesFilter() common.LogMessagesFilter {
-	return common.LogMessagesFilter{
+func getKubeControllerManagerLogsMessagesFilter() *common.LogMessagesFilter {
+	return &common.LogMessagesFilter{
 		MessagesToSearch: []string{
 			"Internal error occurred: error resolving resource",
 			"syncing garbage collector with updated resources from discovery",

--- a/pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs.go
@@ -35,7 +35,7 @@ import (
 // ### Changes
 // None
 func (g *Gatherer) GatherOpenShiftAPIServerOperatorLogs(ctx context.Context) ([]record.Record, []error) {
-	containersFilter := common.LogContainersFilter{
+	containersFilter := &common.LogResourceFilter{
 		Namespace:     "openshift-apiserver-operator",
 		LabelSelector: "app=openshift-apiserver-operator",
 	}
@@ -61,8 +61,8 @@ func (g *Gatherer) GatherOpenShiftAPIServerOperatorLogs(ctx context.Context) ([]
 	return records, nil
 }
 
-func getAPIServerOperatorLogsMessagesFilter() common.LogMessagesFilter {
-	return common.LogMessagesFilter{
+func getAPIServerOperatorLogsMessagesFilter() *common.LogMessagesFilter {
+	return &common.LogMessagesFilter{
 		MessagesToSearch: []string{
 			"the server has received too many requests and has asked us",
 			"because serving request timed out and response had been started",

--- a/pkg/gatherers/clusterconfig/gather_openshift_authentication_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_authentication_logs.go
@@ -35,7 +35,7 @@ import (
 // ### Changes
 // None
 func (g *Gatherer) GatherOpenshiftAuthenticationLogs(ctx context.Context) ([]record.Record, []error) {
-	containersFilter := common.LogContainersFilter{
+	containersFilter := &common.LogResourceFilter{
 		Namespace:     "openshift-authentication",
 		LabelSelector: "app=oauth-openshift",
 	}
@@ -61,8 +61,8 @@ func (g *Gatherer) GatherOpenshiftAuthenticationLogs(ctx context.Context) ([]rec
 	return records, nil
 }
 
-func getOpenshiftAuthenticationLogsMessagesFilter() common.LogMessagesFilter {
-	return common.LogMessagesFilter{
+func getOpenshiftAuthenticationLogsMessagesFilter() *common.LogMessagesFilter {
+	return &common.LogMessagesFilter{
 		MessagesToSearch: []string{
 			"AuthenticationError: invalid resource name",
 		},

--- a/pkg/gatherers/clusterconfig/gather_openshift_sdn_controller_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_sdn_controller_logs.go
@@ -46,7 +46,7 @@ import (
 // ### Changes
 // None
 func (g *Gatherer) GatherOpenshiftSDNControllerLogs(ctx context.Context) ([]record.Record, []error) {
-	containersFilter := common.LogContainersFilter{
+	resourceFilter := &common.LogResourceFilter{
 		Namespace:     "openshift-sdn",
 		LabelSelector: "app=sdn-controller",
 	}
@@ -61,7 +61,7 @@ func (g *Gatherer) GatherOpenshiftSDNControllerLogs(ctx context.Context) ([]reco
 	records, err := common.CollectLogsFromContainers(
 		ctx,
 		coreClient,
-		containersFilter,
+		resourceFilter,
 		getSDNControllerLogsMessagesFilter(),
 		nil,
 	)
@@ -72,8 +72,8 @@ func (g *Gatherer) GatherOpenshiftSDNControllerLogs(ctx context.Context) ([]reco
 	return records, nil
 }
 
-func getSDNControllerLogsMessagesFilter() common.LogMessagesFilter {
-	return common.LogMessagesFilter{
+func getSDNControllerLogsMessagesFilter() *common.LogMessagesFilter {
+	return &common.LogMessagesFilter{
 		MessagesToSearch: []string{
 			`Node.+is not Ready`,
 			`Node.+may be offline... retrying`,

--- a/pkg/gatherers/clusterconfig/gather_openshift_sdn_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_sdn_logs.go
@@ -38,7 +38,7 @@ import (
 // ### Changes
 // None
 func (g *Gatherer) GatherOpenshiftSDNLogs(ctx context.Context) ([]record.Record, []error) {
-	containersFilter := common.LogContainersFilter{
+	containersFilter := &common.LogResourceFilter{
 		Namespace:     "openshift-sdn",
 		LabelSelector: "app=sdn",
 	}
@@ -64,8 +64,8 @@ func (g *Gatherer) GatherOpenshiftSDNLogs(ctx context.Context) ([]record.Record,
 	return records, nil
 }
 
-func getGatherOpenshiftSDNLogsMessageFilter() common.LogMessagesFilter {
-	return common.LogMessagesFilter{
+func getGatherOpenshiftSDNLogsMessageFilter() *common.LogMessagesFilter {
+	return &common.LogMessagesFilter{
 		MessagesToSearch: []string{
 			"Got OnEndpointsUpdate for unknown Endpoints",
 			"Got OnEndpointsDelete for unknown Endpoints",

--- a/pkg/gatherers/clusterconfig/gather_sap_vsystem_iptables_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_sap_vsystem_iptables_logs.go
@@ -85,7 +85,7 @@ func gatherSAPLicenseManagementLogs(
 	var errs []error
 
 	for _, item := range datahubs {
-		containersFilter := common.LogContainersFilter{
+		containersFilter := &common.LogResourceFilter{
 			Namespace:                item.GetNamespace(),
 			ContainerNameRegexFilter: "^vsystem-iptables$",
 		}
@@ -107,8 +107,8 @@ func gatherSAPLicenseManagementLogs(
 	return records, errs
 }
 
-func getSAPLicenseManagementLogsMessageFilter() common.LogMessagesFilter {
-	return common.LogMessagesFilter{
+func getSAPLicenseManagementLogsMessageFilter() *common.LogMessagesFilter {
+	return &common.LogMessagesFilter{
 		MessagesToSearch: []string{
 			"can't initialize iptables table",
 		},

--- a/pkg/gatherers/clusterconfig/gather_scheduler_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_scheduler_logs.go
@@ -46,7 +46,7 @@ func (g *Gatherer) GatherSchedulerLogs(ctx context.Context) ([]record.Record, []
 
 func gatherSchedulerLogs(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
 	records, err := common.CollectLogsFromContainers(ctx, coreClient,
-		common.LogContainersFilter{
+		&common.LogResourceFilter{
 			Namespace:     "openshift-kube-scheduler",
 			LabelSelector: "app=openshift-kube-scheduler",
 		},
@@ -62,8 +62,8 @@ func gatherSchedulerLogs(ctx context.Context, coreClient corev1client.CoreV1Inte
 	return records, nil
 }
 
-func getSchedulerLogsMessagesFilter() common.LogMessagesFilter {
-	return common.LogMessagesFilter{
+func getSchedulerLogsMessagesFilter() *common.LogMessagesFilter {
+	return &common.LogMessagesFilter{
 		MessagesToSearch: []string{"PodTopologySpread"},
 		SinceSeconds:     logDefaultSinceSeconds,
 		LimitBytes:       logDefaultLimitBytes,

--- a/pkg/gatherers/common/gather_logs.go
+++ b/pkg/gatherers/common/gather_logs.go
@@ -59,8 +59,8 @@ type LogMessagesFilter struct {
 func CollectLogsFromContainers( //nolint:gocyclo
 	ctx context.Context,
 	coreClient v1.CoreV1Interface,
-	containersFilter LogContainersFilter,
-	messagesFilter LogMessagesFilter,
+	containersFilter *LogContainersFilter,
+	messagesFilter *LogMessagesFilter,
 	buildLogFileName func(namespace string, podName string, containerName string) string,
 ) ([]record.Record, error) {
 	if buildLogFileName == nil {
@@ -212,7 +212,7 @@ func FilterLogFromScanner(scanner *bufio.Scanner, messagesToSearch []string, reg
 	return strings.Join(result, "\n"), nil
 }
 
-func podLogOptions(containerName string, messagesFilter LogMessagesFilter) *corev1.PodLogOptions {
+func podLogOptions(containerName string, messagesFilter *LogMessagesFilter) *corev1.PodLogOptions {
 	sinceSeconds := &messagesFilter.SinceSeconds
 	if messagesFilter.SinceSeconds == 0 {
 		sinceSeconds = nil

--- a/pkg/gatherers/common/gather_logs.go
+++ b/pkg/gatherers/common/gather_logs.go
@@ -22,6 +22,7 @@ type LogContainersFilter struct {
 	Namespace                string
 	LabelSelector            string
 	FieldSelector            string
+	PodNameRegexFilter       string
 	ContainerNameRegexFilter string
 	MaxNamespaceContainers   int
 }
@@ -80,6 +81,16 @@ func CollectLogsFromContainers( //nolint:gocyclo
 	var records []record.Record
 
 	for i := range pods.Items {
+		if len(containersFilter.PodNameRegexFilter) > 0 {
+			match, err := regexp.MatchString(containersFilter.PodNameRegexFilter, pods.Items[i].Name)
+			if err != nil {
+				return nil, err
+			}
+			if !match {
+				continue
+			}
+		}
+
 		var containerNames []string
 		for j := range pods.Items[i].Spec.Containers {
 			containerNames = append(containerNames, pods.Items[i].Spec.Containers[j].Name)

--- a/pkg/gatherers/common/gather_logs_test.go
+++ b/pkg/gatherers/common/gather_logs_test.go
@@ -74,10 +74,10 @@ func testGatherLogs(t *testing.T, regexSearch bool, stringToSearch string, shoul
 	records, err := CollectLogsFromContainers(
 		ctx,
 		coreClient,
-		LogContainersFilter{
+		&LogContainersFilter{
 			Namespace: testPodName,
 		},
-		LogMessagesFilter{
+		&LogMessagesFilter{
 			MessagesToSearch: []string{
 				stringToSearch,
 			},

--- a/pkg/gatherers/common/gather_logs_test.go
+++ b/pkg/gatherers/common/gather_logs_test.go
@@ -74,7 +74,7 @@ func testGatherLogs(t *testing.T, regexSearch bool, stringToSearch string, shoul
 	records, err := CollectLogsFromContainers(
 		ctx,
 		coreClient,
-		&LogContainersFilter{
+		&LogResourceFilter{
 			Namespace: testPodName,
 		},
 		&LogMessagesFilter{

--- a/pkg/gatherers/conditional/common.go
+++ b/pkg/gatherers/conditional/common.go
@@ -4,11 +4,16 @@ import (
 	"fmt"
 )
 
+var (
+	ErrAlertPodNameMissing      = fmt.Errorf("alert is missing 'pod' label")
+	ErrAlertPodNamespaceMissing = fmt.Errorf("alert is missing 'namespace' label")
+	ErrAlertPodContainerMissing = fmt.Errorf("alert is missing 'container' label")
+)
+
 func getAlertPodName(labels AlertLabels) (string, error) {
 	name, ok := labels["pod"]
 	if !ok {
-		newErr := fmt.Errorf("alert is missing 'pod' label")
-		return "", newErr
+		return "", ErrAlertPodNameMissing
 	}
 	return name, nil
 }
@@ -16,17 +21,15 @@ func getAlertPodName(labels AlertLabels) (string, error) {
 func getAlertPodNamespace(labels AlertLabels) (string, error) {
 	namespace, ok := labels["namespace"]
 	if !ok {
-		newErr := fmt.Errorf("alert is missing 'namespace' label")
-		return "", newErr
+		return "", ErrAlertPodNamespaceMissing
 	}
 	return namespace, nil
 }
 
 func getAlertPodContainer(labels AlertLabels) (string, error) {
 	container, ok := labels["container"]
-	if !ok && len(container) > 0 {
-		newErr := fmt.Errorf("alert is missing 'container' label")
-		return "", newErr
+	if !ok || len(container) == 0 {
+		return "", ErrAlertPodContainerMissing
 	}
 	return container, nil
 }

--- a/pkg/gatherers/conditional/common_test.go
+++ b/pkg/gatherers/conditional/common_test.go
@@ -1,6 +1,7 @@
 package conditional
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -28,13 +29,8 @@ func Test_getAlertPodName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getAlertPodName(tt.labels)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getAlertPodName() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("getAlertPodName() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -63,13 +59,8 @@ func Test_getAlertPodNamespace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getAlertPodNamespace(tt.labels)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getAlertPodNamespace() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("getAlertPodNamespace() got = %v, want %v", got, tt.want)
-			}
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -123,12 +114,8 @@ func TestGetAlertPodContainer(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			container, err := getAlertPodContainer(tc.labels)
-			if container != tc.expectedResult {
-				t.Errorf("Expected result to be %s but got %s", tc.expectedResult, container)
-			}
-			if err != tc.expectedErr {
-				t.Errorf("Expected error to be %v but got %v", tc.expectedErr, err)
-			}
+			assert.Equal(t, tc.expectedResult, container)
+			assert.Equal(t, tc.expectedErr, err)
 		})
 	}
 }

--- a/pkg/gatherers/conditional/common_test.go
+++ b/pkg/gatherers/conditional/common_test.go
@@ -1,8 +1,9 @@
 package conditional
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // nolint:dupl

--- a/pkg/gatherers/conditional/common_test.go
+++ b/pkg/gatherers/conditional/common_test.go
@@ -1,6 +1,8 @@
 package conditional
 
-import "testing"
+import (
+	"testing"
+)
 
 // nolint:dupl
 func Test_getAlertPodName(t *testing.T) {
@@ -67,6 +69,65 @@ func Test_getAlertPodNamespace(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("getAlertPodNamespace() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// nolint:dupl
+func TestGetAlertPodContainer(t *testing.T) {
+	testCases := []struct {
+		name           string
+		labels         AlertLabels
+		expectedResult string
+		expectedErr    error
+	}{
+		{
+			name: "valid container label",
+			labels: AlertLabels{
+				"container": "my-container",
+			},
+			expectedResult: "my-container",
+			expectedErr:    nil,
+		},
+		{
+			name:           "missing container label",
+			labels:         AlertLabels{},
+			expectedResult: "",
+			expectedErr:    ErrAlertPodContainerMissing,
+		},
+		{
+			name: "empty container label",
+			labels: AlertLabels{
+				"container": "",
+			},
+			expectedResult: "",
+			expectedErr:    ErrAlertPodContainerMissing,
+		},
+		{
+			name:           "nil labels",
+			labels:         nil,
+			expectedResult: "",
+			expectedErr:    ErrAlertPodContainerMissing,
+		},
+		{
+			name: "valid labels but missing container key",
+			labels: AlertLabels{
+				"namespace": "my-namespace",
+			},
+			expectedResult: "",
+			expectedErr:    ErrAlertPodContainerMissing,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			container, err := getAlertPodContainer(tc.labels)
+			if container != tc.expectedResult {
+				t.Errorf("Expected result to be %s but got %s", tc.expectedResult, container)
+			}
+			if err != tc.expectedErr {
+				t.Errorf("Expected error to be %v but got %v", tc.expectedErr, err)
 			}
 		})
 	}

--- a/pkg/gatherers/conditional/gather_containers_logs.go
+++ b/pkg/gatherers/conditional/gather_containers_logs.go
@@ -89,7 +89,7 @@ func (g *Gatherer) gatherContainersLogs(
 			continue
 		}
 
-		logContainersFilter := common.LogContainersFilter{
+		logContainersFilter := &common.LogContainersFilter{
 			Namespace: info.namespace,
 		}
 
@@ -109,7 +109,7 @@ func (g *Gatherer) gatherContainersLogs(
 			ctx,
 			coreClient,
 			logContainersFilter,
-			common.LogMessagesFilter{
+			&common.LogMessagesFilter{
 				TailLines: params.TailLines,
 				Previous:  params.Previous,
 			},

--- a/pkg/gatherers/conditional/gather_containers_logs.go
+++ b/pkg/gatherers/conditional/gather_containers_logs.go
@@ -142,24 +142,24 @@ func (g *Gatherer) gatherContainersLogs(
 }
 
 func parseAlertLabels(labels AlertLabels) (podInfo, error) {
-	var podInfo podInfo
+	var info podInfo
 	podNamespace, err := getAlertPodNamespace(labels)
 	if err != nil {
-		return podInfo, err
+		return info, err
 	}
-	podInfo.namespace = podNamespace
+	info.namespace = podNamespace
 
 	podName, err := getAlertPodName(labels)
 	if err != nil {
-		return podInfo, err
+		return info, err
 	}
-	podInfo.name = podName
+	info.name = podName
 
 	podContainer, err := getAlertPodContainer(labels)
 	if err != nil {
-		return podInfo, err
+		return info, err
 	}
-	podInfo.container = podContainer
+	info.container = podContainer
 
-	return podInfo, nil
+	return info, nil
 }

--- a/pkg/gatherers/conditional/gather_containers_logs.go
+++ b/pkg/gatherers/conditional/gather_containers_logs.go
@@ -96,6 +96,8 @@ func (g *Gatherer) gatherContainersLogs(
 		if len(params.Container) > 0 {
 			logContainersFilter.ContainerNameRegexFilter = fmt.Sprintf("^%s$", params.Container)
 		} else if len(info.container) > 0 {
+			// KubePod* conditions does not have the container so, we need to verify it first,
+			// and then we can apply it to the creation of the regex rule.
 			logContainersFilter.ContainerNameRegexFilter = fmt.Sprintf("^%s$", info.container)
 		}
 

--- a/pkg/gatherers/conditional/gather_containers_logs.go
+++ b/pkg/gatherers/conditional/gather_containers_logs.go
@@ -104,6 +104,7 @@ func (g *Gatherer) gatherContainersLogs(
 		if len(params.PodName) > 0 {
 			logContainersFilter.PodNameRegexFilter = fmt.Sprintf("^%s$", params.PodName)
 		} else {
+			// If we are not overwriting the PodName with params, we use the one from the alert.
 			logContainersFilter.FieldSelector = fmt.Sprintf("metadata.name=%s", info.name)
 		}
 
@@ -159,6 +160,8 @@ func parseAlertLabels(labels AlertLabels) (podInfo, error) {
 
 	podContainer, err := getAlertPodContainer(labels)
 	if err != nil {
+		// Some alerts don't have container, so it isn't actually an error, but let's log it
+		// (e.g.: AlertmanagerFailedToSendAlerts)
 		return info, err
 	}
 	info.container = podContainer

--- a/pkg/gatherers/conditional/gather_containers_logs.go
+++ b/pkg/gatherers/conditional/gather_containers_logs.go
@@ -93,29 +93,29 @@ func (g *Gatherer) gatherContainersLogs(
 			continue
 		}
 
-		logContainersFilter := &common.LogContainersFilter{
+		resourceFilter := &common.LogResourceFilter{
 			Namespace: info.namespace,
 		}
 
 		if len(params.Container) > 0 {
-			logContainersFilter.ContainerNameRegexFilter = fmt.Sprintf("^%s$", params.Container)
+			resourceFilter.ContainerNameRegexFilter = fmt.Sprintf("^%s$", params.Container)
 		} else if len(info.container) > 0 {
 			// KubePod* conditions does not have the container so, we need to verify it first,
 			// and then we can apply it to the creation of the regex rule.
-			logContainersFilter.ContainerNameRegexFilter = fmt.Sprintf("^%s$", info.container)
+			resourceFilter.ContainerNameRegexFilter = fmt.Sprintf("^%s$", info.container)
 		}
 
 		if len(params.PodName) > 0 {
-			logContainersFilter.PodNameRegexFilter = fmt.Sprintf("^%s$", params.PodName)
+			resourceFilter.PodNameRegexFilter = fmt.Sprintf("^%s$", params.PodName)
 		} else {
 			// If we are not overwriting the PodName with params, we use the one from the alert.
-			logContainersFilter.FieldSelector = fmt.Sprintf("metadata.name=%s", info.name)
+			resourceFilter.FieldSelector = fmt.Sprintf("metadata.name=%s", info.name)
 		}
 
 		logRecords, err := common.CollectLogsFromContainers(
 			ctx,
 			coreClient,
-			logContainersFilter,
+			resourceFilter,
 			&common.LogMessagesFilter{
 				TailLines: params.TailLines,
 				Previous:  params.Previous,

--- a/pkg/gatherers/conditional/gather_containers_logs.go
+++ b/pkg/gatherers/conditional/gather_containers_logs.go
@@ -63,6 +63,10 @@ type podInfo struct {
 	container string
 }
 
+// gatherContainersLogs gathers logs from a pod's container in response to an alert firing.
+// It takes in a context, parameters for gathering logs, and a client for interacting with the Kubernetes API.
+// The parameters passed in will overwrite any information obtained from the alert labels.
+// It returns gathered logs and any errors that occurred during execution.
 func (g *Gatherer) gatherContainersLogs(
 	ctx context.Context,
 	params GatherContainersLogsParams,

--- a/pkg/gatherers/conditional/gather_containers_logs_test.go
+++ b/pkg/gatherers/conditional/gather_containers_logs_test.go
@@ -67,7 +67,7 @@ func TestGatherer_gatherContainersLogs(t *testing.T) {
 				Captured: time.Time{},
 				Item:     marshal.Raw{Str: "fake logs"},
 			}},
-			wantErr: nil,
+			wantErr: []error{ErrAlertPodContainerMissing},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/gatherers/conditional/gather_logs_of_namespace.go
+++ b/pkg/gatherers/conditional/gather_logs_of_namespace.go
@@ -67,11 +67,11 @@ func (g *Gatherer) gatherLogsOfNamespace(ctx context.Context, namespace string, 
 	records, err := common.CollectLogsFromContainers(
 		ctx,
 		coreClient,
-		common.LogContainersFilter{
+		&common.LogContainersFilter{
 			Namespace:              namespace,
 			MaxNamespaceContainers: 64, // arbitrary fixed value
 		},
-		common.LogMessagesFilter{
+		&common.LogMessagesFilter{
 			TailLines: tailLines,
 		},
 		func(namespace string, podName string, containerName string) string {

--- a/pkg/gatherers/conditional/gather_logs_of_namespace.go
+++ b/pkg/gatherers/conditional/gather_logs_of_namespace.go
@@ -67,7 +67,7 @@ func (g *Gatherer) gatherLogsOfNamespace(ctx context.Context, namespace string, 
 	records, err := common.CollectLogsFromContainers(
 		ctx,
 		coreClient,
-		&common.LogContainersFilter{
+		&common.LogResourceFilter{
 			Namespace:              namespace,
 			MaxNamespaceContainers: 64, // arbitrary fixed value
 		},

--- a/pkg/gatherers/conditional/gathering_functions.go
+++ b/pkg/gatherers/conditional/gathering_functions.go
@@ -94,6 +94,7 @@ type GatherAPIRequestCountsParams struct {
 // GatherContainersLogsParams defines parameters for container_logs gatherer
 type GatherContainersLogsParams struct {
 	AlertName string `json:"alert_name"`
+	PodName   string `json:"pod_name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 	Container string `json:"container,omitempty"`
 	TailLines int64  `json:"tail_lines"`


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR enables `containers_logs` conditional gather to collect logs only from the given container and specific pods.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

n/a

## Documentation
<!-- Are these changes reflected in documentation? -->

n/a

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

n/a

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-8768
