### PR TITLE
Add unit tests for log gatherers

### DIFF
--- a/pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs.go
@@ -39,15 +39,6 @@ func (g *Gatherer) GatherOpenShiftAPIServerOperatorLogs(ctx context.Context) ([]
 		Namespace:     "openshift-apiserver-operator",
 		LabelSelector: "app=openshift-apiserver-operator",
 	}
-	messagesFilter := common.LogMessagesFilter{
-		MessagesToSearch: []string{
-			"the server has received too many requests and has asked us",
-			"because serving request timed out and response had been started",
-		},
-		IsRegexSearch: false,
-		SinceSeconds:  logDefaultSinceSeconds,
-		LimitBytes:    logDefaultLimitBytes,
-	}
 
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {
@@ -60,7 +51,7 @@ func (g *Gatherer) GatherOpenShiftAPIServerOperatorLogs(ctx context.Context) ([]
 		ctx,
 		coreClient,
 		containersFilter,
-		messagesFilter,
+		getAPIServerOperatorLogsMessagesFilter(),
 		nil,
 	)
 	if err != nil {
@@ -68,4 +59,16 @@ func (g *Gatherer) GatherOpenShiftAPIServerOperatorLogs(ctx context.Context) ([]
 	}
 
 	return records, nil
+}
+
+func getAPIServerOperatorLogsMessagesFilter() common.LogMessagesFilter {
+	return common.LogMessagesFilter{
+		MessagesToSearch: []string{
+			"the server has received too many requests and has asked us",
+			"because serving request timed out and response had been started",
+		},
+		IsRegexSearch: false,
+		SinceSeconds:  logDefaultSinceSeconds,
+		LimitBytes:    logDefaultLimitBytes,
+	}
 }

--- a/pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs_test.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs_test.go
@@ -1,0 +1,57 @@
+package clusterconfig
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/gatherers/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GatherOpenShiftAPIServerOperatorLogs(t *testing.T) {
+	// Unit Tests
+	testCases := []struct {
+		name     string
+		logline  string
+		expected string
+	}{
+		{
+			name:     "No log line matches the messages to search",
+			logline:  "mock logline",
+			expected: "",
+		},
+		{
+			name:     "Logs with 'the server has received too many ...' string matches successfully",
+			logline:  "{text before} the server has received too many requests and has asked us {text after}",
+			expected: "the server has received too many requests and has asked us",
+		},
+		{
+			name:     "Logs with 'because serving request ...' string matches successfully",
+			logline:  "{text before} because serving request timed out and response had been started {text after}",
+			expected: "because serving request timed out and response had been started",
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Given
+			msgFilter := getAPIServerOperatorLogsMessagesFilter()
+
+			// When
+			test, err := common.FilterLogFromScanner(
+				bufio.NewScanner(strings.NewReader(
+					tc.logline,
+				)),
+				msgFilter.MessagesToSearch,
+				msgFilter.IsRegexSearch,
+				nil)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Contains(t, test, tc.expected)
+		})
+	}
+}

--- a/pkg/gatherers/clusterconfig/gather_openshift_authentication_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_authentication_logs.go
@@ -39,14 +39,6 @@ func (g *Gatherer) GatherOpenshiftAuthenticationLogs(ctx context.Context) ([]rec
 		Namespace:     "openshift-authentication",
 		LabelSelector: "app=oauth-openshift",
 	}
