### PR TITLE
OCPBUGS-5347: do not periodically update Available clusteroperator co…

### DIFF
--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -70,11 +70,12 @@ func newConditions(cos *configv1.ClusterOperatorStatus, time metav1.Time) *condi
 }
 
 func (c *conditions) setCondition(conditionType configv1.ClusterStatusConditionType,
-	status configv1.ConditionStatus, reason, message string, lastTime metav1.Time) {
+	status configv1.ConditionStatus, reason, message string) {
 	originalCondition, ok := c.entryMap[conditionType]
+	transitionTime := metav1.Now()
 	// if condition is defined and there is not new status then don't update transition time
 	if ok && originalCondition.Status == status {
-		lastTime = originalCondition.LastTransitionTime
+		transitionTime = originalCondition.LastTransitionTime
 	}
 
 	c.entryMap[conditionType] = configv1.ClusterOperatorStatusCondition{
@@ -82,7 +83,7 @@ func (c *conditions) setCondition(conditionType configv1.ClusterStatusConditionT
 		Reason:             reason,
 		Status:             status,
 		Message:            message,
-		LastTransitionTime: lastTime,
+		LastTransitionTime: transitionTime,
 	}
 }
 

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -32,7 +32,14 @@ const (
 	// as InsightsUploadDegraded
 	uploadFailuresCountThreshold = 5
 
+	asExpectedReason         = "AsExpected"
+	degradedReason           = "Degraded"
+	noTokenReason            = "NoToken"
+	upgradeableReason        = "InsightsUpgradeable"
 	insightsAvailableMessage = "Insights works as expected"
+	reportingDisabledMsg     = "Health reporting is disabled"
+	monitoringMsg            = "Monitoring the cluster"
+	canBeUpgradedMsg         = "Insights operator can be upgraded"
 )
 
 type Reported struct {
@@ -160,7 +167,7 @@ func (c *Controller) merge(clusterOperator *configv1.ClusterOperator) *configv1.
 	// cluster operator conditions
 	cs := newConditions(&clusterOperator.Status, metav1.Time{Time: now})
 	c.updateControllerConditions(cs, isInitializing, lastTransition)
-	updateControllerConditionsByStatus(cs, c.ctrlStatus, isInitializing)
+	c.updateControllerConditionsByStatus(cs, isInitializing)
 
 	// all status conditions from conditions to cluster operator
 	clusterOperator.Status.Conditions = cs.entries()
@@ -335,7 +342,7 @@ func (c *Controller) updateControllerConditions(cs *conditions,
 			cs.setCondition(OperatorDisabled, configv1.ConditionTrue, ds.reason, ds.message, metav1.Now())
 		}
 		if !cs.hasCondition(configv1.OperatorDegraded) {
-			cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, "AsExpected", "", metav1.Now())
+			cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, asExpectedReason, "", metav1.Now())
 		}
 	}
 
@@ -344,14 +351,14 @@ func (c *Controller) updateControllerConditions(cs *conditions,
 	if ds := c.ctrlStatus.getStatus(DisabledStatus); ds != nil {
 		cs.setCondition(OperatorDisabled, configv1.ConditionTrue, ds.reason, ds.message, metav1.Now())
 	} else {
-		cs.setCondition(OperatorDisabled, configv1.ConditionFalse, "AsExpected", "", metav1.Now())
+		cs.setCondition(OperatorDisabled, configv1.ConditionFalse, asExpectedReason, "", metav1.Now())
 	}
 
 	// handle when has errors
 	if es := c.ctrlStatus.getStatus(ErrorStatus); es != nil && !c.ctrlStatus.isDisabled() {
 		cs.setCondition(configv1.OperatorDegraded, configv1.ConditionTrue, es.reason, es.message, metav1.Time{Time: lastTransition})
 	} else {
-		cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, "AsExpected", insightsAvailableMessage, metav1.Now())
+		cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, asExpectedReason, insightsAvailableMessage, metav1.Now())
 	}
 
 	// handle when upload fails
