### PR TITLE
[release-4.12] OCPBUGS-5976: operators gatherer - handle ingresscontroller relatedOb…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -238,7 +238,8 @@ information includes:
 
 ## ClusterOperators
 
-collects all the ClusterOperators definitions and their resources.
+collects all the ClusterOperators definitions and their related resources
+from the `operator.openshift.io` group.
 
 The Kubernetes api https://github.com/openshift/client-go/blob/master/config/clientset/versioned/typed/config/v1/clusteroperator.go#L62
 Response see https://docs.openshift.com/container-platform/4.3/rest_api/index.html#clusteroperatorlist-v1config-openshift-io

--- a/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/ingresscontroller/openshift-ingress-operator/default.json
+++ b/docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/ingresscontroller/openshift-ingress-operator/default.json
@@ -1,0 +1,23 @@
+{
+    "apiVersion": "operator.openshift.io/v1",
+    "kind": "IngressController",
+    "name": "default",
+    "spec": {
+        "clientTLS": {
+            "clientCA": {
+                "name": ""
+            },
+            "clientCertificatePolicy": ""
+        },
+        "httpCompression": {},
+        "httpEmptyRequestsPolicy": "Respond",
+        "httpErrorCodePages": {
+            "name": ""
+        },
+        "replicas": 2,
+        "tuningOptions": {
+            "reloadInterval": "0s"
+        },
+        "unsupportedConfigOverrides": null
+    }
+}

--- a/pkg/gatherers/clusterconfig/operators_test.go
+++ b/pkg/gatherers/clusterconfig/operators_test.go
@@ -9,35 +9,76 @@ import (
 	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	openshiftscheme "github.com/openshift/client-go/config/clientset/versioned/scheme"
 	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
-func newClusterOperator() configv1.ClusterOperator {
-	return configv1.ClusterOperator{
+var gvr = schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "testcontroller"}
+
+func createTestClusterOperator(cli *configfake.Clientset) (*configv1.ClusterOperator, error) {
+	co := &configv1.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-clusteroperator",
 		},
-	}
+		Spec: configv1.ClusterOperatorSpec{},
+		Status: configv1.ClusterOperatorStatus{
+			RelatedObjects: []configv1.ObjectReference{
+				{
+					Group:    "operator.openshift.io",
+					Resource: "testcontroller",
+					Name:     "foo",
+				},
+				{
+					Group:    "",
+					Resource: "anotherTestResource",
+					Name:     "bar",
+				},
+			},
+		}}
+
+	return cli.ConfigV1().ClusterOperators().Create(context.Background(), co, metav1.CreateOptions{})
 }
 
-func Test_Operators_GatherClusterOperators(t *testing.T) {
-	testOperator := newClusterOperator()
-	cfg := configfake.NewSimpleClientset()
-	_, err := cfg.ConfigV1().ClusterOperators().Create(context.Background(), &testOperator, metav1.CreateOptions{})
+func createTestRelatedObject(dynamicCli *dynamicfake.FakeDynamicClient) (*unstructured.Unstructured, error) {
+	var yamlDefinition = `
+apiVersion: operator.openshift.io/v1
+kind: TestController
+metadata:
+    name: foo
+`
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	unstructuredObj := &unstructured.Unstructured{}
+
+	_, _, err := decUnstructured.Decode([]byte(yamlDefinition), nil, unstructuredObj)
 	if err != nil {
-		t.Fatal("unable to create fake clusteroperator", err)
+		return nil, err
 	}
+	return dynamicCli.Resource(gvr).Create(context.Background(), unstructuredObj, metav1.CreateOptions{})
+}
+
+func createFakeDynamicClient() *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		gvr: "TestControllersList",
+	})
+}
+func Test_Operators_GatherClusterOperators(t *testing.T) {
+	cfg := configfake.NewSimpleClientset()
+	_, err := createTestClusterOperator(cfg)
+	assert.NoError(t, err, "unable to create fake clusteroperator")
 
 	records, err := gatherClusterOperators(
 		context.Background(),
 		cfg.ConfigV1(),
 		cfg.Discovery(),
-		dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		createFakeDynamicClient(),
 	)
 	if err != nil {
 		t.Errorf("unexpected errors: %#v", err)
@@ -92,12 +133,20 @@ func Test_Operators_ClusterOperatorsRecords(t *testing.T) {
 	}
 }
 
-func Test_Operators_CollectClusterOperatorResources(t *testing.T) {
+func Test_Operators_collectClusterOperatorRelatedObjects(t *testing.T) {
+	// create test clusteroperator resource
+	co, err := createTestClusterOperator(configfake.NewSimpleClientset())
+	assert.NoError(t, err, "unable to create fake clusteroperator")
+	dynamicFake := createFakeDynamicClient()
+	// create test related object to clusteroperator resource
+	_, err = createTestRelatedObject(dynamicFake)
+	assert.NoError(t, err, "unable to create fake related object")
+
 	type args struct {
 		ctx           context.Context
 		dynamicClient dynamic.Interface
 		co            configv1.ClusterOperator
-		resVer        map[string][]string
+		resVer        map[schema.GroupResource]string
 	}
 	tests := []struct {
 		name string
@@ -105,25 +154,33 @@ func Test_Operators_CollectClusterOperatorResources(t *testing.T) {
 		want []clusterOperatorResource
 	}{
 		{
-			name: "empty cluster operator resources",
+			name: "cluster operator relatedObject obtained",
 			args: args{
-				ctx:           context.TODO(),
-				dynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
-				co:            newClusterOperator(),
-				resVer:        map[string][]string{},
+				ctx:           context.Background(),
+				dynamicClient: dynamicFake,
+				co:            *co,
+				resVer: map[schema.GroupResource]string{
+					{Group: "operator.openshift.io", Resource: "testcontroller"}: "v1",
+				},
 			},
-			want: nil,
+			want: []clusterOperatorResource{
+				{
+					APIVersion: "operator.openshift.io/v1",
+					Kind:       "TestController",
+					Name:       "foo",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := collectClusterOperatorResources(
+			actualClusterOperatorRelObjects := collectClusterOperatorRelatedObjects(
 				tt.args.ctx,
 				tt.args.dynamicClient,
 				tt.args.co,
-				tt.args.resVer); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("collectClusterOperatorResources() = %v, want %v", got, tt.want)
-			}
+				tt.args.resVer)
+			assert.Len(t, actualClusterOperatorRelObjects, 1)
+			assert.Equal(t, tt.want, actualClusterOperatorRelObjects)
 		})
 	}
 }
@@ -135,13 +192,13 @@ func Test_Operators_GetOperatorResourcesVersions(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    map[string][]string
+		want    map[schema.GroupResource]string
 		wantErr bool
 	}{
 		{
 			name:    "empty operator resources versions",
 			args:    args{discoveryClient: kubefake.NewSimpleClientset().Discovery()},
-			want:    map[string][]string{},
+			want:    map[schema.GroupResource]string{},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
…ject & simplify (#714)

the code

<!-- Short description of the PR. What does it do? -->
Backport of https://github.com/openshift/insights-operator/pull/714

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/clusteroperator/operator.openshift.io/ingresscontroller/openshift-ingress-operator/default.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/operators_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-5976
https://access.redhat.com/solutions/???