-	messagesFilter := common.LogMessagesFilter{
-		MessagesToSearch: []string{
-			"AuthenticationError: invalid resource name",
-		},
-		IsRegexSearch: false,
-		SinceSeconds:  logDefaultSinceSeconds,
-		LimitBytes:    logDefaultLimitBytes,
-	}
 
 	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
 	if err != nil {
@@ -59,7 +51,7 @@ func (g *Gatherer) GatherOpenshiftAuthenticationLogs(ctx context.Context) ([]rec
 		ctx,
 		coreClient,
 		containersFilter,
-		messagesFilter,
+		getOpenshiftAuthenticationLogsMessagesFilter(),
 		nil,
 	)
 	if err != nil {
@@ -67,4 +59,15 @@ func (g *Gatherer) GatherOpenshiftAuthenticationLogs(ctx context.Context) ([]rec
 	}
 
 	return records, nil
+}
+
+func getOpenshiftAuthenticationLogsMessagesFilter() common.LogMessagesFilter {
+	return common.LogMessagesFilter{
+		MessagesToSearch: []string{
+			"AuthenticationError: invalid resource name",
+		},
+		IsRegexSearch: false,
+		SinceSeconds:  logDefaultSinceSeconds,
+		LimitBytes:    logDefaultLimitBytes,
+	}
 }

--- a/pkg/gatherers/clusterconfig/gather_openshift_authentication_logs_test.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_authentication_logs_test.go
@@ -1,0 +1,52 @@
+package clusterconfig
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/gatherers/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GatherOpenshiftAuthenticationLogs(t *testing.T) {
+	// Unit Tests
+	testCases := []struct {
+		name     string
+		logline  string
+		expected string
+	}{
+		{
+			name:     "No log line matches the messages to search",
+			logline:  "mock logline",
+			expected: "",
+		},
+		{
+			name:     "Logs with 'AuthenticationError: ' string matches successfully",
+			logline:  "{text before} AuthenticationError: invalid resource name {text after}",
+			expected: "AuthenticationError: invalid resource name",
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Given
+			msgFilter := getOpenshiftAuthenticationLogsMessagesFilter()
+
+			// When
+			test, err := common.FilterLogFromScanner(
+				bufio.NewScanner(strings.NewReader(
+					tc.logline,
+				)),
+				msgFilter.MessagesToSearch,
+				msgFilter.IsRegexSearch,
+				nil)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Contains(t, test, tc.expected)
+		})
+	}
+}

--- a/pkg/gatherers/clusterconfig/gather_sap_vsystem_iptables_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_sap_vsystem_iptables_logs.go
@@ -89,20 +89,12 @@ func gatherSAPLicenseManagementLogs(
 			Namespace:                item.GetNamespace(),
 			ContainerNameRegexFilter: "^vsystem-iptables$",
 		}
-		messagesFilter := common.LogMessagesFilter{
-			MessagesToSearch: []string{
-				"can't initialize iptables table",
-			},
-			IsRegexSearch: false,
-			SinceSeconds:  logDefaultSinceSeconds,
-			LimitBytes:    logDefaultLimitBytes,
-		}
 
 		namespaceRecords, err := common.CollectLogsFromContainers(
 			ctx,
 			coreClient,
 			containersFilter,
-			messagesFilter,
+			getSAPLicenseManagementLogsMessageFilter(),
 			nil,
 		)
 		if err != nil {
@@ -113,4 +105,15 @@ func gatherSAPLicenseManagementLogs(
 	}
 
 	return records, errs
+}
+
+func getSAPLicenseManagementLogsMessageFilter() common.LogMessagesFilter {
+	return common.LogMessagesFilter{
+		MessagesToSearch: []string{
+			"can't initialize iptables table",
+		},
+		IsRegexSearch: false,
+		SinceSeconds:  logDefaultSinceSeconds,
+		LimitBytes:    logDefaultLimitBytes,
+	}
 }

--- a/pkg/gatherers/clusterconfig/gather_sap_vsystem_iptables_logs_test.go
+++ b/pkg/gatherers/clusterconfig/gather_sap_vsystem_iptables_logs_test.go
@@ -1,0 +1,52 @@
+package clusterconfig
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/gatherers/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GatherSAPVsystemIptablesLogs(t *testing.T) {
+	// Unit Tests
+	testCases := []struct {
+		name     string
+		logline  string
+		expected string
+	}{
+		{
+			name:     "No log line matches the messages to search",
+			logline:  "mock logline",
+			expected: "",
+		},
+		{
+			name:     "Logs with 'can't initialize iptables table' string matches successfully",
+			logline:  "{text before} can't initialize iptables table {text after}",
+			expected: "can't initialize iptables table",
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Given
+			msgFilter := getSAPLicenseManagementLogsMessageFilter()
+
+			// When
+			test, err := common.FilterLogFromScanner(
+				bufio.NewScanner(strings.NewReader(
+					tc.logline,
+				)),
+				msgFilter.MessagesToSearch,
+				msgFilter.IsRegexSearch,
+				nil)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Contains(t, test, tc.expected)
+		})
+	}
+}