@@ -401,20 +408,19 @@ func (c *Controller) updateControllerConditionByReason(cs *conditions,
 func (c *Controller) checkDisabledGathering() {
 	// disabled state only when it's disabled by config. It means that gathering will not happen
 	if !c.secretConfigurator.Config().Report {
-		c.ctrlStatus.setStatus(DisabledStatus, "NoToken", "Health reporting is disabled")
+		c.ctrlStatus.setStatus(DisabledStatus, noTokenReason, reportingDisabledMsg)
 	}
 
 	// check if the gathering is disabled in the `insightsdatagather.config.openshift.io` API
 	if c.apiConfigurator != nil {
 		if c.apiConfigurator.GatherDisabled() {
-			c.ctrlStatus.setStatus(DisabledStatus, "DisabledInAPI", "Health reporting is disabled")
+			c.ctrlStatus.setStatus(DisabledStatus, "DisabledInAPI", reportingDisabledMsg)
 		}
 	}
 }
 
 // update the current controller state by it status
-func updateControllerConditionsByStatus(cs *conditions, ctrlStatus *controllerStatus,
-	isInitializing bool) {
+func (c *Controller) updateControllerConditionsByStatus(cs *conditions, isInitializing bool) {
 	if isInitializing {
 		klog.V(4).Infof("The operator is still being initialized")
 		// if we're still starting up and some sources are not ready, initialize the conditions
@@ -424,27 +430,27 @@ func updateControllerConditionsByStatus(cs *conditions, ctrlStatus *controllerSt
 		}
 	}
 
-	if es := ctrlStatus.getStatus(ErrorStatus); es != nil && !ctrlStatus.isDisabled() {
+	if es := c.ctrlStatus.getStatus(ErrorStatus); es != nil && !c.ctrlStatus.isDisabled() {
 		klog.V(4).Infof("The operator has some internal errors: %s", es.message)
-		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, "Degraded", "An error has occurred", metav1.Now())
+		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, degradedReason, "An error has occurred", metav1.Now())
 		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, es.reason, es.message, metav1.Now())
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, "InsightsNotUpgradeable", es.message, metav1.Now())
+		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, degradedReason, es.message, metav1.Now())
 	}
 
-	if ds := ctrlStatus.getStatus(DisabledStatus); ds != nil {
+	// when the operator is already healthy then it doesn't make sense to set those, but when it's degraded and then
+	// marked as disabled then it's reasonable to set Available=True
+	if ds := c.ctrlStatus.getStatus(DisabledStatus); ds != nil && !c.ctrlStatus.isHealthy() {
 		klog.V(4).Infof("The operator is marked as disabled")
-		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, ds.reason, ds.message, metav1.Now())
-		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, ds.reason, ds.message, metav1.Now())
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, "InsightsUpgradeable",
-			"Insights operator can be upgraded", metav1.Now())
+		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, asExpectedReason, monitoringMsg, metav1.Now())
+		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, asExpectedReason, insightsAvailableMessage, metav1.Now())
+		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, upgradeableReason, canBeUpgradedMsg, metav1.Now())
 	}
 
-	if ctrlStatus.isHealthy() {
+	if c.ctrlStatus.isHealthy() {
 		klog.V(4).Infof("The operator is healthy")
-		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, "AsExpected", "Monitoring the cluster", metav1.Now())
-		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "AsExpected", insightsAvailableMessage, metav1.Now())
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, "InsightsUpgradeable",
-			"Insights operator can be upgraded", metav1.Now())
+		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, asExpectedReason, monitoringMsg, metav1.Now())
+		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, asExpectedReason, insightsAvailableMessage, metav1.Now())
+		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, upgradeableReason, canBeUpgradedMsg, metav1.Now())
 	}
 }
 

