### PR TITLE
[release-4.13] OCPBUGS-11902: feat(clusterconfig): adds virtual machine instances gather

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1918,6 +1918,34 @@ Collects `ValidatingWebhookConfiguration` resources
 None
 
 
+## VirtualMachineInstances
+
+Collects `VirtualMachineInstance` resources from cluster if available.
+
+### API Reference
+None
+
+### Sample data
+- [docs/insights-archive-sample/config/virtualmachineinstances/openshift-cnv/fedora-r2nf0eocvxbkmqjy.json](./insights-archive-sample/config/virtualmachineinstances/openshift-cnv/fedora-r2nf0eocvxbkmqjy.json)
+
+### Location in archive
+| Version   | Path														|
+| --------- | ---------------------------------------------------------- |
+| >= 4.14   | config/virtualmachineinstances/{namespace}/{name}.json		|
+
+### Config ID
+`clusterconfig/virtual_machine_instances`
+
+### Released version
+- 4.14
+
+### Backported versions
+None
+
+### Notes
+None
+
+
 ## WorkloadInfo
 
 Collects summarized info about the workloads on a cluster

--- a/docs/insights-archive-sample/config/virtualmachineinstances/openshift-cnv/fedora-r2nf0eocvxbkmqjy.json
+++ b/docs/insights-archive-sample/config/virtualmachineinstances/openshift-cnv/fedora-r2nf0eocvxbkmqjy.json
@@ -1,0 +1,151 @@
+{
+    "apiVersion": "kubevirt.io/v1alpha3",
+    "kind": "VirtualMachineInstance",
+    "metadata": {
+        "annotations": {
+            "kubevirt.io/latest-observed-api-version": "v1",
+            "kubevirt.io/storage-observed-api-version": "v1alpha3",
+            "vm.kubevirt.io/flavor": "small",
+            "vm.kubevirt.io/os": "fedora",
+            "vm.kubevirt.io/workload": "server"
+        },
+        "creationTimestamp": "2023-02-27T10:33:34Z",
+        "finalizers": [
+            "kubevirt.io/virtualMachineControllerFinalize",
+            "foregroundDeleteVirtualMachine"
+        ],
+        "generation": 2,
+        "labels": {
+            "kubevirt.io/domain": "fedora-r2nf0eocvxbkmqjy",
+            "kubevirt.io/size": "small"
+        },
+        "name": "fedora-r2nf0eocvxbkmqjy",
+        "namespace": "openshift-cnv",
+        "ownerReferences": [
+            {
+                "apiVersion": "kubevirt.io/v1",
+                "blockOwnerDeletion": true,
+                "controller": true,
+                "kind": "VirtualMachine",
+                "name": "fedora-r2nf0eocvxbkmqjy",
+                "uid": "ece0419f-a83f-43bc-bcdf-8787e5a11cfb"
+            }
+        ],
+        "resourceVersion": "22338",
+        "uid": "dbd1e61d-91bd-4dfe-9205-5f979e9f4a03"
+    },
+    "spec": {
+        "domain": {
+            "cpu": {
+                "cores": 1,
+                "model": "host-model",
+                "sockets": 1,
+                "threads": 1
+            },
+            "devices": {
+                "disks": [
+                    {
+                        "disk": {
+                            "bus": "virtio"
+                        },
+                        "name": "rootdisk"
+                    },
+                    {
+                        "disk": {
+                            "bus": "virtio"
+                        },
+                        "name": "cloudinitdisk"
+                    }
+                ],
+                "interfaces": [
+                    {
+                        "macAddress": "02:4a:4f:00:00:00",
+                        "masquerade": {},
+                        "model": "virtio",
+                        "name": "default"
+                    }
+                ],
+                "networkInterfaceMultiqueue": true,
+                "rng": {}
+            },
+            "features": {
+                "acpi": {
+                    "enabled": true
+                },
+                "smm": {
+                    "enabled": true
+                }
+            },
+            "firmware": {
+                "bootloader": {
+                    "efi": {}
+                },
+                "uuid": "63c6ddbd-72e4-5fe0-8b63-6bb8bef8e1ac"
+            },
+            "machine": {
+                "type": "pc-q35-rhel8.6.0"
+            },
+            "resources": {
+                "requests": {
+                    "memory": "2Gi"
+                }
+            }
+        },
+        "evictionStrategy": "LiveMigrate",
+        "networks": [
+            {
+                "name": "default",
+                "pod": {}
+            }
+        ],
+        "terminationGracePeriodSeconds": 180,
+        "volumes": [
+            {
+                "dataVolume": {
+                    "name": "fedora-r2nf0eocvxbkmqjy"
+                },
+                "name": "rootdisk"
+            },
+            {
+                "cloudInitNoCloud": "",
+                "name": "cloudinitdisk"
+            }
+        ]
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastProbeTime": "2023-02-27T10:33:34Z",
+                "lastTransitionTime": "2023-02-27T10:33:34Z",
+                "message": "virt-launcher pod has not yet been scheduled",
+                "reason": "PodNotExists",
+                "status": "False",
+                "type": "Ready"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": null,
+                "status": "True",
+                "type": "Provisioning"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2023-02-27T10:33:34Z",
+                "message": "failed to create virtual machine pod: pods \"virt-launcher-fedora-r2nf0eocvxbkmqjy-jxkcs\" is forbidden: violates PodSecurity \"restricted:latest\": seLinuxOptions (pod set forbidden securityContext.seLinuxOptions: type \"virt_launcher.process\"), allowPrivilegeEscalation != false (container \"compute\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"compute\" must set securityContext.capabilities.drop=[\"ALL\"]; container \"compute\" must not include \"SYS_PTRACE\" in securityContext.capabilities.add), seccompProfile (pod or container \"compute\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")",
+                "reason": "FailedCreate",
+                "status": "False",
+                "type": "Synchronized"
+            }
+        ],
+        "guestOSInfo": {},
+        "phase": "Pending",
+        "phaseTransitionTimestamps": [
+            {
+                "phase": "Pending",
+                "phaseTransitionTimestamp": "2023-02-27T10:33:34Z"
+            }
+        ],
+        "runtimeUser": 107,
+        "virtualMachineRevisionName": "revision-start-vm-ece0419f-a83f-43bc-bcdf-8787e5a11cfb-2"
+    }
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -87,6 +87,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"active_alerts":                     (*Gatherer).GatherActiveAlerts,
 	"ceph_cluster":                      (*Gatherer).GatherCephCluster,
 	"openshift_machine_api_events":      (*Gatherer).GatherOpenshiftMachineAPIEvents,
