### PR TITLE
OCPBUGS-13915: disable all the Insights alerts when corresponding config option is set

### DIFF
--- a/manifests/08-prometheus_rule.yaml
+++ b/manifests/08-prometheus_rule.yaml
@@ -17,7 +17,7 @@ spec:
         description: 'Insights operator is disabled. In order to enable Insights and benefit from recommendations specific to your cluster, please follow steps listed in the documentation: https://docs.openshift.com/container-platform/latest/support/remote_health_monitoring/enabling-remote-health-reporting.html'
         summary: Insights operator is disabled.
       expr: |
-       max without (job, pod, service, instance) (cluster_operator_conditions{name="insights", condition="Disabled"} == 1)
+       max without (job, pod, service, instance) (cluster_operator_conditions{name="insights", condition="Disabled"} == 1) + scalar(insights_alerts_disabled) == 1
       for: 5m
       labels:
         severity: info
@@ -27,7 +27,7 @@ spec:
         description: 'Simple content access (SCA) is not enabled. Once enabled, Insights Operator can automatically import the SCA certificates from Red Hat OpenShift Cluster Manager making it easier to use the content provided by your Red Hat subscriptions when creating container images. See https://docs.openshift.com/container-platform/latest/cicd/builds/running-entitled-builds.html for more information.'
         summary: Simple content access certificates are not available.
       expr: |
-       max without (job, pod, service, instance) (max_over_time(cluster_operator_conditions{name="insights", condition="SCAAvailable", reason="NotFound"}[5m]) == 0)
+       max without (job, pod, service, instance) (max_over_time(cluster_operator_conditions{name="insights", condition="SCAAvailable", reason="NotFound"}[5m]) == 0) + scalar(insights_alerts_disabled) == 1
       for: 5m
       labels:
         severity: info


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is adding a new metric called `insights_alerts_disabled`, which is a helper metric to tell whether the corresponding config option is set. If the config option `disableInsightsAlerts` is set then this reports 1 and the corresponding alerts will not fire. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

no new test

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
