### PR TITLE
[release-4.11] OCPBUGS-5349: do not periodically update Available clusteroperator co…

### DIFF
--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -68,11 +68,12 @@ func newConditions(cos *configv1.ClusterOperatorStatus, time metav1.Time) *condi
 }
 
 func (c *conditions) setCondition(conditionType configv1.ClusterStatusConditionType,
-	status configv1.ConditionStatus, reason, message string, lastTime metav1.Time) {
+	status configv1.ConditionStatus, reason, message string) {
 	originalCondition, ok := c.entryMap[conditionType]
+	transitionTime := metav1.Now()
 	// if condition is defined and there is not new status then don't update transition time
 	if ok && originalCondition.Status == status {
-		lastTime = originalCondition.LastTransitionTime
+		transitionTime = originalCondition.LastTransitionTime
 	}
 
 	c.entryMap[conditionType] = configv1.ClusterOperatorStatusCondition{
@@ -80,7 +81,7 @@ func (c *conditions) setCondition(conditionType configv1.ClusterStatusConditionT
 		Reason:             reason,
 		Status:             status,
 		Message:            message,
-		LastTransitionTime: lastTime,
+		LastTransitionTime: transitionTime,
 	}
 }
 

--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -1,6 +1,8 @@
 package status
 
 import (
+	"sort"
+
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -102,10 +104,15 @@ func (c *conditions) findCondition(condition configv1.ClusterStatusConditionType
 	return nil
 }
 
+// entries returns a sorted list of status conditions from the mapped values.
+// The list is sorted by  by type ClusterStatusConditionType to ensure consistent ordering for deep equal checks.
 func (c *conditions) entries() []configv1.ClusterOperatorStatusCondition {
 	var res []configv1.ClusterOperatorStatusCondition
 	for _, v := range c.entryMap {
 		res = append(res, v)
 	}
+	sort.SliceStable(res, func(i, j int) bool {
+		return string(res[i].Type) < string(res[j].Type)
+	})
 	return res
 }

--- a/pkg/controller/status/conditions_test.go
+++ b/pkg/controller/status/conditions_test.go
@@ -52,6 +52,49 @@ func Test_conditions_entries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Condition array is always sorted by type",
+			fields: fields{entryMap: map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition{
+				configv1.OperatorProgressing: {
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+				configv1.OperatorAvailable: {
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+				configv1.OperatorDegraded: {
+					Type:               configv1.OperatorDegraded,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+			}},
+			want: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+				{
+					Type:               configv1.OperatorDegraded,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+				{
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionUnknown,
+					LastTransitionTime: time,
+					Reason:             "",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,6 +103,9 @@ func Test_conditions_entries(t *testing.T) {
 			}
 			got := c.entries()
 			assert.ElementsMatchf(t, got, tt.want, "entries() = %v, want %v", got, tt.want)
+			for i, expected := range tt.want {
+				assert.Equal(t, expected, got[i])
+			}
 		})
 	}
 }

--- a/pkg/controller/status/conditions_test.go
+++ b/pkg/controller/status/conditions_test.go
@@ -301,7 +301,7 @@ func Test_conditions_setCondition(t *testing.T) {
 			args: args{
 				condition: configv1.OperatorDegraded,
 				status:    configv1.ConditionUnknown,
-				reason:    "degraded reason",
+				reason:    degradedReason,
 				message:   "degraded message",
 				lastTime:  time,
 			},
@@ -317,7 +317,7 @@ func Test_conditions_setCondition(t *testing.T) {
 						Type:               configv1.OperatorDegraded,
 						Status:             configv1.ConditionUnknown,
 						LastTransitionTime: time,
-						Reason:             "degraded reason",
+						Reason:             degradedReason,
 						Message:            "degraded message",
 					},
 				},
@@ -328,8 +328,8 @@ func Test_conditions_setCondition(t *testing.T) {
 			fields: fields{entryMap: map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition{
 				configv1.OperatorAvailable: {
 					Type:               configv1.OperatorAvailable,
-					Status:             configv1.ConditionUnknown,
 					LastTransitionTime: time,
+					Status:             configv1.ConditionTrue,
 					Reason:             "",
 				},
 				configv1.OperatorDegraded: {
@@ -340,11 +340,11 @@ func Test_conditions_setCondition(t *testing.T) {
 				},
 			}},
 			args: args{
-				condition: configv1.OperatorAvailable,
+				condition: configv1.OperatorDegraded,
 				status:    configv1.ConditionTrue,
-				reason:    "available reason",
-				message:   "",
 				lastTime:  time,
+				reason:    degradedReason,
+				message:   "error",
 			},
 			want: &conditions{
 				entryMap: map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition{
@@ -352,13 +352,14 @@ func Test_conditions_setCondition(t *testing.T) {
 						Type:               configv1.OperatorAvailable,
 						Status:             configv1.ConditionTrue,
 						LastTransitionTime: time,
-						Reason:             "available reason",
+						Reason:             "",
 					},
 					configv1.OperatorDegraded: {
 						Type:               configv1.OperatorDegraded,
-						Status:             configv1.ConditionUnknown,
 						LastTransitionTime: time,
-						Reason:             "",
+						Status:             configv1.ConditionTrue,
+						Reason:             degradedReason,
+						Message:            "error",
 					},
 				},
 			},
@@ -369,10 +370,20 @@ func Test_conditions_setCondition(t *testing.T) {
 			c := &conditions{
 				entryMap: tt.fields.entryMap,
 			}
-			c.setCondition(tt.args.condition, tt.args.status, tt.args.reason, tt.args.message, time)
-			if !reflect.DeepEqual(c, tt.want) {
-				t.Errorf("setConditions() = %v, want %v", c, tt.want)
-			}
+			c.setCondition(tt.args.condition, tt.args.status, tt.args.reason, tt.args.message)
+
+			actualAvailableCon := tt.fields.entryMap[configv1.OperatorAvailable]
+			expectedAvailableCon := tt.want.entryMap[configv1.OperatorAvailable]
+			assert.Equal(t, expectedAvailableCon, actualAvailableCon)
+
+			actualDegradedCon := tt.fields.entryMap[configv1.OperatorDegraded]
+			expectedDegradedCon := tt.want.entryMap[configv1.OperatorDegraded]
+			assert.Equal(t, expectedDegradedCon.Status, actualDegradedCon.Status)
+			assert.Equal(t, expectedDegradedCon.Reason, actualDegradedCon.Reason)
+			assert.Equal(t, expectedDegradedCon.Message, actualDegradedCon.Message)
+			// we expect transition time update only in degraded condition, because in the first case
+			// it was introduced as a new condition and in the second case the status has been updated
+			assert.True(t, expectedDegradedCon.LastTransitionTime.Before(&actualDegradedCon.LastTransitionTime))
 		})
 	}
 }

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -32,7 +32,14 @@ const (
 	// as InsightsUploadDegraded
 	uploadFailuresCountThreshold = 5
 
+	asExpectedReason         = "AsExpected"
+	degradedReason           = "Degraded"
+	disabledReason           = "Disabled"
+	upgradeableReason        = "InsightsUpgradeable"
 	insightsAvailableMessage = "Insights works as expected"
+	reportingDisabledMsg     = "Health reporting is disabled"
+	monitoringMsg            = "Monitoring the cluster"
+	canBeUpgradedMsg         = "Insights operator can be upgraded"
 )
 
 type Reported struct {
@@ -142,7 +149,7 @@ func (c *Controller) merge(clusterOperator *configv1.ClusterOperator) *configv1.
 	c.ctrlStatus.reset()
 
 	// calculate the current controller state
-	allReady, lastTransition := c.currentControllerStatus()
+	allReady := c.currentControllerStatus()
 
 	clusterOperator = clusterOperator.DeepCopy()
 	now := time.Now()
@@ -154,8 +161,8 @@ func (c *Controller) merge(clusterOperator *configv1.ClusterOperator) *configv1.
 
 	// cluster operator conditions
 	cs := newConditions(&clusterOperator.Status, metav1.Time{Time: now})
-	c.updateControllerConditions(cs, isInitializing, lastTransition)
-	updateControllerConditionsByStatus(cs, c.ctrlStatus, isInitializing)
+	c.updateControllerConditions(cs, isInitializing)
+	c.updateControllerConditionsByStatus(cs, isInitializing)
 
 	// all status conditions from conditions to cluster operator
 	clusterOperator.Status.Conditions = cs.entries()
@@ -176,7 +183,7 @@ func (c *Controller) merge(clusterOperator *configv1.ClusterOperator) *configv1.
 }
 
 // calculate the current controller status based on its given sources
-func (c *Controller) currentControllerStatus() (allReady bool, lastTransition time.Time) { //nolint: gocyclo
+func (c *Controller) currentControllerStatus() (allReady bool) { //nolint: gocyclo
 	var errorReason string
 	var errs []string
 
@@ -232,10 +239,6 @@ func (c *Controller) currentControllerStatus() (allReady bool, lastTransition ti
 			errorReason = summary.Reason
 			errs = append(errs, summary.Message)
 		}
-
-		if lastTransition.Before(summary.LastTransitionTime) {
-			lastTransition = summary.LastTransitionTime
-		}
 	}
 
 	// handling errors
@@ -249,7 +252,7 @@ func (c *Controller) currentControllerStatus() (allReady bool, lastTransition ti
 		c.ctrlStatus.setStatus(DisabledStatus, "Disabled", "Health reporting is disabled")
 	}
 
-	return allReady, lastTransition
+	return allReady
 }
 
 // Start starts the periodic checking of sources.
@@ -325,43 +328,41 @@ func (c *Controller) updateStatus(ctx context.Context, initial bool) error {
 }
 
 // update the cluster controller status conditions
-func (c *Controller) updateControllerConditions(cs *conditions,
-	isInitializing bool, lastTransition time.Time) {
+func (c *Controller) updateControllerConditions(cs *conditions, isInitializing bool) {
 	if isInitializing {
 		// the disabled condition is optional, but set it now if we already know we're disabled
 		if ds := c.ctrlStatus.getStatus(DisabledStatus); ds != nil {
-			cs.setCondition(OperatorDisabled, configv1.ConditionTrue, ds.reason, ds.message, metav1.Now())
+			cs.setCondition(OperatorDisabled, configv1.ConditionTrue, ds.reason, ds.message)
 		}
 		if !cs.hasCondition(configv1.OperatorDegraded) {
-			cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, "AsExpected", "", metav1.Now())
+			cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, asExpectedReason, "")
 		}
 	}
 
 	// once we've initialized set Failing and Disabled as best we know
 	// handle when disabled
 	if ds := c.ctrlStatus.getStatus(DisabledStatus); ds != nil {
-		cs.setCondition(OperatorDisabled, configv1.ConditionTrue, ds.reason, ds.message, metav1.Now())
+		cs.setCondition(OperatorDisabled, configv1.ConditionTrue, ds.reason, ds.message)
 	} else {
-		cs.setCondition(OperatorDisabled, configv1.ConditionFalse, "AsExpected", "", metav1.Now())
+		cs.setCondition(OperatorDisabled, configv1.ConditionFalse, asExpectedReason, "")
 	}
-
 	// handle when has errors
 	if es := c.ctrlStatus.getStatus(ErrorStatus); es != nil && !c.ctrlStatus.isDisabled() {
-		cs.setCondition(configv1.OperatorDegraded, configv1.ConditionTrue, es.reason, es.message, metav1.Time{Time: lastTransition})
+		cs.setCondition(configv1.OperatorDegraded, configv1.ConditionTrue, es.reason, es.message)
 	} else {
-		cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, "AsExpected", insightsAvailableMessage, metav1.Now())
+		cs.setCondition(configv1.OperatorDegraded, configv1.ConditionFalse, asExpectedReason, insightsAvailableMessage)
 	}
 
 	// handle when upload fails
 	if ur := c.ctrlStatus.getStatus(UploadStatus); ur != nil && !c.ctrlStatus.isDisabled() {
-		cs.setCondition(InsightsUploadDegraded, configv1.ConditionTrue, ur.reason, ur.message, metav1.Time{Time: lastTransition})
+		cs.setCondition(InsightsUploadDegraded, configv1.ConditionTrue, ur.reason, ur.message)
 	} else {
 		cs.removeCondition(InsightsUploadDegraded)
 	}
 
 	// handle when download fails
 	if ds := c.ctrlStatus.getStatus(DownloadStatus); ds != nil && !c.ctrlStatus.isDisabled() {
-		cs.setCondition(InsightsDownloadDegraded, configv1.ConditionTrue, ds.reason, ds.message, metav1.Time{Time: lastTransition})
+		cs.setCondition(InsightsDownloadDegraded, configv1.ConditionTrue, ds.reason, ds.message)
 	} else {
 		cs.removeCondition(InsightsDownloadDegraded)
 	}
@@ -390,45 +391,47 @@ func (c *Controller) updateControllerConditionByReason(cs *conditions,
 		return
 	}
 	if summary.Reason == reason {
-		cs.setCondition(condition, configv1.ConditionTrue, summary.Reason, summary.Message, metav1.Time{Time: summary.LastTransitionTime})
+		cs.setCondition(condition, configv1.ConditionTrue, summary.Reason, summary.Message)
 	} else {
-		cs.setCondition(condition, configv1.ConditionFalse, summary.Reason, summary.Message, metav1.Time{Time: summary.LastTransitionTime})
+		cs.setCondition(condition, configv1.ConditionFalse, summary.Reason, summary.Message)
 	}
 }
 
 // update the current controller state by it status
