### PR TITLE
refactor(scheduler): move GatherSchedulerLogs to its own file

### DIFF
--- a/pkg/gatherers/clusterconfig/scheduler.go
+++ b/pkg/gatherers/clusterconfig/scheduler.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-
-	"github.com/openshift/insights-operator/pkg/gatherers/common"
 	"github.com/openshift/insights-operator/pkg/record"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GatherSchedulers collects information about schedulers
@@ -47,49 +43,6 @@ func gatherSchedulerInfo(
 			Name: fmt.Sprintf("config/schedulers/%v", scheduler.Name),
 			Item: record.ResourceMarshaller{Resource: scheduler},
 		})
-	}
-
-	return records, nil
-}
-
-// GatherSchedulerLogs collects logs from pods in openshift-kube-scheduler-namespace from app openshift-kube-scheduler
-// with following substring:
-//   - "PodTopologySpread"
-//
-// The Kubernetes API:
-//
-//	https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
-//
-// Response see:
-//
-//	https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
-//
-// * Location in archive: config/pod/openshift-kube-scheduler/logs/{pod-name}/messages.log
-// * Id in config: clusterconfig/scheduler_logs
-// * Since versions:
-//   - 4.10+
-func (g *Gatherer) GatherSchedulerLogs(ctx context.Context) ([]record.Record, []error) {
-	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
-	if err != nil {
-		return nil, []error{err}
-	}
-
-	return gatherSchedulerLogs(ctx, gatherKubeClient.CoreV1())
-}
-
-func gatherSchedulerLogs(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
-	records, err := common.CollectLogsFromContainers(ctx, coreClient, common.LogContainersFilter{
-		Namespace:     "openshift-kube-scheduler",
-		LabelSelector: "app=openshift-kube-scheduler",
-	}, common.LogMessagesFilter{
-		MessagesToSearch: []string{"PodTopologySpread"},
-		SinceSeconds:     logDefaultSinceSeconds,
-		LimitBytes:       logDefaultLimitBytes,
-	}, func(namespace string, podName string, containerName string) string {
-		return fmt.Sprintf("config/pod/%s/logs/%s/messages.log", namespace, podName)
-	})
-	if err != nil {
-		return nil, []error{err}
 	}
 
 	return records, nil

--- a/pkg/gatherers/clusterconfig/scheduler_logs.go
+++ b/pkg/gatherers/clusterconfig/scheduler_logs.go
@@ -1,0 +1,54 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/insights-operator/pkg/gatherers/common"
+	"github.com/openshift/insights-operator/pkg/record"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// GatherSchedulerLogs collects logs from pods in openshift-kube-scheduler-namespace from app openshift-kube-scheduler
+// with following substring:
+//   - "PodTopologySpread"
+//
+// The Kubernetes API:
+//
+//	https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/pod_expansion.go#L48
+//
+// Response see:
+//
+//	https://docs.openshift.com/container-platform/4.6/rest_api/workloads_apis/pod-core-v1.html#apiv1namespacesnamespacepodsnamelog
+//
+// * Location in archive: config/pod/openshift-kube-scheduler/logs/{pod-name}/messages.log
+// * Id in config: clusterconfig/scheduler_logs
+// * Since versions:
+//   - 4.10+
+func (g *Gatherer) GatherSchedulerLogs(ctx context.Context) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherSchedulerLogs(ctx, gatherKubeClient.CoreV1())
+}
+
+func gatherSchedulerLogs(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
+	records, err := common.CollectLogsFromContainers(ctx, coreClient, common.LogContainersFilter{
+		Namespace:     "openshift-kube-scheduler",
+		LabelSelector: "app=openshift-kube-scheduler",
+	}, common.LogMessagesFilter{
+		MessagesToSearch: []string{"PodTopologySpread"},
+		SinceSeconds:     logDefaultSinceSeconds,
+		LimitBytes:       logDefaultLimitBytes,
+	}, func(namespace string, podName string, containerName string) string {
+		return fmt.Sprintf("config/pod/%s/logs/%s/messages.log", namespace, podName)
+	})
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return records, nil
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR moves the `SchedulerLogs` to its own file.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

N/A

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

N/A

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
