### PR TITLE
OCPBUGS-1351: do not include disabled rules in the total metric

### DIFF
--- a/pkg/insights/insightsreport/insightsreport_test.go
+++ b/pkg/insights/insightsreport/insightsreport_test.go
@@ -21,7 +21,7 @@ func Test_readInsightsReport(t *testing.T) {
 		{
 			name: "basic test with all rules enabled",
 			testController: &Controller{
-				configurator: config.NewMockConfigurator(&config.Controller{
+				configurator: config.NewMockSecretConfigurator(&config.Controller{
 					DisableInsightsAlerts: false,
 				}),
 			},
@@ -108,7 +108,7 @@ func Test_readInsightsReport(t *testing.T) {
 		{
 			name: "basic test with some rules disabled",
 			testController: &Controller{
-				configurator: config.NewMockConfigurator(&config.Controller{
+				configurator: config.NewMockSecretConfigurator(&config.Controller{
 					DisableInsightsAlerts: false,
 				}),
 			},
@@ -183,7 +183,7 @@ func Test_readInsightsReport(t *testing.T) {
 		{
 			name: "Insights recommendations as alerts are disabled => no active recommendations",
 			testController: &Controller{
-				configurator: config.NewMockConfigurator(&config.Controller{
+				configurator: config.NewMockSecretConfigurator(&config.Controller{
 					DisableInsightsAlerts: true,
 				}),
 			},


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

No new data

## Documentation
<!-- Are these changes reflected in documentation? -->

no docs required

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->
improvements in
- `pkg/insights/insightsreport/insightsreport_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
