### PR TITLE
[release-4.11] OCPBUGS-2320: refactor(dvo_metrics): remove name and namespace from dvo metrics

### DIFF
--- a/pkg/utils/read_lines_with_prefix.go
+++ b/pkg/utils/read_lines_with_prefix.go
@@ -8,7 +8,7 @@ import (
 
 // ReadAllLinesWithPrefix reads lines from the given reader
 // and returns those that begin with the specified prefix.
-func ReadAllLinesWithPrefix(reader io.Reader, prefix []byte) ([]byte, error) {
+func ReadAllLinesWithPrefix(reader io.Reader, prefix []byte, lineFunc func(b []byte) []byte) ([]byte, error) {
 	buff := []byte{}
 	tmp := make([]byte, 1024)
 	partialLine := []byte{}
@@ -47,6 +47,9 @@ func ReadAllLinesWithPrefix(reader io.Reader, prefix []byte) ([]byte, error) {
 		// The slice now only contains full lines.
 		for _, line := range lines {
 			buff = appendBufferIfLinePrefixed(buff, prefix, line)
+			if lineFunc != nil {
+				buff = lineFunc(buff)
+			}
 		}
 
 		// If the EOF was reported by the reader.

--- a/pkg/utils/read_lines_with_prefix_test.go
+++ b/pkg/utils/read_lines_with_prefix_test.go
@@ -14,7 +14,7 @@ func Test_ReadAllLinesWithPrefix(t *testing.T) {
 		"prefix_fourth_line",
 		"prefix_last_line",
 	}, string(MetricsLineSep)))
-	lines, err := ReadAllLinesWithPrefix(reader, []byte("prefix_"))
+	lines, err := ReadAllLinesWithPrefix(reader, []byte("prefix_"), nil)
 	if err != nil && err != io.EOF {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR backports #685

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Enhancement
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

N/A

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

No

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-2320
