### PR TITLE
PoC for running gather as a job

### DIFF
--- a/cmd/insights-operator/main.go
+++ b/cmd/insights-operator/main.go
@@ -60,6 +60,7 @@ func NewOperatorCommand() *cobra.Command {
 	cmd.AddCommand(start.NewOperator())
 	cmd.AddCommand(start.NewReceiver())
 	cmd.AddCommand(start.NewGather())
+	cmd.AddCommand(start.NewGatherAndUpload())
 
 	return cmd
 }

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -376,6 +376,8 @@ rules:
     verbs:
       - create
       - get
+      - list 
+      - delete
   - apiGroups:
       - apps
     resources:

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -369,6 +369,19 @@ rules:
       - pods
     verbs:
       - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -58,7 +58,12 @@ func NewGather() *cobra.Command {
 		Controller: config.Controller{
 			ConditionalGathererEndpoint: "https://console.redhat.com/api/gathering/gathering_rules",
 			StoragePath:                 "/var/lib/insights-operator",
-			Interval:                    30 * time.Minute,
+			Interval:                    2 * time.Hour,
+			Endpoint:                    "https://console.redhat.com/api/ingress/v1/upload",
+			ReportEndpoint:              "https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports",
+			ReportPullingDelay:          60 * time.Second,
+			ReportMinRetryTime:          10 * time.Second,
+			ReportPullingTimeout:        30 * time.Minute,
 		},
 	}
 	cfg := controllercmd.NewControllerCommandConfig("openshift-insights-operator", version.Get(), nil)

--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -67,11 +67,6 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 		return err
 	}
 
-	operatorClient, err := operatorv1client.NewForConfig(kubeConfig)
-	if err != nil {
-		return err
-	}
-
 	gatherProtoKubeConfig, gatherKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig := prepareGatherConfigs(
 		protoKubeConfig, kubeConfig, d.Impersonate,
 	)
@@ -109,11 +104,11 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	// the recorder stores the collected data and we flush at the end.
 	recdriver := diskrecorder.New(d.StoragePath)
 	rec := recorder.New(recdriver, d.Interval, anonymizer)
-	/* 	defer func() {
+	defer func() {
 		if err := rec.Flush(); err != nil {
 			klog.Error(err)
 		}
-	}() */
+	}()
 
 	authorizer := clusterauthorizer.New(configObserver)
 	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherKubeConfig)
@@ -122,12 +117,99 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,
 		configObserver, insightsClient,
 	)
-	uploader := insightsuploader.New(recdriver, insightsClient, configObserver, nil, nil, 0)
 
