### PR TITLE
[release-4.11] OCPBUGS-5349: do not periodically update Available clusteroperator co…

### DIFF
--- a/pkg/controller/status/controller_test.go
+++ b/pkg/controller/status/controller_test.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -12,6 +13,8 @@ import (
 	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
 	"github.com/openshift/insights-operator/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclientfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -81,4 +84,90 @@ func Test_Status_SaveInitialStart(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_updatingConditionsInDisabledState(t *testing.T) {
+	lastTransitionTime := metav1.Date(2022, 3, 21, 16, 20, 30, 0, time.UTC)
+
+	availableCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorAvailable,
+		Status:             configv1.ConditionTrue,
+		Reason:             asExpectedReason,
+		Message:            insightsAvailableMessage,
+		LastTransitionTime: lastTransitionTime,
+	}
+	progressingCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorProgressing,
+		Status:             configv1.ConditionFalse,
+		Reason:             asExpectedReason,
+		Message:            monitoringMsg,
+		LastTransitionTime: lastTransitionTime,
+	}
+	degradedCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorDegraded,
+		Status:             configv1.ConditionFalse,
+		Reason:             asExpectedReason,
+		Message:            insightsAvailableMessage,
+		LastTransitionTime: lastTransitionTime,
+	}
+	upgradeableCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorUpgradeable,
+		Status:             configv1.ConditionTrue,
+		Reason:             upgradeableReason,
+		Message:            canBeUpgradedMsg,
+		LastTransitionTime: lastTransitionTime,
+	}
+
+	testCO := configv1.ClusterOperator{
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				availableCondition,
+				progressingCondition,
+				degradedCondition,
+				upgradeableCondition,
+				{
+					Type:               OperatorDisabled,
+					Status:             configv1.ConditionFalse,
+					Reason:             asExpectedReason,
+					LastTransitionTime: lastTransitionTime,
+				},
+			},
+		},
+	}
+	testController := Controller{
+		ctrlStatus: newControllerStatus(),
+		// marking operator as disabled
+		configurator: config.NewMockConfigurator(&config.Controller{Report: false}),
+	}
+	updatedCO := testController.merge(&testCO)
+	// check that all the conditions are not touched except the disabled one
+	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
+	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+
+	disabledCondition := getConditionByType(updatedCO.Status.Conditions, OperatorDisabled)
+	assert.Equal(t, configv1.ConditionTrue, disabledCondition.Status)
+	assert.Equal(t, disabledReason, disabledCondition.Reason)
+	assert.Equal(t, reportingDisabledMsg, disabledCondition.Message)
+	assert.True(t, disabledCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	// upgrade status again and nothing should change
+	updatedCO = testController.merge(updatedCO)
+	// check that all the conditions are not touched including the disabled one
+	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
+	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+	assert.Equal(t, disabledCondition, getConditionByType(updatedCO.Status.Conditions, OperatorDisabled))
+}
+
+func getConditionByType(conditions []configv1.ClusterOperatorStatusCondition,
+	ctype configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for _, c := range conditions {
+		if c.Type == ctype {
+			return &c
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
…ndition in disabled state

<!-- Short description of the PR. What does it do? -->
Backport of https://github.com/openshift/insights-operator/pull/710

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-5349
https://access.redhat.com/solutions/???