-func updateControllerConditionsByStatus(cs *conditions, ctrlStatus *controllerStatus,
-	isInitializing bool) {
+func (c *Controller) updateControllerConditionsByStatus(cs *conditions, isInitializing bool) {
 	if isInitializing {
 		klog.V(4).Infof("The operator is still being initialized")
 		// if we're still starting up and some sources are not ready, initialize the conditions
 		// but don't update
 		if !cs.hasCondition(configv1.OperatorProgressing) {
-			cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "Initializing", "Initializing the operator", metav1.Now())
+			cs.setCondition(configv1.OperatorProgressing, configv1.ConditionTrue, "Initializing", "Initializing the operator")
 		}
 	}
 
-	if es := ctrlStatus.getStatus(ErrorStatus); es != nil && !ctrlStatus.isDisabled() {
+	if es := c.ctrlStatus.getStatus(ErrorStatus); es != nil && !c.ctrlStatus.isDisabled() {
 		klog.V(4).Infof("The operator has some internal errors: %s", es.message)
-		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, "Degraded", "An error has occurred", metav1.Now())
-		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, es.reason, es.message, metav1.Now())
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, "InsightsNotUpgradeable", es.message, metav1.Now())
+		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, degradedReason, "An error has occurred")
+		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, es.reason, es.message)
+		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, degradedReason, es.message)
 	}
 
