### PR TITLE
OCPBUGS-2346: refactor(dvo_metrics): remove name and namespace from dvo metrics

### DIFF
--- a/pkg/gatherers/clusterconfig/dvo_metrics.go
+++ b/pkg/gatherers/clusterconfig/dvo_metrics.go
@@ -130,15 +130,17 @@ func gatherDVOMetricsFromEndpoint(
 		}
 	}()
 
+	// precompile regex rules
+	regexString := `(?m)(,?%s=[^\,\}]*")`
+	filterProps := []*regexp.Regexp{
+		regexp.MustCompile(fmt.Sprintf(regexString, "name")),
+		regexp.MustCompile(fmt.Sprintf(regexString, "namespace")),
+	}
 	prefixedLines, err := utils.ReadAllLinesWithPrefix(dataReader, dvoMetricsPrefix, func(b []byte) []byte {
-		filterProps := []string{"name", "namespace"}
-
-		for _, f := range filterProps {
-			re := regexp.MustCompile(fmt.Sprintf(`(?m)(,?%s=[^\,\}]*")`, f))
+		for _, re := range filterProps {
 			str := re.ReplaceAllString(string(b), "")
 			b = []byte(str)
 		}
-
 		return b
 	})
 	if err != io.EOF {

--- a/pkg/utils/read_lines_with_prefix.go
+++ b/pkg/utils/read_lines_with_prefix.go
@@ -8,7 +8,7 @@ import (
 
 // ReadAllLinesWithPrefix reads lines from the given reader
 // and returns those that begin with the specified prefix.
-func ReadAllLinesWithPrefix(reader io.Reader, prefix []byte) ([]byte, error) {
+func ReadAllLinesWithPrefix(reader io.Reader, prefix []byte, lineFunc func(b []byte) []byte) ([]byte, error) {
 	buff := []byte{}
 	tmp := make([]byte, 1024)
 	partialLine := []byte{}
@@ -47,6 +47,9 @@ func ReadAllLinesWithPrefix(reader io.Reader, prefix []byte) ([]byte, error) {
 		// The slice now only contains full lines.
 		for _, line := range lines {
 			buff = appendBufferIfLinePrefixed(buff, prefix, line)
+			if lineFunc != nil {
+				buff = lineFunc(buff)
+			}
 		}
 
 		// If the EOF was reported by the reader.

--- a/pkg/utils/read_lines_with_prefix_test.go
+++ b/pkg/utils/read_lines_with_prefix_test.go
@@ -14,7 +14,7 @@ func Test_ReadAllLinesWithPrefix(t *testing.T) {
 		"prefix_fourth_line",
 		"prefix_last_line",
 	}, string(MetricsLineSep)))
-	lines, err := ReadAllLinesWithPrefix(reader, []byte("prefix_"))
+	lines, err := ReadAllLinesWithPrefix(reader, []byte("prefix_"), nil)
 	if err != nil && err != io.EOF {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements the filtering for DVO Metrics information. The idea is that the DVO metrics will have the `name` and `namespace` information on the cluster unless the IO archive will not have this information by default.

**How to test it?**

- Create a Cluster (clusterbot or AWS)
- Install DVO from its repository (or you can run it locally)
    - Allow openshift-monitoring to access the metrics:
```sh
$ oc process --local NAMESPACE='openshift-monitoring' -f deploy/openshift/network-policies.yaml | oc create -f -
```
[deploy/openshift/network-policies.yaml](https://github.com/app-sre/deployment-validation-operator/blob/master/deploy/openshift/network-policies.yaml)

- Forward metrics service:
```
$ kubectl port-forward service/deployment-validation-operator-metrics 8383:8383 -n openshift-operators
```
- Get this PR and you can run it locally
- Create a standard httpserver deployment at the `default` namespace, and scale it down to 2 instances

**You should expect to:**
- The DVO metrics being generated here
```sh
$ curl http://localhost:8383/metrics
```
- IO should gather this info at the `dvo_metrics` and remove the namespace and name from the metric

## Categories

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
N/A

## Documentation
N/A

## Unit Tests
WIP

## Privacy

Yes. There are no sensitive data in the newly collected information.

## Changelog

## Breaking Changes

Yes. It removes the `name` and `namespace` from DVO metrics.

## References

https://issues.redhat.com/browse/CCXDEV-9328
https://issues.redhat.com/browse/OCPBUGS-2346