### PR TITLE
OCPBUGS-5257: do not get disabled rules

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -8,7 +8,7 @@ endpoint: https://console.redhat.com/api/ingress/v1/upload
 conditionalGathererEndpoint: https://console.redhat.com/api/gathering/gathering_rules
 impersonate: system:serviceaccount:openshift-insights:gather
 pull_report:
-  endpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports?get_disabled=true
+  endpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports
   delay: "60s"
   timeout: "3000s"
   min_retry: "30s"


### PR DESCRIPTION
There are two ways to disable a rule. First is to do that for particular cluster. This would work with this original query parameter. Second is to do that for your organization (multiple clusters) and this is not currently supported by the API (and the query parameter).

<!-- Short description of the PR. What does it do? -->


## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browseOCPBUGS-5257 
https://access.redhat.com/solutions/???
