### PR TITLE
OCPBUGS-11008: update the cluster transfer interval to 12h

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -16,5 +16,5 @@ ocm:
   scaEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/certificates
   scaInterval: "8h"
   clusterTransferEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/cluster_transfers/
-  clusterTransferInterval: "24h"
+  clusterTransferInterval: "12h"
 

--- a/pkg/ocm/clustertransfer/cluster_transfer.go
+++ b/pkg/ocm/clustertransfer/cluster_transfer.go
@@ -209,7 +209,7 @@ func (c *Controller) updatePullSecret(newData []byte) error {
 // The exponential backoff is applied only for HTTP errors >= 500.
 func (c *Controller) requestClusterTransferWithExponentialBackoff(endpoint string) ([]byte, error) {
 	bo := wait.Backoff{
-		Duration: c.configurator.Config().OCMConfig.ClusterTransferInterval / 48, // 30 min as the first waiting
+		Duration: c.configurator.Config().OCMConfig.ClusterTransferInterval / 24, // 30 min as the first waiting
 		Factor:   2,
 		Jitter:   0,
 		Steps:    ocm.OCMAPIFailureCountThreshold,


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This updates the cluster transfer query interval to 12h. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->


## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-11008
https://access.redhat.com/solutions/???
