### PR TITLE
[release-4.11] OCPBUGS-1355: update the DVO metrics gatherer (#664)

### DIFF
--- a/pkg/cmd/start/receiver.go
+++ b/pkg/cmd/start/receiver.go
@@ -20,7 +20,7 @@ func NewReceiver() *cobra.Command {
 		Use:   "start-receiver",
 		Short: "Start a listener that accepts and logs uploaded content",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return http.ListenAndServe(listen, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			return http.ListenAndServe(listen, http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) { // nolint: gosec
 				klog.Infof("Handling %s", req.URL.Path)
 				contentType := req.Header.Get("Content-Type")
 				if len(contentType) == 0 {

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -158,7 +158,7 @@ func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (*insightscli
 		if isNotArchiveFile(fileInfo) {
 			continue
 		}
-		if !fileInfo.ModTime().After(since) {
+		if fileInfo.ModTime().Before(since) {
 			continue
 		}
 		recentFiles = append(recentFiles, file.Name())


### PR DESCRIPTION
* OCPBUGS-439 update the DVO metrics gatherer

* Fix linting

<!-- Short description of the PR. What does it do? -->
Backport of the https://github.com/openshift/insights-operator/pull/664

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Enhancement
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->


## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->



## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-1355
https://access.redhat.com/solutions/???
