### PR TITLE
OCPBUGS-8059: Stop Clusterversion caching

### DIFF
--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -12,8 +12,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/api/config/v1alpha1"
-	configclient "github.com/openshift/client-go/config/clientset/versioned"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/insights-operator/pkg/anonymization"
 	"github.com/openshift/insights-operator/pkg/authorizer/clusterauthorizer"
 	"github.com/openshift/insights-operator/pkg/config"
@@ -43,7 +42,7 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 		return err
 	}
 
-	configClient, err := configclient.NewForConfig(kubeConfig)
+	configClient, err := configv1client.NewForConfig(kubeConfig)
 	if err != nil {
 		return err
 	}
@@ -92,11 +91,7 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	}()
 
 	authorizer := clusterauthorizer.New(configObserver)
-	gatherConfigClient, err := configv1client.NewForConfig(gatherKubeConfig)
-	if err != nil {
-		return err
-	}
-	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherConfigClient)
+	insightsClient := insightsclient.New(nil, 0, "default", authorizer, configClient)
 
 	gatherers := gather.CreateAllGatherers(
 		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,

--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -92,12 +92,15 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 
 	authorizer := clusterauthorizer.New(configObserver)
 
-	gatherClient, err := configv1client.NewForConfig(gatherKubeConfig)
+	// gatherConfigClient is configClient created from gatherKubeConfig, this name was used because configClient was already taken
+	// this client is only used in insightsClient, it is created here
+	// because pkg/insights/insightsclient/request_test.go unit test won't work otherwise
+	gatherConfigClient, err := configv1client.NewForConfig(gatherKubeConfig)
 	if err != nil {
 		return err
 	}
 
-	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherClient)
+	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherConfigClient)
 	gatherers := gather.CreateAllGatherers(
 		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,
 		configObserver, insightsClient,

--- a/pkg/controller/gather_job.go
+++ b/pkg/controller/gather_job.go
@@ -91,8 +91,13 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	}()
 
 	authorizer := clusterauthorizer.New(configObserver)
-	insightsClient := insightsclient.New(nil, 0, "default", authorizer, configClient)
 
+	gatherClient, err := configv1client.NewForConfig(gatherKubeConfig)
+	if err != nil {
+		return err
+	}
+
+	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherClient)
 	gatherers := gather.CreateAllGatherers(
 		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,
 		configObserver, insightsClient,

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -128,12 +128,15 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 
 	authorizer := clusterauthorizer.New(secretConfigObserver)
 
-	gatherClient, err := configv1client.NewForConfig(gatherKubeConfig)
+	// gatherConfigClient is configClient created from gatherKubeConfig, this name was used because configClient was already taken
+	// this client is only used in insightsClient, it is created here
+	// because pkg/insights/insightsclient/request_test.go unit test won't work otherwise
+	gatherConfigClient, err := configv1client.NewForConfig(gatherKubeConfig)
 	if err != nil {
 		return err
 	}
 
-	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherClient)
+	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherConfigClient)
 
 	// the gatherers are periodically called to collect the data from the cluster
 	// and provide the results for the recorder

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -127,7 +127,13 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	go rec.PeriodicallyPrune(ctx, statusReporter)
 
 	authorizer := clusterauthorizer.New(secretConfigObserver)
-	insightsClient := insightsclient.New(nil, 0, "default", authorizer, configClient)
+
+	gatherClient, err := configv1client.NewForConfig(gatherKubeConfig)
+	if err != nil {
+		return err
+	}
+
+	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherClient)
 
 	// the gatherers are periodically called to collect the data from the cluster
 	// and provide the results for the recorder

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -162,11 +162,7 @@ func userAgent(releaseVersionEnv string, v apimachineryversion.Info, cv *configv
 }
 
 func (c *Client) GetClusterVersion() (*configv1.ClusterVersion, error) {
-	if c.clusterVersion != nil {
-		return c.clusterVersion, nil
-	}
 	ctx := context.Background()
-
 	gatherConfigClient, err := configv1client.NewForConfig(c.gatherKubeConfig)
 	if err != nil {
 		return nil, err

--- a/pkg/insights/insightsclient/requests_test.go
+++ b/pkg/insights/insightsclient/requests_test.go
@@ -74,12 +74,11 @@ func TestClient_RecvGatheringRules(t *testing.T) {
 		}),
 		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 		GroupVersion:         configv1.GroupVersion,
-		VersionedAPIPath:     "/apis/config.openshift.io/v1/clusterversions/version",
 	}
 
 	configClient := configv1client.New(fakeClient)
 	insightsClient := New(http.DefaultClient, 0, "", &MockAuthorizer{}, configClient)
-	gatheringRulesBytes, err := insightsClient.RecvGatheringRules(context.TODO(), endpoint)
+	gatheringRulesBytes, err := insightsClient.RecvGatheringRules(context.Background(), endpoint)
 	assert.NoError(t, err)
 	assert.JSONEq(t, testRules, string(gatheringRulesBytes))
 }

--- a/pkg/insights/insightsclient/requests_test.go
+++ b/pkg/insights/insightsclient/requests_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -77,8 +77,8 @@ func TestClient_RecvGatheringRules(t *testing.T) {
 		VersionedAPIPath:     "/apis/config.openshift.io/v1/clusterversions/version",
 	}
 
-	gatherConfigClient := configv1client.New(fakeClient)
-	insightsClient := New(http.DefaultClient, 0, "", &MockAuthorizer{}, gatherConfigClient)
+	configClient := configv1client.New(fakeClient)
+	insightsClient := New(http.DefaultClient, 0, "", &MockAuthorizer{}, configClient)
 	gatheringRulesBytes, err := insightsClient.RecvGatheringRules(context.TODO(), endpoint)
 	assert.NoError(t, err)
 	assert.JSONEq(t, testRules, string(gatheringRulesBytes))

--- a/pkg/insights/insightsclient/requests_test.go
+++ b/pkg/insights/insightsclient/requests_test.go
@@ -47,9 +47,7 @@ func TestClient_RecvGatheringRules(t *testing.T) {
 	httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
 		_, err := writer.Write([]byte(testRules))
-		if err != nil {
-			assert.NoError(t, err)
-		}
+		assert.NoError(t, err)
 	}))
 	endpoint := httpServer.URL
 	defer httpServer.Close()
@@ -80,12 +78,9 @@ func TestClient_RecvGatheringRules(t *testing.T) {
 	}
 
 	gatherConfigClient := configv1client.New(fakeClient)
-	assert.NoError(t, err)
 	insightsClient := New(http.DefaultClient, 0, "", &MockAuthorizer{}, gatherConfigClient)
-
 	gatheringRulesBytes, err := insightsClient.RecvGatheringRules(context.TODO(), endpoint)
 	assert.NoError(t, err)
-
 	assert.JSONEq(t, testRules, string(gatheringRulesBytes))
 }
 

--- a/pkg/insights/insightsclient/requests_test.go
+++ b/pkg/insights/insightsclient/requests_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -68,7 +68,7 @@ func TestClient_RecvGatheringRules(t *testing.T) {
 		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(bytes.NewReader(cv)),
+				Body:       io.NopCloser(bytes.NewReader(cv)),
 			}
 			return resp, nil
 		}),


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR fixes the problem of having old ClusterID cached when cluster has already new ClusterID.
## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->


## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/insights/insightsclient/request_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-8059
