### PR TITLE
Add new gatherer for openshift ingress' error logs

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -691,6 +691,26 @@ Response see:
 * Id in config: clusterconfig/openshift_apiserver_operator_logs
 
 
+## OpenShiftIngressLogs
+
+collects logs from openshift-ingress:
+  - if the log line is on error level
+  - if the log line is on warning level and contains "error" substring
+
+The Kubernetes API:
+
+	https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+
+Response see:
+
+	https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+
+* Location in archive: config/pod/openshift-ingress/logs/{pod-name}/errors.log
+* Id in config: cluspoterconfig/openshift_ingress_logs
+* Since version:
+  - 4.12+
+
+
 ## OpenshiftAuthenticationLogs
 
 collects logs from pods in openshift-authentication namespace with following substring:
@@ -733,7 +753,7 @@ from "openshift-machine-api" namespace
 * Location of events in archive: events/
 * Id in config: clusterconfig/openshift_machine_api_events
 * Since versions:
-	 * 4.12+
+  - 4.12+
 
 
 ## OpenshiftSDNControllerLogs
@@ -805,10 +825,9 @@ API Reference:
 
 ## PNCC
 
-collects a summary of failed PodNetworkConnectivityChecks.
+collects a summary of failed PodNetworkConnectivityChecks from
+last 24 hours.
 Time of the most recently failed check with each reason and message is recorded.
-The checks are requested via a dynamic client and
-then unmarshaled into the appropriate structure.
 
 Resource API: podnetworkconnectivitychecks.controlplane.operator.openshift.io/v1alpha1
 Docs for relevant types: https://pkg.go.dev/github.com/openshift/api/operatorcontrolplane/v1alpha1

--- a/docs/insights-archive-sample/config/pod/openshift-ingress/router-default-5b656f8bc8-79wpd/errors.log
+++ b/docs/insights-archive-sample/config/pod/openshift-ingress/router-default-5b656f8bc8-79wpd/errors.log
@@ -1,0 +1,1 @@
+2022-10-04T13:46:57.361842703Z Trace[1053814210]: ---"Objects listed" error:the server is currently unable to handle the request (get routes.route.openshift.io) 30003ms (13:46:57.361)

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -60,6 +60,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"openshift_sdn_logs":                (*Gatherer).GatherOpenshiftSDNLogs,
 	"openshift_sdn_controller_logs":     (*Gatherer).GatherOpenshiftSDNControllerLogs,
 	"openshift_authentication_logs":     (*Gatherer).GatherOpenshiftAuthenticationLogs,
+	"openshift_ingress_logs":            (*Gatherer).GatherOpenShiftIngressLogs,
 	"sap_config":                        (*Gatherer).GatherSAPConfig,
 	"sap_license_management_logs":       (*Gatherer).GatherSAPVsystemIptablesLogs,
 	"sap_pods":                          (*Gatherer).GatherSAPPods,

--- a/pkg/gatherers/clusterconfig/openshift_ingress_logs.go
+++ b/pkg/gatherers/clusterconfig/openshift_ingress_logs.go
@@ -1,0 +1,65 @@
+package clusterconfig
+
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/insights-operator/pkg/gatherers/common"
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+// Extraction of dependency allows testing
+var ingressCollectLogsFromContainers = common.CollectLogsFromContainers
+
+// GatherOpenShiftIngressLogs collects logs from openshift-ingress:
+//   - if the log line is on error level
+//   - if the log line is on warning level and contains "error" substring
+//
+// The Kubernetes API:
+//
+//	https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+//
+// Response see:
+//
+//	https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+//
+// * Location in archive: config/pod/openshift-ingress/logs/{pod-name}/errors.log
+// * Id in config: cluspoterconfig/openshift_ingress_logs
+// * Since version:
+//   - 4.12+
+func (g *Gatherer) GatherOpenShiftIngressLogs(ctx context.Context) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	coreClient := gatherKubeClient.CoreV1()
+
+	containersFilter := common.LogContainersFilter{
+		Namespace: "openshift-ingress",
+	}
+
+	messagesFilter := common.LogMessagesFilter{
+		MessagesToSearch: []string{
+			"E\\d+\\s",
+			"W\\d+\\s.*error.*",
+		},
+		SinceSeconds:  logDefaultSinceSeconds,
+		LimitBytes:    logDefaultLimitBytes,
+		IsRegexSearch: true,
+	}
+
+	records, err := ingressCollectLogsFromContainers(
+		ctx,
+		coreClient,
+		containersFilter,
+		messagesFilter,
+		nil,
+	)
+
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return records, nil
+}

--- a/pkg/gatherers/clusterconfig/openshift_ingress_logs_test.go
+++ b/pkg/gatherers/clusterconfig/openshift_ingress_logs_test.go
@@ -1,0 +1,63 @@
+package clusterconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/gatherers/common"
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+)
+
+func Test_GatherOpenShiftIngressLogs(t *testing.T) {
+	tests := []struct {
+		name    string
+		fnMock  func() ([]record.Record, error)
+		wantErr bool
+		want    []record.Record
+	}{
+		{
+			name: "case collectLogsFromContainer returns an error",
+			fnMock: func() ([]record.Record, error) {
+				return []record.Record{}, errors.New("collectLogsFromContainer error")
+			},
+			wantErr: true,
+		},
+		{
+			name: "case collectLogsFromContainer returns a record collection",
+			fnMock: func() ([]record.Record, error) {
+				return []record.Record{{Name: "mock record"}}, nil
+			},
+			want: []record.Record{{Name: "mock record"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Mocking dependencies
+			mockGatherer := Gatherer{gatherProtoKubeConfig: &rest.Config{}}
+			ingressCollectLogsFromContainers = func(
+				ctx context.Context,
+				coreClient v1.CoreV1Interface,
+				containersFilter common.LogContainersFilter,
+				messagesFilter common.LogMessagesFilter,
+				buildLogFileName func(namespace string, podName string, containerName string) string,
+			) ([]record.Record, error) {
+				return test.fnMock()
+			}
+
+			// Given
+			records, err := mockGatherer.GatherOpenShiftIngressLogs(context.TODO())
+
+			// Assertions
+			if test.wantErr {
+				assert.Len(t, err, 1)
+				assert.Error(t, err[0])
+			}
+			assert.ElementsMatch(t, test.want, records)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/pod/openshift-ingress/router-default-5b656f8bc8-79wpd/errors.log`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md#OpenShiftIngressLogs`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/openshift_ingress_logs_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-9346