+	"virtual_machine_instances":         (*Gatherer).GatherVirtualMachineInstances,
 }
 
 func New(

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -30,7 +30,8 @@ var (
 	// logDefaultLimitBytes is used in calls to common.CollectLogsFromContainers
 	logDefaultLimitBytes = int64(1024 * 64) // maximum 64 kb of logs
 
-	defaultNamespaces           = []string{"default", "kube-system", "kube-public", "openshift"}
+	defaultNamespaces = []string{"default", "kube-system", "kube-public", "openshift"}
+
 	datahubGroupVersionResource = schema.GroupVersionResource{
 		Group: "installers.datahub.sap.com", Version: "v1alpha1", Resource: "datahubs",
 	}
@@ -68,6 +69,11 @@ var (
 		Group:    "operators.coreos.com",
 		Version:  "v1alpha1",
 		Resource: "clusterserviceversions",
+	}
+	virtualMachineInstancesResource = schema.GroupVersionResource{
+		Group:    "kubevirt.io",
+		Version:  "v1alpha3",
+		Resource: "virtualmachineinstances",
 	}
 )
 

--- a/pkg/gatherers/clusterconfig/gather_virtual_machine_instances.go
+++ b/pkg/gatherers/clusterconfig/gather_virtual_machine_instances.go
@@ -1,0 +1,115 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/insights-operator/pkg/utils"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"k8s.io/klog/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+// GatherVirtualMachineInstances Collects `VirtualMachineInstance` resources from cluster if available.
+//
+// ### API Reference
+// None
+//
+// ### Sample data
+// - docs/insights-archive-sample/config/virtualmachineinstances/openshift-cnv/fedora-r2nf0eocvxbkmqjy.json
+//
+// ### Location in archive
+// | Version   | Path														|
+// | --------- | ---------------------------------------------------------- |
+// | >= 4.14   | config/virtualmachineinstances/{namespace}/{name}.json		|
+//
+// ### Config ID
+// `clusterconfig/virtual_machine_instances`
+//
+// ### Released version
+// - 4.14
+//
+// ### Backported versions
+// None
+//
+// ### Notes
+// None
+func (g *Gatherer) GatherVirtualMachineInstances(ctx context.Context) ([]record.Record, []error) {
+	gatherDynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherVirtualMachineInstances(ctx, gatherDynamicClient)
+}
+
+func gatherVirtualMachineInstances(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	virtualizationList, err := dynamicClient.Resource(virtualMachineInstancesResource).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	var errs []error
+	// Limit the number of gathered virtualmachineinstances.kubevirt.io
+	var limit = 5
+	records := make([]record.Record, 0, limit)
+	for i := range virtualizationList.Items {
+		item := &virtualizationList.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("config/virtualmachineinstances/%s/%s", item.GetNamespace(), item.GetName()),
+			Item: record.ResourceMarshaller{Resource: anonymizeVirtualMachineInstances(item)},
+		})
+		// limit the gathered records
+		if len(records) == limit {
+			err = fmt.Errorf("limit %d for number of gathered %s resources exceeded (found: %d)",
+				limit, virtualMachineInstancesResource.GroupResource(), len(virtualizationList.Items))
+			errs = append(errs, err)
+			break
+		}
+	}
+
+	return records, errs
+}
+
+func anonymizeVirtualMachineInstances(data *unstructured.Unstructured) *unstructured.Unstructured {
+	const errMsg = "error during anonymizing virtualmachineinstances:"
+	volumes, err := utils.NestedSliceWrapper(data.Object, "spec", "volumes")
+	if err != nil {
+		klog.Infof("%s unable to find volumes %v", errMsg, err)
+		return data
+	}
+
+	for i := range volumes {
+		volume, ok := volumes[i].(map[string]interface{})
+		if !ok {
+			klog.Infof("%s volumes is not a map", errMsg)
+			continue
+		}
+
+		_, ok = volume["cloudInitNoCloud"]
+		if !ok {
+			klog.Infof("%s cloudInitNoCloud not found", errMsg)
+			continue
+		}
+
+		volume["cloudInitNoCloud"] = ""
+	}
+
+	err = unstructured.SetNestedSlice(data.Object, volumes, "spec", "volumes")
+	if err != nil {
+		klog.Infof("%s unable to set anonymized volumes: %v", errMsg, err.Error())
+	}
+
+	return data
+}