--- a/pkg/controller/status/controller_test.go
+++ b/pkg/controller/status/controller_test.go
@@ -239,7 +239,6 @@ func Test_updatingConditionsFromDegradedToDisabled(t *testing.T) {
 	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
 	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
 	assert.Equal(t, disabledCondition, getConditionByType(updatedCO.Status.Conditions, OperatorDisabled))
-
 }
 
 func getConditionByType(conditions []configv1.ClusterOperatorStatusCondition,

--- a/pkg/controller/status/controller_test.go
+++ b/pkg/controller/status/controller_test.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -12,6 +13,8 @@ import (
 	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
 	"github.com/openshift/insights-operator/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclientfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -81,4 +84,170 @@ func Test_Status_SaveInitialStart(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_updatingConditionsInDisabledState(t *testing.T) {
+	lastTransitionTime := metav1.Date(2022, 3, 21, 16, 20, 30, 0, time.UTC)
+
+	availableCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorAvailable,
+		Status:             configv1.ConditionTrue,
+		Reason:             asExpectedReason,
+		Message:            insightsAvailableMessage,
+		LastTransitionTime: lastTransitionTime,
+	}
+	progressingCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorProgressing,
+		Status:             configv1.ConditionFalse,
+		Reason:             asExpectedReason,
+		Message:            monitoringMsg,
+		LastTransitionTime: lastTransitionTime,
+	}
+	degradedCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorDegraded,
+		Status:             configv1.ConditionFalse,
+		Reason:             asExpectedReason,
+		Message:            insightsAvailableMessage,
+		LastTransitionTime: lastTransitionTime,
+	}
+	upgradeableCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorUpgradeable,
+		Status:             configv1.ConditionTrue,
+		Reason:             upgradeableReason,
+		Message:            canBeUpgradedMsg,
+		LastTransitionTime: lastTransitionTime,
+	}
+
+	testCO := configv1.ClusterOperator{
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				availableCondition,
+				progressingCondition,
+				degradedCondition,
+				upgradeableCondition,
+				{
+					Type:               OperatorDisabled,
+					Status:             configv1.ConditionFalse,
+					Reason:             asExpectedReason,
+					LastTransitionTime: lastTransitionTime,
+				},
+			},
+		},
+	}
+	testController := Controller{
+		ctrlStatus: newControllerStatus(),
+		// marking operator as disabled
+		secretConfigurator: config.NewMockSecretConfigurator(&config.Controller{Report: false}),
+		apiConfigurator:    config.NewMockAPIConfigurator(nil),
+	}
+	updatedCO := testController.merge(&testCO)
+	// check that all the conditions are not touched except the disabled one
+	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
+	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+
+	disabledCondition := getConditionByType(updatedCO.Status.Conditions, OperatorDisabled)
+	assert.Equal(t, configv1.ConditionTrue, disabledCondition.Status)
+	assert.Equal(t, noTokenReason, disabledCondition.Reason)
+	assert.Equal(t, reportingDisabledMsg, disabledCondition.Message)
+	assert.True(t, disabledCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	// upgrade status again and nothing should change
+	updatedCO = testController.merge(updatedCO)
+	// check that all the conditions are not touched including the disabled one
+	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
+	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+	assert.Equal(t, disabledCondition, getConditionByType(updatedCO.Status.Conditions, OperatorDisabled))
+}
+
+func Test_updatingConditionsFromDegradedToDisabled(t *testing.T) {
+	lastTransitionTime := metav1.Date(2022, 3, 21, 16, 20, 30, 0, time.UTC)
+	progressingCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorProgressing,
+		Status:             configv1.ConditionFalse,
+		Reason:             asExpectedReason,
+		Message:            monitoringMsg,
+		LastTransitionTime: lastTransitionTime,
+	}
+	testCO := configv1.ClusterOperator{
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionFalse,
+					Reason:             "UploadFailed",
+					LastTransitionTime: lastTransitionTime,
+				},
+				progressingCondition,
+				{
+					Type:               configv1.OperatorDegraded,
+					Status:             configv1.ConditionTrue,
+					Reason:             "UploadFailed",
+					LastTransitionTime: lastTransitionTime,
+				},
+				{
+					Type:               configv1.OperatorUpgradeable,
+					Status:             configv1.ConditionFalse,
+					Reason:             degradedReason,
+					LastTransitionTime: lastTransitionTime,
+				},
+				{
+					Type:               OperatorDisabled,
+					Status:             configv1.ConditionFalse,
+					Reason:             asExpectedReason,
+					LastTransitionTime: lastTransitionTime,
+				},
+			},
+		},
+	}
+	testController := Controller{
+		ctrlStatus: newControllerStatus(),
+		// marking operator as disabled
+		secretConfigurator: config.NewMockSecretConfigurator(&config.Controller{Report: false}),
+		apiConfigurator:    config.NewMockAPIConfigurator(nil),
+	}
+	updatedCO := testController.merge(&testCO)
+	// check that all conditions changed except the Progressing since it's still False
+	availableCondition := *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable)
+	assert.Equal(t, availableCondition.Status, configv1.ConditionTrue)
+	assert.True(t, availableCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	degradedCondition := *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded)
+	assert.Equal(t, degradedCondition.Status, configv1.ConditionFalse)
+	assert.True(t, degradedCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	upgradeableCondition := *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable)
+	assert.Equal(t, upgradeableCondition.Status, configv1.ConditionTrue)
+	assert.True(t, upgradeableCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+
+	disabledCondition := getConditionByType(updatedCO.Status.Conditions, OperatorDisabled)
+	assert.Equal(t, configv1.ConditionTrue, disabledCondition.Status)
+	assert.Equal(t, noTokenReason, disabledCondition.Reason)
+	assert.Equal(t, reportingDisabledMsg, disabledCondition.Message)
+	assert.True(t, disabledCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	// upgrade status again and nothing should change
+	updatedCO = testController.merge(updatedCO)
+	// check that all the conditions are not touched including the disabled one
+	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
+	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+	assert.Equal(t, disabledCondition, getConditionByType(updatedCO.Status.Conditions, OperatorDisabled))
+
+}
+
+func getConditionByType(conditions []configv1.ClusterOperatorStatusCondition,
+	ctype configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for _, c := range conditions {
+		if c.Type == ctype {
+			return &c
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
…ndition in disabled state

<!-- Short description of the PR. What does it do? -->

It doesn't make any sense to set some other conditions in disabled state, because it's still "healthy" state from operator perspective. Temporarily setting a different  `Available` condition status caused the "since" time reset every 2 mins and unnecessarily updated the transition time of the condition:

```
oc get co insights --watch
NAME       VERSION       AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
insights   4.13.0-ec.1   True        False         False      62s     
insights   4.13.0-ec.1   True        False         False      1s      
insights   4.13.0-ec.1   True        False         False      0s      
insights   4.13.0-ec.1   True        False         False      1s      
insights   4.13.0-ec.1   True        False         False      0s      
insights   4.13.0-ec.1   True        False         False      0s      
```

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

extended 
- `pkg/controller/status/controller_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-5347
https://access.redhat.com/solutions/???
