### PR TITLE
service_accounts.go Marshall fix

### DIFF
--- a/docs/insights-archive-sample/config/serviceaccounts.json
+++ b/docs/insights-archive-sample/config/serviceaccounts.json
@@ -1,255 +1,1549 @@
 {
   "serviceAccounts": {
-    "TOTAL_COUNT": 310,
+    "TOTAL_COUNT": 352,
     "namespaces": {
-      "default": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "kube-public": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "kube-system": {
-        "name": "statefulset-controller",
-        "secrets": 2
-      },
-      "openshift": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-apiserver": {
-        "name": "openshift-apiserver-sa",
-        "secrets": 2
-      },
-      "openshift-apiserver-operator": {
-        "name": "openshift-apiserver-operator",
-        "secrets": 2
-      },
-      "openshift-authentication": {
-        "name": "oauth-openshift",
-        "secrets": 2
-      },
-      "openshift-authentication-operator": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-cloud-credential-operator": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-cluster-csi-drivers": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-cluster-machine-approver": {
-        "name": "machine-approver-sa",
-        "secrets": 2
-      },
-      "openshift-cluster-node-tuning-operator": {
-        "name": "tuned",
-        "secrets": 2
-      },
-      "openshift-cluster-samples-operator": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-cluster-storage-operator": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-cluster-version": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-config": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-config-managed": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-config-operator": {
-        "name": "openshift-config-operator",
-        "secrets": 2
-      },
-      "openshift-console": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-console-operator": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-console-user-settings": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-controller-manager": {
-        "name": "openshift-controller-manager-sa",
-        "secrets": 2
-      },
-      "openshift-controller-manager-operator": {
-        "name": "openshift-controller-manager-operator",
-        "secrets": 2
-      },
-      "openshift-dns": {
-        "name": "dns",
-        "secrets": 2
-      },
-      "openshift-dns-operator": {
-        "name": "dns-operator",
-        "secrets": 2
-      },
-      "openshift-etcd": {
-        "name": "installer-sa",
-        "secrets": 2
-      },
-      "openshift-etcd-operator": {
-        "name": "etcd-operator",
-        "secrets": 2
-      },
-      "openshift-host-network": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-image-registry": {
-        "name": "registry",
-        "secrets": 2
-      },
-      "openshift-infra": {
-        "name": "unidling-controller",
-        "secrets": 2
-      },
-      "openshift-ingress": {
-        "name": "router",
-        "secrets": 2
-      },
-      "openshift-ingress-canary": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-ingress-operator": {
-        "name": "ingress-operator",
-        "secrets": 2
-      },
-      "openshift-insights": {
-        "name": "operator",
-        "secrets": 2
-      },
-      "openshift-kni-infra": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-kube-apiserver": {
-        "name": "localhost-recovery-client",
-        "secrets": 2
-      },
-      "openshift-kube-apiserver-operator": {
-        "name": "kube-apiserver-operator",
-        "secrets": 2
-      },
-      "openshift-kube-controller-manager": {
-        "name": "localhost-recovery-client",
-        "secrets": 2
-      },
-      "openshift-kube-controller-manager-operator": {
-        "name": "kube-controller-manager-operator",
-        "secrets": 2
-      },
-      "openshift-kube-scheduler": {
-        "name": "openshift-kube-scheduler-sa",
-        "secrets": 2
-      },
-      "openshift-kube-scheduler-operator": {
-        "name": "openshift-kube-scheduler-operator",
-        "secrets": 2
-      },
-      "openshift-kube-storage-version-migrator": {
-        "name": "kube-storage-version-migrator-sa",
-        "secrets": 2
-      },
-      "openshift-kube-storage-version-migrator-operator": {
-        "name": "kube-storage-version-migrator-operator",
-        "secrets": 2
-      },
-      "openshift-kubevirt-infra": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-machine-api": {
-        "name": "machine-api-termination-handler",
-        "secrets": 2
-      },
-      "openshift-machine-config-operator": {
-        "name": "node-bootstrapper",
-        "secrets": 2
-      },
-      "openshift-marketplace": {
-        "name": "redhat-operators",
-        "secrets": 2
-      },
-      "openshift-monitoring": {
-        "name": "thanos-querier",
-        "secrets": 2
-      },
-      "openshift-multus": {
-        "name": "multus",
-        "secrets": 2
-      },
-      "openshift-network-diagnostics": {
-        "name": "network-diagnostics",
-        "secrets": 2
-      },
-      "openshift-network-operator": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-node": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-oauth-apiserver": {
-        "name": "oauth-apiserver-sa",
-        "secrets": 2
-      },
-      "openshift-openstack-infra": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-operator-lifecycle-manager": {
-        "name": "olm-operator-serviceaccount",
-        "secrets": 2
-      },
-      "openshift-operators": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-ovirt-infra": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-sdn": {
-        "name": "sdn-controller",
-        "secrets": 2
-      },
-      "openshift-service-ca": {
-        "name": "service-ca",
-        "secrets": 2
-      },
-      "openshift-service-ca-operator": {
-        "name": "service-ca-operator",
-        "secrets": 2
-      },
-      "openshift-user-workload-monitoring": {
-        "name": "deployer",
-        "secrets": 2
-      },
-      "openshift-vsphere-infra": {
-        "name": "deployer",
-        "secrets": 2
-      }
+      "default": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "kube-public": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "kube-system": [
+        {
+          "name": "attachdetach-controller",
+          "secrets": 1
+        },
+        {
+          "name": "aws-cloud-provider",
+          "secrets": 1
+        },
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "certificate-controller",
+          "secrets": 1
+        },
+        {
+          "name": "cloud-controller-manager",
+          "secrets": 1
+        },
+        {
+          "name": "clusterrole-aggregation-controller",
+          "secrets": 1
+        },
+        {
+          "name": "cronjob-controller",
+          "secrets": 1
+        },
+        {
+          "name": "daemon-set-controller",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "deployment-controller",
+          "secrets": 1
+        },
+        {
+          "name": "disruption-controller",
+          "secrets": 1
+        },
+        {
+          "name": "endpoint-controller",
+          "secrets": 1
+        },
+        {
+          "name": "endpointslice-controller",
+          "secrets": 1
+        },
+        {
+          "name": "endpointslicemirroring-controller",
+          "secrets": 1
+        },
+        {
+          "name": "ephemeral-volume-controller",
+          "secrets": 1
+        },
+        {
+          "name": "expand-controller",
+          "secrets": 1
+        },
+        {
+          "name": "generic-garbage-collector",
+          "secrets": 1
+        },
+        {
+          "name": "horizontal-pod-autoscaler",
+          "secrets": 1
+        },
+        {
+          "name": "job-controller",
+          "secrets": 1
+        },
+        {
+          "name": "namespace-controller",
+          "secrets": 1
+        },
+        {
+          "name": "node-controller",
+          "secrets": 1
+        },
+        {
+          "name": "persistent-volume-binder",
+          "secrets": 1
+        },
+        {
+          "name": "pod-garbage-collector",
+          "secrets": 1
+        },
+        {
+          "name": "pv-protection-controller",
+          "secrets": 1
+        },
+        {
+          "name": "pvc-protection-controller",
+          "secrets": 1
+        },
+        {
+          "name": "replicaset-controller",
+          "secrets": 1
+        },
+        {
+          "name": "replication-controller",
+          "secrets": 1
+        },
+        {
+          "name": "resourcequota-controller",
+          "secrets": 1
+        },
+        {
+          "name": "root-ca-cert-publisher",
+          "secrets": 1
+        },
+        {
+          "name": "service-account-controller",
+          "secrets": 1
+        },
+        {
+          "name": "service-ca-cert-publisher",
+          "secrets": 1
+        },
+        {
+          "name": "service-controller",
+          "secrets": 1
+        },
+        {
+          "name": "statefulset-controller",
+          "secrets": 1
+        },
+        {
+          "name": "ttl-after-finished-controller",
+          "secrets": 1
+        }
+      ],
+      "openshift": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-apiserver": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "openshift-apiserver-sa",
+          "secrets": 1
+        }
+      ],
+      "openshift-apiserver-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "openshift-apiserver-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-authentication": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "oauth-openshift",
+          "secrets": 1
+        }
+      ],
+      "openshift-authentication-operator": [
+        {
+          "name": "authentication-operator",
+          "secrets": 1
+        },
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-cloud-controller-manager": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cloud-controller-manager",
+          "secrets": 1
+        },
+        {
+          "name": "cloud-node-manager",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-cloud-controller-manager-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-cloud-controller-manager",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-cloud-credential-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cloud-credential-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "pod-identity-webhook",
+          "secrets": 1
+        }
+      ],
+      "openshift-cloud-network-config-controller": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cloud-network-config-controller",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-cluster-csi-drivers": [
+        {
+          "name": "aws-ebs-csi-driver-controller-sa",
+          "secrets": 1
+        },
+        {
+          "name": "aws-ebs-csi-driver-node-sa",
+          "secrets": 1
+        },
+        {
+          "name": "aws-ebs-csi-driver-operator",
+          "secrets": 1
+        },
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-cluster-machine-approver": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "machine-approver-sa",
+          "secrets": 1
+        }
+      ],
+      "openshift-cluster-node-tuning-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-node-tuning-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "tuned",
+          "secrets": 1
+        }
+      ],
+      "openshift-cluster-samples-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-samples-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-cluster-storage-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-storage-operator",
+          "secrets": 1
+        },
+        {
+          "name": "csi-snapshot-controller",
+          "secrets": 1
+        },
+        {
+          "name": "csi-snapshot-controller-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-cluster-version": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-compliance": [
+        {
+          "name": "api-resource-collector",
+          "secrets": 1
+        },
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "compliance-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "profileparser",
+          "secrets": 1
+        },
+        {
+          "name": "remediation-aggregator",
+          "secrets": 1
+        },
+        {
+          "name": "rerunner",
+          "secrets": 1
+        },
+        {
+          "name": "resultscollector",
+          "secrets": 1
+        },
+        {
+          "name": "resultserver",
+          "secrets": 1
+        }
+      ],
+      "openshift-config": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-config-managed": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-config-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "openshift-config-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-console": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "console",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-console-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "console-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-console-user-settings": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-controller-manager": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "openshift-controller-manager-sa",
+          "secrets": 1
+        }
+      ],
+      "openshift-controller-manager-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "openshift-controller-manager-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-dns": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "dns",
+          "secrets": 1
+        },
+        {
+          "name": "node-resolver",
+          "secrets": 1
+        }
+      ],
+      "openshift-dns-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "dns-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-etcd": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "etcd-sa",
+          "secrets": 1
+        },
+        {
+          "name": "installer-sa",
+          "secrets": 1
+        }
+      ],
+      "openshift-etcd-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "etcd-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-host-network": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-image-registry": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-image-registry-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "node-ca",
+          "secrets": 1
+        },
+        {
+          "name": "pruner",
+          "secrets": 1
+        },
+        {
+          "name": "registry",
+          "secrets": 1
+        }
+      ],
+      "openshift-infra": [
+        {
+          "name": "build-config-change-controller",
+          "secrets": 1
+        },
+        {
+          "name": "build-controller",
+          "secrets": 1
+        },
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-csr-approver-controller",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-quota-reconciliation-controller",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "default-rolebindings-controller",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "deployer-controller",
+          "secrets": 1
+        },
+        {
+          "name": "deploymentconfig-controller",
+          "secrets": 1
+        },
+        {
+          "name": "image-import-controller",
+          "secrets": 1
+        },
+        {
+          "name": "image-trigger-controller",
+          "secrets": 1
+        },
+        {
+          "name": "ingress-to-route-controller",
+          "secrets": 1
+        },
+        {
+          "name": "namespace-security-allocation-controller",
+          "secrets": 1
+        },
+        {
+          "name": "node-bootstrapper",
+          "secrets": 1
+        },
+        {
+          "name": "origin-namespace-controller",
+          "secrets": 1
+        },
+        {
+          "name": "podsecurity-admission-label-syncer-controller",
+          "secrets": 1
+        },
+        {
+          "name": "pv-recycler-controller",
+          "secrets": 1
+        },
+        {
+          "name": "resourcequota-controller",
+          "secrets": 1
+        },
+        {
+          "name": "serviceaccount-controller",
+          "secrets": 1
+        },
+        {
+          "name": "serviceaccount-pull-secrets-controller",
+          "secrets": 1
+        },
+        {
+          "name": "template-instance-controller",
+          "secrets": 1
+        },
+        {
+          "name": "template-instance-finalizer-controller",
+          "secrets": 1
+        },
+        {
+          "name": "unidling-controller",
+          "secrets": 1
+        }
+      ],
+      "openshift-ingress": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "router",
+          "secrets": 1
+        }
+      ],
+      "openshift-ingress-canary": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-ingress-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "ingress-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-insights": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "gather",
+          "secrets": 1
+        },
+        {
+          "name": "operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-kni-infra": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-kube-apiserver": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "installer-sa",
+          "secrets": 1
+        },
+        {
+          "name": "localhost-recovery-client",
+          "secrets": 1
+        }
+      ],
+      "openshift-kube-apiserver-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "kube-apiserver-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-kube-controller-manager": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "installer-sa",
+          "secrets": 1
+        },
+        {
+          "name": "kube-controller-manager-sa",
+          "secrets": 1
+        },
+        {
+          "name": "localhost-recovery-client",
+          "secrets": 1
+        }
+      ],
+      "openshift-kube-controller-manager-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "kube-controller-manager-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-kube-scheduler": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "installer-sa",
+          "secrets": 1
+        },
+        {
+          "name": "localhost-recovery-client",
+          "secrets": 1
+        },
+        {
+          "name": "openshift-kube-scheduler-sa",
+          "secrets": 1
+        }
+      ],
+      "openshift-kube-scheduler-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "openshift-kube-scheduler-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-kube-storage-version-migrator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "kube-storage-version-migrator-sa",
+          "secrets": 1
+        }
+      ],
+      "openshift-kube-storage-version-migrator-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "kube-storage-version-migrator-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-machine-api": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-autoscaler",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-autoscaler-operator",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-baremetal-operator",
+          "secrets": 1
+        },
+        {
+          "name": "control-plane-machine-set-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "machine-api-controllers",
+          "secrets": 1
+        },
+        {
+          "name": "machine-api-operator",
+          "secrets": 1
+        },
+        {
+          "name": "machine-api-termination-handler",
+          "secrets": 1
+        }
+      ],
+      "openshift-machine-config-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "machine-config-controller",
+          "secrets": 1
+        },
+        {
+          "name": "machine-config-daemon",
+          "secrets": 1
+        },
+        {
+          "name": "machine-config-server",
+          "secrets": 1
+        },
+        {
+          "name": "node-bootstrapper",
+          "secrets": 1
+        }
+      ],
+      "openshift-marketplace": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "certified-operators",
+          "secrets": 1
+        },
+        {
+          "name": "community-operators",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "marketplace-operator",
+          "secrets": 1
+        },
+        {
+          "name": "redhat-marketplace",
+          "secrets": 1
+        },
+        {
+          "name": "redhat-operators",
+          "secrets": 1
+        }
+      ],
+      "openshift-monitoring": [
+        {
+          "name": "alertmanager-main",
+          "secrets": 1
+        },
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "cluster-monitoring-operator",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "kube-state-metrics",
+          "secrets": 1
+        },
+        {
+          "name": "node-exporter",
+          "secrets": 1
+        },
+        {
+          "name": "openshift-state-metrics",
+          "secrets": 1
+        },
+        {
+          "name": "prometheus-adapter",
+          "secrets": 1
+        },
+        {
+          "name": "prometheus-k8s",
+          "secrets": 1
+        },
+        {
+          "name": "prometheus-operator",
+          "secrets": 1
+        },
+        {
+          "name": "prometheus-operator-admission-webhook",
+          "secrets": 1
+        },
+        {
+          "name": "telemeter-client",
+          "secrets": 1
+        },
+        {
+          "name": "thanos-querier",
+          "secrets": 1
+        }
+      ],
+      "openshift-multus": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "metrics-daemon-sa",
+          "secrets": 1
+        },
+        {
+          "name": "multus",
+          "secrets": 1
+        },
+        {
+          "name": "multus-ac",
+          "secrets": 1
+        }
+      ],
+      "openshift-network-diagnostics": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "network-diagnostics",
+          "secrets": 1
+        }
+      ],
+      "openshift-network-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-node": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-nutanix-infra": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-oauth-apiserver": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "oauth-apiserver-sa",
+          "secrets": 1
+        }
+      ],
+      "openshift-openstack-infra": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-operator-lifecycle-manager": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "collect-profiles",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "olm-operator-serviceaccount",
+          "secrets": 1
+        }
+      ],
+      "openshift-operators": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-ovirt-infra": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-ovn-kubernetes": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "ovn-kubernetes-controller",
+          "secrets": 1
+        },
+        {
+          "name": "ovn-kubernetes-node",
+          "secrets": 1
+        }
+      ],
+      "openshift-route-controller-manager": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "route-controller-manager-sa",
+          "secrets": 1
+        }
+      ],
+      "openshift-service-ca": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "service-ca",
+          "secrets": 1
+        }
+      ],
+      "openshift-service-ca-operator": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        },
+        {
+          "name": "service-ca-operator",
+          "secrets": 1
+        }
+      ],
+      "openshift-user-workload-monitoring": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ],
+      "openshift-vsphere-infra": [
+        {
+          "name": "builder",
+          "secrets": 1
+        },
+        {
+          "name": "default",
+          "secrets": 1
+        },
+        {
+          "name": "deployer",
+          "secrets": 1
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR fixes the bug in service_accounts.go where in Marshall function there wouldn't be all service accounts saved.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/serviceaccounts.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

no update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/service_accounts_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-10265