+	allFunctionReports := make(map[string]gather.GathererFunctionReport)
+	for _, gatherer := range gatherers {
+		functionReports, err := gather.CollectAndRecordGatherer(ctx, gatherer, rec, &gatherConfig)
+		if err != nil {
+			klog.Errorf("unable to process gatherer %v, error: %v", gatherer.GetName(), err)
+		}
+
+		for i := range functionReports {
+			allFunctionReports[functionReports[i].FuncName] = functionReports[i]
+		}
+	}
+
+	return gather.RecordArchiveMetadata(mapToArray(allFunctionReports), rec, anonymizer)
+}
+
+// Gather runs a single gather and stores the generated archive, without uploading it.
+// 1. Creates the necessary configs/clients
+// 2. Creates the configobserver to get more configs
+// 3. Initiates the recorder
+// 4. Executes a Gather
+// 5. Flushes the results
+func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) error {
+	klog.Infof("Starting insights-operator %s", version.Get().String())
+	// these are operator clients
+	kubeClient, err := kubernetes.NewForConfig(protoKubeConfig)
+	if err != nil {
+		return err
+	}
+
+	configClient, err := configv1client.NewForConfig(kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	operatorClient, err := operatorv1client.NewForConfig(kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	gatherProtoKubeConfig, gatherKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig := prepareGatherConfigs(
+		protoKubeConfig, kubeConfig, d.Impersonate,
+	)
+
+	// The reason for using longer context is that the upload can fail and then there is the exponential backoff
+	// See the insightsuploader Upload method
+	ctx, cancel := context.WithTimeout(context.Background(), d.Interval*4)
+	defer cancel()
+
+	tpEnabled, err := isTechPreviewEnabled(ctx, configClient)
+	if err != nil {
+		klog.Error("can't read cluster feature gates: %v", err)
+	}
+	var gatherConfig v1alpha1.GatherConfig
+	if tpEnabled {
+		insightsDataGather, err := configClient.ConfigV1alpha1().InsightsDataGathers().Get(ctx, "cluster", metav1.GetOptions{}) //nolint: govet
+		if err != nil {
+			return err
+		}
+		gatherConfig = insightsDataGather.Spec.GatherConfig
+	}
+
+	// ensure the insight snapshot directory exists
+	if _, err = os.Stat(d.StoragePath); err != nil && os.IsNotExist(err) {
+		if err = os.MkdirAll(d.StoragePath, 0777); err != nil {
+			return fmt.Errorf("can't create --path: %v", err)
+		}
+	}
+
+	// configobserver synthesizes all config into the status reporter controller
+	configObserver := configobserver.New(d.Controller, kubeClient)
+
+	// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
+	anonymizer, err := anonymization.NewAnonymizerFromConfig(
+		ctx, gatherKubeConfig, gatherProtoKubeConfig, protoKubeConfig, configObserver, nil)
+	if err != nil {
+		return err
+	}
+
+	// the recorder stores the collected data and we flush at the end.
+	recdriver := diskrecorder.New(d.StoragePath)
+	rec := recorder.New(recdriver, d.Interval, anonymizer)
+	authorizer := clusterauthorizer.New(configObserver)
+	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherKubeConfig)
+
+	gatherers := gather.CreateAllGatherers(
+		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,
+		configObserver, insightsClient,
+	)
+	uploader := insightsuploader.New(insightsClient, configObserver, nil)
 	reporter := insightsreport.New(insightsClient, configObserver, operatorClient.InsightsOperators())
 
 	allFunctionReports := make(map[string]gather.GathererFunctionReport)
-	gatherTime := metav1.Now()
 	for _, gatherer := range gatherers {
 		functionReports, err := gather.CollectAndRecordGatherer(ctx, gatherer, rec, &gatherConfig)
 		if err != nil {
@@ -141,23 +223,22 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	err = gather.RecordArchiveMetadata(mapToArray(allFunctionReports), rec, anonymizer)
 	if err != nil {
 		klog.Error(err)
+		return err
 	}
 	err = rec.Flush()
 	if err != nil {
 		klog.Error(err)
-	}
-
-	err = updateOperatorStatusCR(operatorClient.InsightsOperators(), allFunctionReports, gatherTime)
-	if err != nil {
-		klog.Error(err)
+		return err
 	}
 	lastArchive, err := recdriver.LastArchive()
 	if err != nil {
 		klog.Error(err)
+		return err
 	}
 	err = uploader.Upload(ctx, lastArchive)
 	if err != nil {
 		klog.Error(err)
+		return err
 	}
 	reporter.RetrieveReport()
 	return nil

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -9,7 +9,6 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
-	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,18 +19,14 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	"github.com/openshift/insights-operator/pkg/anonymization"
 	"github.com/openshift/insights-operator/pkg/authorizer/clusterauthorizer"
 	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
 	"github.com/openshift/insights-operator/pkg/controller/periodic"
 	"github.com/openshift/insights-operator/pkg/controller/status"
-	"github.com/openshift/insights-operator/pkg/gather"
 	"github.com/openshift/insights-operator/pkg/insights/insightsclient"
 	"github.com/openshift/insights-operator/pkg/ocm/clustertransfer"
 	"github.com/openshift/insights-operator/pkg/ocm/sca"
-	"github.com/openshift/insights-operator/pkg/recorder"
-	"github.com/openshift/insights-operator/pkg/recorder/diskrecorder"
 )
 
 // Operator is the type responsible for controlling the start up of the Insights Operator
@@ -64,12 +59,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 		return err
 	}
 
-	operatorClient, err := operatorv1client.NewForConfig(controller.KubeConfig)
-	if err != nil {
-		return err
-	}
-
-	gatherProtoKubeConfig, gatherKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig := prepareGatherConfigs(
+	gatherProtoKubeConfig, gatherKubeConfig, _, _ := prepareGatherConfigs(
 		controller.ProtoKubeConfig, controller.KubeConfig, s.Impersonate,
 	)
 
@@ -108,33 +98,9 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	// the status controller initializes the cluster operator object and retrieves
 	// the last sync time, if any was set
 	statusReporter := status.NewController(configClient.ConfigV1(), secretConfigObserver, apiConfigObserver, os.Getenv("POD_NAMESPACE"))
-
-	// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
-	anonymizer, err := anonymization.NewAnonymizerFromConfig(ctx, gatherKubeConfig,
-		gatherProtoKubeConfig, controller.ProtoKubeConfig, secretConfigObserver, apiConfigObserver)
-	if err != nil {
-		// in case of an error anonymizer will be nil and anonymization will be just skipped
-		klog.Errorf(anonymization.UnableToCreateAnonymizerErrorMessage, err)
-		return err
-	}
-
-	// the recorder periodically flushes any recorded data to disk as tar.gz files
-	// in s.StoragePath, and also prunes files above a certain age
-	recdriver := diskrecorder.New(s.StoragePath)
-	rec := recorder.New(recdriver, s.Interval, anonymizer)
-	//go rec.PeriodicallyPrune(ctx, statusReporter)
-
 	authorizer := clusterauthorizer.New(secretConfigObserver)
 	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherKubeConfig)
-
-	// the gatherers are periodically called to collect the data from the cluster
-	// and provide the results for the recorder
-	gatherers := gather.CreateAllGatherers(
-		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,
-		secretConfigObserver, insightsClient,
-	)
-	periodicGather := periodic.New(secretConfigObserver, rec, gatherers, anonymizer, operatorClient.InsightsOperators(), apiConfigObserver, kubeClient)
-	//statusReporter.AddSources(periodicGather.Sources()...)
+	periodicJobOrchestrator := periodic.New(secretConfigObserver, apiConfigObserver, kubeClient)
 
 	// check we can read IO container status and we are not in crash loop
 	initialCheckTimeout := s.Controller.Interval / 24
@@ -145,24 +111,13 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 		initialDelay = wait.Jitter(baseInitialDelay, 0.5)
 		klog.Infof("Unable to check insights-operator pod status. Setting initial delay to %s", initialDelay)
 	}
-	go periodicGather.Run(ctx.Done(), initialDelay)
-
-	// upload results to the provided client - if no client is configured reporting
-	// is permanently disabled, but if a client does exist the server may still disable reporting
-	/* 	uploader := insightsuploader.New(recdriver, insightsClient, secretConfigObserver, apiConfigObserver, statusReporter, initialDelay)
-	   	statusReporter.AddSources(uploader) */
+	go periodicJobOrchestrator.PeriodicPrune(ctx)
+	go periodicJobOrchestrator.Run(ctx.Done(), initialDelay)
 
 	// start reporting status now that all controller loops are added as sources
 	if err = statusReporter.Start(ctx); err != nil {
 		return fmt.Errorf("unable to set initial cluster status: %v", err)
 	}
-	// start uploading status, so that we
-	// know any previous last reported time
-	//go uploader.Run(ctx)
-
-	/* 	reportGatherer := insightsreport.New(insightsClient, secretConfigObserver, uploader, operatorClient.InsightsOperators())
-	   	statusReporter.AddSources(reportGatherer)
-	   	go reportGatherer.Run(ctx) */
 
 	scaController := initiateSCAController(ctx, kubeClient, secretConfigObserver, insightsClient)
 	if scaController != nil {

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -3,17 +3,12 @@ package periodic
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
-	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
-	"github.com/openshift/insights-operator/pkg/anonymization"
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
-	"github.com/openshift/insights-operator/pkg/controllerstatus"
-	"github.com/openshift/insights-operator/pkg/gatherers"
-	"github.com/openshift/insights-operator/pkg/recorder"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -21,7 +16,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
+/* const (
 	dataGatheredCondition = "DataGathered"
 	// NoDataGathered is a reason when there is no data gathered - e.g the resource is not in a cluster
 	noDataGatheredReason = "NoData"
@@ -33,58 +28,41 @@ const (
 	gatheredOKReason = "GatheredOK"
 	// GatheredWithError is a reason when data is gathered partially or with another error message
 	gatheredWithErrorReason = "GatheredWithError"
-)
+) */
 
 var (
-	serviceCABundle     = "service-ca-bundle"
-	serviceCABundlePath = "/var/run/configmaps/service-ca-bundle"
-	insightsNamespace   = "openshift-insights"
+	serviceCABundle             = "service-ca-bundle"
+	serviceCABundlePath         = "/var/run/configmaps/service-ca-bundle"
+	insightsNamespace           = "openshift-insights"
+	falseB                      = new(bool)
+	trueB                       = true
+	deletePropagationBackground = metav1.DeletePropagationBackground
 )
 
 // Controller periodically runs gatherers, records their results to the recorder
 // and flushes the recorder to create archives
 type Controller struct {
-	secretConfigurator  configobserver.Configurator
-	apiConfigurator     configobserver.APIConfigObserver
-	recorder            recorder.FlushInterface
-	gatherers           []gatherers.Interface
-	statuses            map[string]controllerstatus.StatusController
-	anonymizer          *anonymization.Anonymizer
-	insightsOperatorCLI operatorv1client.InsightsOperatorInterface
-	kubeClient          kubernetes.Clientset
+	secretConfigurator configobserver.Configurator
+	apiConfigurator    configobserver.APIConfigObserver
+	kubeClient         kubernetes.Clientset
+	image              string
 }
 
 // New creates a new instance of Controller which periodically invokes the gatherers
 // and flushes the recorder to create archives.
 func New(
 	secretConfigurator configobserver.Configurator,
-	rec recorder.FlushInterface,
-	listGatherers []gatherers.Interface,
-	anonymizer *anonymization.Anonymizer,
-	insightsOperatorCLI operatorv1client.InsightsOperatorInterface,
 	apiConfigurator configobserver.APIConfigObserver,
 	kubeClient *kubernetes.Clientset,
 ) *Controller {
-	statuses := make(map[string]controllerstatus.StatusController)
-
-	for _, gatherer := range listGatherers {
-		gathererName := gatherer.GetName()
-		statuses[gathererName] = controllerstatus.New(fmt.Sprintf("periodic-%s", gathererName))
-	}
-
 	return &Controller{
-		secretConfigurator:  secretConfigurator,
-		apiConfigurator:     apiConfigurator,
-		recorder:            rec,
-		gatherers:           listGatherers,
-		statuses:            statuses,
-		anonymizer:          anonymizer,
-		insightsOperatorCLI: insightsOperatorCLI,
-		kubeClient:          *kubeClient,
+		secretConfigurator: secretConfigurator,
+		apiConfigurator:    apiConfigurator,
+		kubeClient:         *kubeClient,
 	}
 }
 
-func (c *Controller) Sources() []controllerstatus.StatusController {
+/* func (c *Controller) Sources() []controllerstatus.StatusController {
 	keys := make([]string, 0, len(c.statuses))
 	for key := range c.statuses {
 		keys = append(keys, key)
@@ -95,7 +73,7 @@ func (c *Controller) Sources() []controllerstatus.StatusController {
 		sources = append(sources, c.statuses[key])
 	}
 	return sources
-}
+} */
 
 func (c *Controller) Run(stopCh <-chan struct{}, initialDelay time.Duration) {
 	defer utilruntime.HandleCrash()
@@ -114,7 +92,6 @@ func (c *Controller) Run(stopCh <-chan struct{}, initialDelay time.Duration) {
 	}
 
 	go wait.Until(func() { c.periodicTrigger(stopCh) }, time.Second, stopCh)
-
 	<-stopCh
 }
 
@@ -123,26 +100,35 @@ func (c *Controller) GatherJob() {
 		klog.V(3).Info("Gather is disabled by configuration.")
 		return
 	}
-
-	image, err := c.getInsightsImage()
-	if err != nil {
-		klog.Errorf("Can't get operator image. Gathering will not run: %v", err)
-		return
+	if c.image == "" {
+		image, err := c.getInsightsImage()
+		if err != nil {
+			klog.Errorf("Can't get operator image. Gathering will not run: %v", err)
+			return
+		}
+		c.image = image
 	}
 
 	now := time.Now()
-	gatherJobName := fmt.Sprintf("gather-%d-%d-%d-%d-%d", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute())
-	optional := true
+	gatherJobName := fmt.Sprintf("periodic-gather-%d-%d-%d-%d-%d", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute())
 	gj := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gatherJobName,
 			Namespace: insightsNamespace,
 		},
 		Spec: batchv1.JobSpec{
+			// backoff limit is 0 - we dont' want to restart the gathering immediately in case of failure
+			BackoffLimit: new(int32),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: "operator",
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &trueB,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Volumes: []corev1.Volume{
 						{
 							Name: "archives-path",
@@ -157,17 +143,27 @@ func (c *Controller) GatherJob() {
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: serviceCABundle,
 									},
-									Optional: &optional,
+									Optional: &trueB,
 								},
 							},
 						},
 					},
 					Containers: []corev1.Container{
 						{
-							Name: "insights-gathering",
-							// TODO read image from container ?
-							Image: image,
-							Args:  []string{"gather", "-v=4", "--config=/etc/insights-operator/server.yaml"},
+							Name:  "insights-gathering",
+							Image: c.image,
+							Args:  []string{"gather-and-upload", "-v=4", "--config=/etc/insights-operator/server.yaml"},
+							Env: []corev1.EnvVar{
+								// this is to pair job with corresponding CR having the same name
+								{
+									Name:  "JOB_NAME",
+									Value: gatherJobName,
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: falseB,
+								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "archives-path",
@@ -184,11 +180,41 @@ func (c *Controller) GatherJob() {
 			},
 		},
 	}
+
 	klog.Infof("Creating gathering job %v", gj.Name)
-	_, err = c.kubeClient.BatchV1().Jobs(insightsNamespace).Create(context.Background(), gj, metav1.CreateOptions{})
+	gj, err := c.kubeClient.BatchV1().Jobs(insightsNamespace).Create(context.Background(), gj, metav1.CreateOptions{})
 	if err != nil {
 		klog.Error(err)
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), c.secretConfigurator.Config().Interval*4)
+	defer cancel()
+	err = c.waitForJobCompletion(ctx, gj)
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			klog.Errorf("Failed to read job status: %v", err)
+			return
+		}
+		klog.Error(err)
+	}
+	klog.Infof("Job completed %s", gj.Name)
+	// TODO read the status of the CR and copy to insightsoperator CR
+}
+
+func (c *Controller) waitForJobCompletion(ctx context.Context, job *batchv1.Job) error {
+	return wait.PollUntil(20*time.Second, func() (done bool, err error) {
+		j, err := c.kubeClient.BatchV1().Jobs(insightsNamespace).Get(ctx, job.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, err
+		}
+		if j.Status.Succeeded > 0 {
+			return true, nil
+		}
+		if j.Status.Failed > 0 {
+			return true, fmt.Errorf("job %s failed", job.Name)
+		}
+		// TODO check job conditions ?
+		return false, nil
+	}, ctx.Done())
 }
 
 /* // Gather Runs the gatherers one after the other.
@@ -288,6 +314,39 @@ func (c *Controller) periodicTrigger(stopCh <-chan struct{}) {
 			c.GatherJob()
 		}
 	}
+}
+
+// PeriodicPrune runs periodically and deletes jobs (including the related pods) older
+// than given time
+func (c *Controller) PeriodicPrune(ctx context.Context) {
+	pruneInterval := 1 * time.Hour
+	klog.Infof("Pruning old jobs every %s", pruneInterval)
+	for {
+		select {
+		case <-ctx.Done():
+		// TODO change time
+		case <-time.After(pruneInterval):
+			jobs, err := c.kubeClient.BatchV1().Jobs(insightsNamespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				klog.Error(err)
+			}
+			for i := range jobs.Items {
+				job := jobs.Items[i]
+				// TODO the time duration should be configurable
+				if time.Now().Sub(job.CreationTimestamp.Time) > 8*time.Hour {
+					err = c.kubeClient.BatchV1().Jobs(insightsNamespace).Delete(ctx, job.Name, metav1.DeleteOptions{
+						PropagationPolicy: &deletePropagationBackground,
+					})
+					if err != nil {
+						klog.Errorf("Failed to delete job %s: %v", job.Name, err)
+						continue
+					}
+					klog.Infof("Job %s successfully removed", job.Name)
+				}
+			}
+		}
+	}
+
 }
 
 /* // updateOperatorStatusCR gets the 'cluster' insightsoperators.operator.openshift.io resource and updates its status with the last

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -206,9 +206,9 @@ func Test_createGathererStatus(t *testing.T) { //nolint: funlen
 				},
 				Conditions: []metav1.Condition{
 					{
-						Type:    DataGatheredCondition,
+						Type:    dataGatheredCondition,
 						Status:  metav1.ConditionTrue,
-						Reason:  GatheredOKReason,
+						Reason:  gatheredOKReason,
 						Message: "Created 5 records in the archive.",
 					},
 				},
@@ -228,9 +228,9 @@ func Test_createGathererStatus(t *testing.T) { //nolint: funlen
 				},
 				Conditions: []metav1.Condition{
 					{
-						Type:   DataGatheredCondition,
+						Type:   dataGatheredCondition,
 						Status: metav1.ConditionFalse,
-						Reason: NoDataGatheredReason,
+						Reason: noDataGatheredReason,
 					},
 				},
 			},
@@ -250,9 +250,9 @@ func Test_createGathererStatus(t *testing.T) { //nolint: funlen
 				},
 				Conditions: []metav1.Condition{
 					{
-						Type:    DataGatheredCondition,
+						Type:    dataGatheredCondition,
 						Status:  metav1.ConditionFalse,
-						Reason:  GatherErrorReason,
+						Reason:  gatherErrorReason,
 						Message: "unable to read the data",
 					},
 				},
@@ -273,9 +273,9 @@ func Test_createGathererStatus(t *testing.T) { //nolint: funlen
 				},
 				Conditions: []metav1.Condition{
 					{
-						Type:    DataGatheredCondition,
+						Type:    dataGatheredCondition,
 						Status:  metav1.ConditionTrue,
-						Reason:  GatheredWithErrorReason,
+						Reason:  gatheredWithErrorReason,
 						Message: "Created 2 records in the archive. Error: didn't find xyz configmap",
 					},
 				},
@@ -296,9 +296,9 @@ func Test_createGathererStatus(t *testing.T) { //nolint: funlen
 				},
 				Conditions: []metav1.Condition{
 					{
-						Type:    DataGatheredCondition,
+						Type:    dataGatheredCondition,
 						Status:  metav1.ConditionFalse,
-						Reason:  GatherPanicReason,
+						Reason:  gatherPanicReason,
 						Message: "quz gatherer panicked",
 					},
 				},

--- a/pkg/recorder/diskrecorder/diskrecorder.go
+++ b/pkg/recorder/diskrecorder/diskrecorder.go
@@ -175,6 +175,38 @@ func (d *DiskRecorder) Summary(_ context.Context, since time.Time) (*insightscli
 	return &insightsclient.Source{Contents: f, CreationTime: d.lastRecording}, true, nil
 }
 
+func (d *DiskRecorder) LastArchive() (*insightsclient.Source, error) {
+	files, err := os.ReadDir(d.basePath)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+	var lastTime time.Time
+	var lastArchive string
+	for _, file := range files {
+		fileInfo, err := file.Info()
+		if err != nil {
+			return nil, err
+		}
+		if isNotArchiveFile(fileInfo) {
+			continue
+		}
+		if fileInfo.ModTime().After(lastTime) {
+			lastTime = fileInfo.ModTime()
+			lastArchive = file.Name()
+		}
+	}
+	f, err := os.Open(filepath.Join(d.basePath, lastArchive))
+	if err != nil {
+		return nil, err
+	}
+
+	return &insightsclient.Source{Contents: f, CreationTime: d.lastRecording}, nil
+
+}
+
 func isNotArchiveFile(file os.FileInfo) bool {
 	return file.IsDir() || !strings.HasPrefix(file.Name(), "insights-") || !strings.HasSuffix(file.Name(), ".tar.gz")
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This is PoC for running the data gathering as a separate job/pod. This will not be merged as is. This is just for experimenting and sharing the idea. This also brings following questions/problems:

- accessing the archives - at the moment one can easily access the archives from the running container. This would be quite complicated and time limited when a job is completed in few minutes
- updating metrics would need to be refactored - e.g when a job is finished then read the status and update the metrics
- workloads gatherer needs to run only once in 12h - we can pass an extra argument to the job for example
- status updating/reporting needs to be updated/refactored as well
-  ~pruning of the old jobs needs to be discussed and implemented~ implemented here


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Probably yes

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