--- a/pkg/gatherers/clusterconfig/gather_scheduler_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_scheduler_logs.go
@@ -45,19 +45,27 @@ func (g *Gatherer) GatherSchedulerLogs(ctx context.Context) ([]record.Record, []
 }
 
 func gatherSchedulerLogs(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
-	records, err := common.CollectLogsFromContainers(ctx, coreClient, common.LogContainersFilter{
-		Namespace:     "openshift-kube-scheduler",
-		LabelSelector: "app=openshift-kube-scheduler",
-	}, common.LogMessagesFilter{
-		MessagesToSearch: []string{"PodTopologySpread"},
-		SinceSeconds:     logDefaultSinceSeconds,
-		LimitBytes:       logDefaultLimitBytes,
-	}, func(namespace string, podName string, containerName string) string {
-		return fmt.Sprintf("config/pod/%s/logs/%s/messages.log", namespace, podName)
-	})
+	records, err := common.CollectLogsFromContainers(ctx, coreClient,
+		common.LogContainersFilter{
+			Namespace:     "openshift-kube-scheduler",
+			LabelSelector: "app=openshift-kube-scheduler",
+		},
+		getSchedulerLogsMessagesFilter(),
+		func(namespace string, podName string, containerName string) string {
+			return fmt.Sprintf("config/pod/%s/logs/%s/messages.log", namespace, podName)
+		},
+	)
 	if err != nil {
 		return nil, []error{err}
 	}
 
 	return records, nil
+}
+
+func getSchedulerLogsMessagesFilter() common.LogMessagesFilter {
+	return common.LogMessagesFilter{
+		MessagesToSearch: []string{"PodTopologySpread"},
+		SinceSeconds:     logDefaultSinceSeconds,
+		LimitBytes:       logDefaultLimitBytes,
+	}
 }

--- a/pkg/gatherers/clusterconfig/gather_scheduler_logs_test.go
+++ b/pkg/gatherers/clusterconfig/gather_scheduler_logs_test.go
@@ -1,0 +1,52 @@
+package clusterconfig
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/gatherers/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GatherSchedulerLogs(t *testing.T) {
+	// Unit Tests
+	testCases := []struct {
+		name     string
+		logline  string
+		expected string
+	}{
+		{
+			name:     "No log line matches the messages to search",
+			logline:  "mock logline",
+			expected: "",
+		},
+		{
+			name:     "Logs with 'PodTopologySpread' string matches successfully",
+			logline:  "{text before} PodTopologySpread {text after}",
+			expected: "PodTopologySpread",
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Given
+			msgFilter := getSchedulerLogsMessagesFilter()
+
+			// When
+			test, err := common.FilterLogFromScanner(
+				bufio.NewScanner(strings.NewReader(
+					tc.logline,
+				)),
+				msgFilter.MessagesToSearch,
+				msgFilter.IsRegexSearch,
+				nil)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Contains(t, test, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements new unit tests for the following log gatherers:
* SAP vsystem Iptables
* OpenshiftAuthentication
* APIServer Operator
* Scheduler

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

- N/A

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs.go`
- `pkg/gatherers/clusterconfig/gather_openshift_authentication_logs.go`
- `pkg/gatherers/clusterconfig/gather_sap_vsystem_iptables_logs.go`
- `pkg/gatherers/clusterconfig/gather_scheduler_logs_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

Yes

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-10122
https://issues.redhat.com/browse/CCXDEV-10123
https://issues.redhat.com/browse/CCXDEV-10126
https://issues.redhat.com/browse/CCXDEV-10127