-	if ds := ctrlStatus.getStatus(DisabledStatus); ds != nil {
+	// when the operator is already healthy then it doesn't make sense to set those, but when it's degraded and then
+	// marked as disabled then it's OK to set the conditions.
+	// Historically we have the state when there are conditions Disabled=True and Available=True, which does not make
+	// much sense, but having Available=False since cluster installation (disconnected cluster with no token in the pull-secret)
+	// is not possible right now, because the CVO will cancel such installation.
+	if ds := c.ctrlStatus.getStatus(DisabledStatus); ds != nil && !c.ctrlStatus.isHealthy() {
 		klog.V(4).Infof("The operator is marked as disabled")
-		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, ds.reason, ds.message, metav1.Now())
-		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, ds.reason, ds.message, metav1.Now())
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, "InsightsUpgradeable",
-			"Insights operator can be upgraded", metav1.Now())
+		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, asExpectedReason, monitoringMsg)
+		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, asExpectedReason, insightsAvailableMessage)
+		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, upgradeableReason, canBeUpgradedMsg)
 	}
 
-	if ctrlStatus.isHealthy() {
+	if c.ctrlStatus.isHealthy() {
 		klog.V(4).Infof("The operator is healthy")
-		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, "AsExpected", "Monitoring the cluster", metav1.Now())
-		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, "AsExpected", insightsAvailableMessage, metav1.Now())
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, "InsightsUpgradeable",
-			"Insights operator can be upgraded", metav1.Now())
+		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, asExpectedReason, monitoringMsg)
+		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, asExpectedReason, insightsAvailableMessage)
+		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, upgradeableReason, canBeUpgradedMsg)
 	}
 }
 

