### PR TITLE
OCPBUGS-1949: limit the size of logs loaded into memory

### DIFF
--- a/pkg/gatherers/clusterconfig/kube_controller_manager_logs.go
+++ b/pkg/gatherers/clusterconfig/kube_controller_manager_logs.go
@@ -40,7 +40,7 @@ func (g *Gatherer) GatherKubeControllerManagerLogs(ctx context.Context) ([]recor
 		},
 		IsRegexSearch: true,
 		SinceSeconds:  logDefaultSinceSeconds,
-		LimitBytes:    0,
+		LimitBytes:    5 * logDefaultLimitBytes,
 	}
 
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
