### PR TITLE
refactor(webhookconfigurations): remove asset method and split tests

### DIFF
--- a/pkg/gatherers/clusterconfig/mutatingwebhookconfigurations_test.go
+++ b/pkg/gatherers/clusterconfig/mutatingwebhookconfigurations_test.go
@@ -8,32 +8,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-
-	"github.com/openshift/insights-operator/pkg/record"
 )
-
-func Test_gatherValidatingWebhookConfigurations(t *testing.T) {
-	client := kubefake.NewSimpleClientset().AdmissionregistrationV1()
-	_, err := client.ValidatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "webhook_config",
-		},
-		Webhooks: []admissionregistrationv1.ValidatingWebhook{
-			{
-				Name: "webhook1",
-			},
-			{
-				Name: "webhook2",
-			},
-		},
-	}, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	records, errs := gatherValidatingWebhookConfigurations(context.TODO(), client)
-	assert.Empty(t, errs)
-
-	assertWebhookConfigurations(t, records, "config/validatingwebhookconfigurations/webhook_config")
-}
 
 func Test_gatherMutatingWebhookConfigurations(t *testing.T) {
 	client := kubefake.NewSimpleClientset().AdmissionregistrationV1()
@@ -55,12 +30,8 @@ func Test_gatherMutatingWebhookConfigurations(t *testing.T) {
 	records, errs := gatherMutatingWebhookConfigurations(context.TODO(), client)
 	assert.Empty(t, errs)
 
-	assertWebhookConfigurations(t, records, "config/mutatingwebhookconfigurations/webhook_config")
-}
-
-func assertWebhookConfigurations(t *testing.T, records []record.Record, expectedName string) {
 	assert.Len(t, records, 1)
-	assert.Equal(t, records[0].Name, expectedName)
+	assert.Equal(t, records[0].Name, "config/mutatingwebhookconfigurations/webhook_config")
 
 	configurationBytes, err := records[0].Item.Marshal()
 	assert.NoError(t, err)

--- a/pkg/gatherers/clusterconfig/validatingwebhookconfigurations_test.go
+++ b/pkg/gatherers/clusterconfig/validatingwebhookconfigurations_test.go
@@ -1,0 +1,46 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_gatherValidatingWebhookConfigurations(t *testing.T) {
+	client := kubefake.NewSimpleClientset().AdmissionregistrationV1()
+	_, err := client.ValidatingWebhookConfigurations().Create(context.TODO(), &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "webhook_config",
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name: "webhook1",
+			},
+			{
+				Name: "webhook2",
+			},
+		},
+	}, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	records, errs := gatherValidatingWebhookConfigurations(context.TODO(), client)
+	assert.Empty(t, errs)
+
+	assert.Len(t, records, 1)
+	assert.Equal(t, records[0].Name, "config/validatingwebhookconfigurations/webhook_config")
+
+	configurationBytes, err := records[0].Item.Marshal()
+	assert.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"metadata": { "name": "webhook_config", "creationTimestamp": null },
+		"webhooks": [
+			{ "name": "webhook1", "clientConfig": {}, "sideEffects": null, "admissionReviewVersions": null },
+			{ "name": "webhook2", "clientConfig": {}, "sideEffects": null, "admissionReviewVersions": null }
+		]
+	}`, string(configurationBytes))
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR removes the shared asset function between (*)webhookconfigurations' gatherers, and it also split the tests for the respective gatherers.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

N/A

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/mutatingwebhookconfigurations_test.go`
- `pkg/gatherers/clusterconfig/validatingwebhookconfigurations_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
