### PR TITLE
OCPBUGS-6732: [backport-4.12] anonymize env vars https proxy

### DIFF
--- a/pkg/gatherers/clusterconfig/container_images.go
+++ b/pkg/gatherers/clusterconfig/container_images.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils/anonymize"
 	"github.com/openshift/insights-operator/pkg/utils/check"
 	"github.com/openshift/library-go/pkg/image/reference"
 )
@@ -68,6 +69,8 @@ func gatherContainerImages(ctx context.Context, coreClient corev1client.CoreV1In
 		for podIndex, pod := range pods.Items { //nolint:gocritic
 			podPtr := &pods.Items[podIndex]
 			if strings.HasPrefix(pod.Namespace, "openshift-") && check.HasContainerInCrashloop(podPtr) {
+				anonymize.SensitiveEnvVars(podPtr.Spec.Containers)
+
 				records = append(records, record.Record{
 					Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name),
 					Item: record.ResourceMarshaller{Resource: podPtr},

--- a/pkg/gatherers/clusterconfig/operators_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/operators_pods_and_events.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/insights-operator/pkg/record"
 	"github.com/openshift/insights-operator/pkg/recorder"
 	"github.com/openshift/insights-operator/pkg/utils"
+	"github.com/openshift/insights-operator/pkg/utils/anonymize"
 	"github.com/openshift/insights-operator/pkg/utils/check"
 	"github.com/openshift/insights-operator/pkg/utils/marshal"
 )
@@ -217,6 +218,8 @@ func gatherPodsAndTheirContainersLogs(ctx context.Context,
 	for _, pod := range pods {
 		// if pod is not healthy then record its definition and try to get previous log
 		if !check.IsHealthyPod(pod, time.Now()) {
+			anonymize.SensitiveEnvVars(pod.Spec.Containers)
+
 			records = append(records, record.Record{
 				Name: fmt.Sprintf("config/pod/%s/%s", pod.Namespace, pod.Name),
 				Item: record.ResourceMarshaller{Resource: pod},

--- a/pkg/gatherers/clusterconfig/version.go
+++ b/pkg/gatherers/clusterconfig/version.go
@@ -78,6 +78,7 @@ func getClusterVersion(ctx context.Context,
 	}
 	for i := range pods.Items {
 		pod := &pods.Items[i]
+		anonymize.SensitiveEnvVars(pod.Spec.Containers)
 
 		// TODO: shift after IsHealthyPod
 		records = append(records, record.Record{

--- a/pkg/gatherers/conditional/gather_pod_definition.go
+++ b/pkg/gatherers/conditional/gather_pod_definition.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/insights-operator/pkg/gatherers"
 	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils/anonymize"
 )
 
 // BuildGatherPodDefinition collects pod definition from pods that are firing one of the configured alerts.
@@ -76,6 +77,8 @@ func (g *Gatherer) gatherPodDefinition(
 			errs = append(errs, err)
 			continue
 		}
+
+		anonymize.SensitiveEnvVars(pod.Spec.Containers)
 
 		records = append(records, record.Record{
 			Name: fmt.Sprintf(

--- a/pkg/utils/anonymize/envvars.go
+++ b/pkg/utils/anonymize/envvars.go
@@ -1,0 +1,23 @@
+package anonymize
+
+import (
+	"regexp"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SensitiveEnvVars finds env variables within the given container list
+// and, if they are a target, it will obfuscate their value
+func SensitiveEnvVars(containers []corev1.Container) {
+	targets := []string{"HTTP_PROXY", "HTTPS_PROXY"}
+	search := regexp.MustCompile(strings.Join(targets, "|"))
+
+	for i := range containers {
+		for j := range containers[i].Env {
+			if search.MatchString(containers[i].Env[j].Name) {
+				containers[i].Env[j].Value = String(containers[i].Env[j].Value)
+			}
+		}
+	}
+}

--- a/pkg/utils/anonymize/envvars_test.go
+++ b/pkg/utils/anonymize/envvars_test.go
@@ -1,0 +1,39 @@
+package anonymize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_EnvVar_Obfuscation(t *testing.T) {
+	// Given
+	mock := []corev1.Container{
+		{
+			Env: []corev1.EnvVar{
+				{Name: "NO_TARGET", Value: "original_value"},
+				{Name: "HTTP_PROXY", Value: "original_value"},
+				{Name: "HTTPS_PROXY", Value: "original_value"},
+			},
+		},
+	}
+	envOriginalValue := "original_value"
+
+	// When
+	SensitiveEnvVars(mock)
+
+	// Assert
+	t.Run("Non target env vars keep their original value", func(t *testing.T) {
+		test := mock[0].Env[0]
+		assert.Equal(t, envOriginalValue, test.Value)
+	})
+	t.Run("HTTP_PROXY is updated with obfuscated value", func(t *testing.T) {
+		test := mock[0].Env[1]
+		assert.NotEqual(t, envOriginalValue, test.Value)
+	})
+	t.Run("HTTPS_PROXY is updated with obfuscated value", func(t *testing.T) {
+		test := mock[0].Env[2]
+		assert.NotEqual(t, envOriginalValue, test.Value)
+	})
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR adds new functionality for pod container gatherers, where it obfuscates HTTP_PROXY and HTTPS_PROXY env variables from retrieved containers.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

N/A

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `/pkg/gatherers/clusterconfig/container_images_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[CCXDEV-10028](https://issues.redhat.com/browse/CCXDEV-10028)
[OCPBUGS-6732](https://issues.redhat.com/browse/OCPBUGS-6732)