--- a/pkg/gatherers/clusterconfig/gather_virtual_machine_instances_test.go
+++ b/pkg/gatherers/clusterconfig/gather_virtual_machine_instances_test.go
@@ -1,0 +1,82 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openshift/insights-operator/pkg/record"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_gatherVirtualMachineInstances(t *testing.T) {
+	var dataYAML = `
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  name: testmachine
+  namespace: openshift-cnv
+spec:
+  volumes:
+  - cloudInitNoCloud:
+      userData: |-
+        #cloud-config
+        user: cloud-user
+        password: lymp-fda4-m1cv
+        chpasswd: { expire: False }
+    name: cloudinitdisk
+`
+
+	decoder := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	testDataUnstructured := &unstructured.Unstructured{}
+
+	_, _, err := decoder.Decode([]byte(dataYAML), nil, testDataUnstructured)
+	assert.NoErrorf(t, err, "unable to decode virtualmachineinstances")
+
+	tests := []struct {
+		name             string
+		gvrList          map[schema.GroupVersionResource]string
+		dataUnstructured *unstructured.Unstructured
+		want             []record.Record
+		wantErrs         []error
+	}{
+		{
+			name:             "Successfully collects VMI",
+			gvrList:          map[schema.GroupVersionResource]string{virtualMachineInstancesResource: "VirtualMachineInstanceList"},
+			dataUnstructured: testDataUnstructured,
+			want: []record.Record{
+				{
+					Name: "config/virtualmachineinstances/openshift-cnv/testmachine",
+					Item: record.ResourceMarshaller{Resource: anonymizeVirtualMachineInstances(testDataUnstructured)},
+				},
+			},
+			wantErrs: nil,
+		},
+	}
+	for _, test := range tests {
+		tt := test
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), tt.gvrList)
+			_, err := dynamicClient.Resource(virtualMachineInstancesResource).
+				Namespace("openshift-cnv").
+				Create(ctx, tt.dataUnstructured, metav1.CreateOptions{})
+			assert.NoErrorf(t, err, "unable to create fake virtualmachineinstances")
+
+			got, gotErrs := gatherVirtualMachineInstances(ctx, dynamicClient)
+			assert.Equalf(t, tt.want, got, "gatherVirtualMachineInstances(%v, %v)", ctx, dynamicClient)
+			assert.Equalf(t, tt.wantErrs, gotErrs, "gatherVirtualMachineInstances(%v, %v)", ctx, dynamicClient)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR backports the #742 (VMI) data enhancement to 4.13.z

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `config/virtualmachineinstances/default/fedora-r2nf0eocvxbkmqjy.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md` (updated)

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_virtual_machine_instances_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. The `cloudInitNoCloud` under `spec.volumes` was anonymized.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-11902
