### PR TITLE
[release-4.11] OCPBUGS-7872: Collect info about monitoring pods pv

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,8 +77,6 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
     - revive
     - goprintffuncname
     - gosec
@@ -108,6 +106,8 @@ linters:
   # - godot
   # - godox
   # - goerr113
+  # - gofmt // break comments documentation guidelines
+  # - goimports // break comments documentation guidelines
   # - interfacer
   # - maligned
   # - nestif

--- a/.openshiftci/install-golangci-lint.sh
+++ b/.openshiftci/install-golangci-lint.sh
@@ -10,5 +10,5 @@ export OUTPUT=bin/golangci-lint
 
 if [ ! -f "$OUTPUT" ]
 then
-    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.50.1
 fi

--- a/docs/insights-archive-sample/config/persistentvolumes/monitoring-persistent-volume.json
+++ b/docs/insights-archive-sample/config/persistentvolumes/monitoring-persistent-volume.json
@@ -1,0 +1,70 @@
+{
+    "metadata": {
+        "name": "pvc-99ffaeb3-8ff8-4137-a1fc-0bf72e7209a5",
+        "uid": "17122aab-411b-4a71-ae35-c13caac23492",
+        "resourceVersion": "20098",
+        "creationTimestamp": "2023-02-20T14:44:30Z",
+        "labels": {
+            "topology.kubernetes.io/region": "us-west-2",
+            "topology.kubernetes.io/zone": "us-west-2c"
+        },
+        "annotations": {
+            "kubernetes.io/createdby": "aws-ebs-dynamic-provisioner",
+            "pv.kubernetes.io/bound-by-controller": "yes",
+            "pv.kubernetes.io/provisioned-by": "kubernetes.io/aws-ebs"
+        },
+        "finalizers": [
+            "kubernetes.io/pv-protection"
+        ]
+    },
+    "spec": {
+        "capacity": {
+            "storage": "20Gi"
+        },
+        "awsElasticBlockStore": {
+            "volumeID": "aws://us-west-2c/vol-07ecf570b7adfedda",
+            "fsType": "ext4"
+        },
+        "accessModes": [
+            "ReadWriteOnce"
+        ],
+        "claimRef": {
+            "kind": "PersistentVolumeClaim",
+            "namespace": "openshift-monitoring",
+            "name": "prometheus-data-prometheus-k8s-1",
+            "uid": "99ffaeb3-8ff8-4137-a1fc-0bf72e7209a5",
+            "apiVersion": "v1",
+            "resourceVersion": "19914"
+        },
+        "persistentVolumeReclaimPolicy": "Delete",
+        "storageClassName": "gp2",
+        "volumeMode": "Filesystem",
+        "nodeAffinity": {
+            "required": {
+                "nodeSelectorTerms": [
+                    {
+                        "matchExpressions": [
+                            {
+                                "key": "topology.kubernetes.io/region",
+                                "operator": "In",
+                                "values": [
+                                    "us-west-2"
+                                ]
+                            },
+                            {
+                                "key": "topology.kubernetes.io/zone",
+                                "operator": "In",
+                                "values": [
+                                    "us-west-2c"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "status": {
+        "phase": "Bound"
+    }
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -52,6 +52,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"machine_sets":                      (*Gatherer).GatherMachineSet,
 	"machine_configs":                   (*Gatherer).GatherMachineConfigs,
 	"machine_healthchecks":              (*Gatherer).GatherMachineHealthCheck,
+	"monitoring_persistent_volumes":     (*Gatherer).GatherMonitoringPVs,
 	"install_plans":                     (*Gatherer).GatherInstallPlans,
 	"service_accounts":                  (*Gatherer).GatherServiceAccounts,
 	"machine_config_pools":              (*Gatherer).GatherMachineConfigPool,

--- a/pkg/gatherers/clusterconfig/gather_monitoring_pvs.go
+++ b/pkg/gatherers/clusterconfig/gather_monitoring_pvs.go
@@ -1,0 +1,88 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	coreV1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// GatherMonitoringPVs Collects Persistent Volumes from openshift-monitoring namespace
+// which matches with ConfigMap configuration yaml
+//
+// ### API Reference
+// - https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/configmap.go
+// - https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/persistentvolume.go
+//
+// ### Sample data
+// - docs/insights-archive-sample/config/persistentvolumes/monitoring-persistent-volume.json
+//
+// ### Location in archive
+// - `config/persistentvolumes/{persistent_volume_name}.json`
+//
+// ### Config ID
+// `clusterconfig/monitoring_persistent_volumes`
+//
+// ### Released version
+// - 4.14
+//
+// ### Backported versions
+// - 4.13
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherMonitoringPVs(ctx context.Context) ([]record.Record, []error) {
+	kubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	mg := MonitoringPVGatherer{client: kubeClient.CoreV1()}
+
+	return mg.gather(ctx)
+}
+
+type MonitoringPVGatherer struct {
+	client coreV1.CoreV1Interface
+}
+
+// gather returns the persistent volumes found as records for its gathering
+// and a collection of errors
+func (mg MonitoringPVGatherer) gather(ctx context.Context) ([]record.Record, []error) {
+	const Namespace = "openshift-monitoring"
+	const PrometheusDefault = "prometheus-k8s"
+
+	pvcList, err := mg.client.PersistentVolumeClaims(Namespace).List(ctx, metaV1.ListOptions{})
+	if err != nil {
+		return []record.Record{}, []error{err}
+	}
+
+	var records []record.Record
+	var errors []error
+
+	pvInterface := mg.client.PersistentVolumes()
+	for i := range pvcList.Items {
+		pvcName := pvcList.Items[i].Name
+
+		if strings.Contains(pvcName, PrometheusDefault) {
+			pvName := pvcList.Items[i].Spec.VolumeName
+
+			pv, err := pvInterface.Get(ctx, pvName, metaV1.GetOptions{})
+			if err != nil {
+				errors = append(errors, err)
+				continue
+			}
+
+			records = append(records, record.Record{
+				Name: fmt.Sprintf("config/persistentvolumes/%s", pv.Name),
+				Item: record.ResourceMarshaller{Resource: pv},
+			})
+		}
+	}
+
+	return records, errors
+}

--- a/pkg/gatherers/clusterconfig/gather_monitoring_pvs_test.go
+++ b/pkg/gatherers/clusterconfig/gather_monitoring_pvs_test.go
@@ -1,0 +1,99 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_GatherMonitoring_gather(t *testing.T) {
+	testCases := []struct {
+		name               string
+		pvc                *corev1.PersistentVolumeClaim
+		pv                 *corev1.PersistentVolume
+		assertErrorsNumber int
+		assertRecordNumber int
+		assertRecord       bool
+		assertError        bool
+	}{
+		{
+			name: "Existent Persistent Volume within the namespace is gathered",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "prometheus-k8s-0", Namespace: "openshift-monitoring"},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "test"},
+			},
+			pv: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status:     corev1.PersistentVolumeStatus{Phase: "Available"},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{},
+				},
+			},
+			assertErrorsNumber: 0,
+			assertRecordNumber: 1,
+			assertRecord:       true,
+		},
+		{
+			name: "Existent Persistent Volume with unmatching prefix is not gathered",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "mockFail", Namespace: "openshift-monitoring"},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "test"},
+			},
+			pv: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Status:     corev1.PersistentVolumeStatus{Phase: "Available"},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{},
+				},
+			},
+			assertErrorsNumber: 0,
+			assertRecordNumber: 0,
+		},
+		{
+			name: "Non-existent Persistent Volume within the namespace throws an error",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "prometheus-k8s-0", Namespace: "openshift-monitoring"},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "test"},
+			},
+			pv:                 &corev1.PersistentVolume{},
+			assertErrorsNumber: 1,
+			assertRecordNumber: 0,
+			assertError:        true,
+		},
+		{
+			name:               "Non-existent Persistent Volume Claim does not throw any error",
+			pvc:                &corev1.PersistentVolumeClaim{},
+			pv:                 &corev1.PersistentVolume{},
+			assertErrorsNumber: 0,
+			assertRecordNumber: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Given
+			coreclient := kubefake.NewSimpleClientset([]runtime.Object{testCase.pvc, testCase.pv}...)
+			gatherer := MonitoringPVGatherer{client: coreclient.CoreV1()}
+
+			// When
+			records, errors := gatherer.gather(context.Background())
+
+			// Assert
+			assert.Len(t, records, testCase.assertRecordNumber)
+			if testCase.assertRecord {
+				assert.Equal(t, "config/persistentvolumes/test", records[0].Name)
+			}
+
+			assert.Len(t, errors, testCase.assertErrorsNumber)
+			if testCase.assertError {
+				assert.Error(t, errors[0])
+				assert.Contains(t, errors[0].Error(), "not found")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements Persistent Volumes gathering from openshift-monitoring namespace. It's a backport from [4.14](https://github.com/openshift/insights-operator/pull/741).

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/persistentvolumes/monitoring-persistent-volume.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md#monitoringpvs`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `/pkg/gatherers/clusterconfig/gather_monitoring_pvs_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

Yes

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-10221
https://issues.redhat.com/browse/OCPBUGS-7872