--- a/pkg/controller/status/controller_test.go
+++ b/pkg/controller/status/controller_test.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
@@ -12,6 +13,8 @@ import (
 	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
 	"github.com/openshift/insights-operator/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclientfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -81,4 +84,167 @@ func Test_Status_SaveInitialStart(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_updatingConditionsInDisabledState(t *testing.T) {
+	lastTransitionTime := metav1.Date(2022, 3, 21, 16, 20, 30, 0, time.UTC)
+
+	availableCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorAvailable,
+		Status:             configv1.ConditionTrue,
+		Reason:             asExpectedReason,
+		Message:            insightsAvailableMessage,
+		LastTransitionTime: lastTransitionTime,
+	}
+	progressingCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorProgressing,
+		Status:             configv1.ConditionFalse,
+		Reason:             asExpectedReason,
+		Message:            monitoringMsg,
+		LastTransitionTime: lastTransitionTime,
+	}
+	degradedCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorDegraded,
+		Status:             configv1.ConditionFalse,
+		Reason:             asExpectedReason,
+		Message:            insightsAvailableMessage,
+		LastTransitionTime: lastTransitionTime,
+	}
+	upgradeableCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorUpgradeable,
+		Status:             configv1.ConditionTrue,
+		Reason:             upgradeableReason,
+		Message:            canBeUpgradedMsg,
+		LastTransitionTime: lastTransitionTime,
+	}
+
+	testCO := configv1.ClusterOperator{
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				availableCondition,
+				progressingCondition,
+				degradedCondition,
+				upgradeableCondition,
+				{
+					Type:               OperatorDisabled,
+					Status:             configv1.ConditionFalse,
+					Reason:             asExpectedReason,
+					LastTransitionTime: lastTransitionTime,
+				},
+			},
+		},
+	}
+	testController := Controller{
+		ctrlStatus: newControllerStatus(),
+		// marking operator as disabled
+		configurator: config.NewMockConfigurator(&config.Controller{Report: false}),
+	}
+	updatedCO := testController.merge(&testCO)
+	// check that all the conditions are not touched except the disabled one
+	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
+	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+
+	disabledCondition := getConditionByType(updatedCO.Status.Conditions, OperatorDisabled)
+	assert.Equal(t, configv1.ConditionTrue, disabledCondition.Status)
+	assert.Equal(t, disabledReason, disabledCondition.Reason)
+	assert.Equal(t, reportingDisabledMsg, disabledCondition.Message)
+	assert.True(t, disabledCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	// upgrade status again and nothing should change
+	updatedCO = testController.merge(updatedCO)
+	// check that all the conditions are not touched including the disabled one
+	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
+	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+	assert.Equal(t, disabledCondition, getConditionByType(updatedCO.Status.Conditions, OperatorDisabled))
+}
+
+func Test_updatingConditionsFromDegradedToDisabled(t *testing.T) {
+	lastTransitionTime := metav1.Date(2022, 3, 21, 16, 20, 30, 0, time.UTC)
+	progressingCondition := configv1.ClusterOperatorStatusCondition{
+		Type:               configv1.OperatorProgressing,
+		Status:             configv1.ConditionFalse,
+		Reason:             asExpectedReason,
+		Message:            monitoringMsg,
+		LastTransitionTime: lastTransitionTime,
+	}
+	testCO := configv1.ClusterOperator{
+		Status: configv1.ClusterOperatorStatus{
+			Conditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:               configv1.OperatorAvailable,
+					Status:             configv1.ConditionFalse,
+					Reason:             "UploadFailed",
+					LastTransitionTime: lastTransitionTime,
+				},
+				progressingCondition,
+				{
+					Type:               configv1.OperatorDegraded,
+					Status:             configv1.ConditionTrue,
+					Reason:             "UploadFailed",
+					LastTransitionTime: lastTransitionTime,
+				},
+				{
+					Type:               configv1.OperatorUpgradeable,
+					Status:             configv1.ConditionFalse,
+					Reason:             degradedReason,
+					LastTransitionTime: lastTransitionTime,
+				},
+				{
+					Type:               OperatorDisabled,
+					Status:             configv1.ConditionFalse,
+					Reason:             asExpectedReason,
+					LastTransitionTime: lastTransitionTime,
+				},
+			},
+		},
+	}
+	testController := Controller{
+		ctrlStatus: newControllerStatus(),
+		// marking operator as disabled
+		configurator: config.NewMockConfigurator(&config.Controller{Report: false}),
+	}
+	updatedCO := testController.merge(&testCO)
+	// check that all conditions changed except the Progressing since it's still False
+	availableCondition := *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable)
+	assert.Equal(t, availableCondition.Status, configv1.ConditionTrue)
+	assert.True(t, availableCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	degradedCondition := *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded)
+	assert.Equal(t, degradedCondition.Status, configv1.ConditionFalse)
+	assert.True(t, degradedCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	upgradeableCondition := *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable)
+	assert.Equal(t, upgradeableCondition.Status, configv1.ConditionTrue)
+	assert.True(t, upgradeableCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+
+	disabledCondition := getConditionByType(updatedCO.Status.Conditions, OperatorDisabled)
+	assert.Equal(t, configv1.ConditionTrue, disabledCondition.Status)
+	assert.Equal(t, disabledReason, disabledCondition.Reason)
+	assert.Equal(t, reportingDisabledMsg, disabledCondition.Message)
+	assert.True(t, disabledCondition.LastTransitionTime.After(lastTransitionTime.Time))
+
+	// upgrade status again and nothing should change
+	updatedCO = testController.merge(updatedCO)
+	// check that all the conditions are not touched including the disabled one
+	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
+	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
+	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
+	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+	assert.Equal(t, disabledCondition, getConditionByType(updatedCO.Status.Conditions, OperatorDisabled))
+}
+
+func getConditionByType(conditions []configv1.ClusterOperatorStatusCondition,
+	ctype configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for _, c := range conditions {
+		if c.Type == ctype {
+			return &c
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
…… (#709)
<!-- Short description of the PR. What does it do? -->
Backport of https://github.com/openshift/insights-operator/pull/710

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->



## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/status/controller_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-5349
https://access.redhat.com/solutions/???
