### PR TITLE
Implement DataGather status conditions

### DIFF
--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -106,19 +106,16 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	return gather.RecordArchiveMetadata(mapToArray(allFunctionReports), rec, anonymizer)
 }
 
-// GatherAndUpload runs a single gather and stores the generated archive, uploads it
-// and waits for the corresponding Insights analysis report.
-// 1. Creates the necessary configs/clients
-// 2. Creates the configobserver
-// 3. Initiates the recorder
-// 4. Executes a Gather
-// 5. Flushes the results
-// 6. Get the latest archive
-// 7. Uploads the archive
-// 8. Waits for the corresponding Insights analysis download
+// GatherAndUpload runs a single gather and stores the generated archive, uploads it.
+// 1. Prepare the necessary kube configs
+// 2. Get the corresponding "datagathers.insights.openshift.io" resource
+// 3. Create all the gatherers
+// 4. Run data gathering
+// 5. Recodrd the data into the Insights archive
+// 6. Get the latest archive and upload it
+// 7. Updates the status of the corresponding "datagathers.insights.openshift.io" resource continuously
 func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) error { // nolint: funlen, gocyclo
-	klog.Infof("Starting insights-operator %s", version.Get().String())
-	// these are operator clients
+	klog.Info("Starting data gathering")
 	kubeClient, err := kubernetes.NewForConfig(protoKubeConfig)
 	if err != nil {
 		return err

--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -142,11 +142,8 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 		klog.Error("failed to get coresponding DataGather custom resource: %v", err)
 		return err
 	}
-	updatedCR := dataGatherCR.DeepCopy()
-	updatedCR.Status.State = insightsv1alpha1.Running
-	updatedCR.Status.StartTime = metav1.Now()
 
-	dataGatherCR, err = insightClient.DataGathers().UpdateStatus(ctx, updatedCR, metav1.UpdateOptions{})
+	dataGatherCR, err = updateDataGatherStatus(ctx, *insightClient, dataGatherCR.DeepCopy(), insightsv1alpha1.Pending, nil)
 	if err != nil {
 		klog.Error("failed to update coresponding DataGather custom resource: %v", err)
 		return err
@@ -185,6 +182,11 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 	)
 	uploader := insightsuploader.New(nil, insightsClient, configObserver, nil, nil, 0)
 
+	dataGatherCR, err = updateDataGatherStatus(ctx, *insightClient, dataGatherCR, insightsv1alpha1.Running, nil)
+	if err != nil {
+		klog.Error("failed to update coresponding DataGather custom resource: %v", err)
+		return err
+	}
 	allFunctionReports := make(map[string]gather.GathererFunctionReport)
 	for _, gatherer := range gatherers {
 		functionReports, err := gather.CollectAndRecordGatherer(ctx, gatherer, rec, dataGatherCR.Spec.Gatherers) // nolint: govet
@@ -196,39 +198,34 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 			allFunctionReports[functionReports[i].FuncName] = functionReports[i]
 		}
 	}
-	err = gather.RecordArchiveMetadata(mapToArray(allFunctionReports), rec, anonymizer)
+	conditions := []metav1.Condition{}
+
+	lastArchive, err := record(mapToArray(allFunctionReports), rec, recdriver, anonymizer)
 	if err != nil {
-		klog.Error(err)
+		conditions = append(conditions, status.DataRecordedCondition(metav1.ConditionFalse, "RecordingFailed",
+			fmt.Sprintf("Failed to record data: %v", err)))
+		_, recErr := updateDataGatherStatus(ctx, *insightClient, dataGatherCR, insightsv1alpha1.Failed, conditions)
+		if recErr != nil {
+			klog.Error("data recording failed and the update of DataGaher resource status failed as well: %v", recErr)
+		}
 		return err
 	}
-	err = rec.Flush()
-	if err != nil {
-		klog.Error(err)
-		return err
-	}
-	lastArchive, err := recdriver.LastArchive()
-	if err != nil {
-		klog.Error(err)
-		return err
-	}
+
+	conditions = append(conditions, status.DataRecordedCondition(metav1.ConditionTrue, "AsExpected", ""))
 	insightsRequestID, err := uploader.Upload(ctx, lastArchive)
 	if err != nil {
 		klog.Error(err)
+		conditions = append(conditions, status.DataUploadedCondition(metav1.ConditionFalse, "UploadFailed",
+			fmt.Sprintf("Failed to upload data: %v", err)))
+		_, updateErr := updateDataGatherStatus(ctx, *insightClient, dataGatherCR, insightsv1alpha1.Failed, conditions)
+		if updateErr != nil {
+			klog.Error("data upload failed and the update of DataGaher resource status failed as well: %v", updateErr)
+		}
 		return err
 	}
 	klog.Infof("Insights archive successfully uploaded with InsightsRequestID: %s", insightsRequestID)
 
-	dataGatherCR.Status.FinishTime = metav1.Now()
-	dataGatherCR.Status.State = insightsv1alpha1.Completed
 	dataGatherCR.Status.InsightsRequestID = insightsRequestID
-	dataGatherCR.Status.Conditions = []metav1.Condition{
-		{
-			Type:               "DataUploaded",
-			Status:             metav1.ConditionTrue,
-			Reason:             "AsExpected",
-			LastTransitionTime: metav1.Now(),
-		},
-	}
 	for k := range allFunctionReports {
 		fr := allFunctionReports[k]
 		// duration = 0 means the gatherer didn't run
@@ -239,7 +236,9 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 		gs := status.CreateDataGatherGathererStatus(&fr)
 		dataGatherCR.Status.Gatherers = append(dataGatherCR.Status.Gatherers, gs)
 	}
-	_, err = insightClient.DataGathers().UpdateStatus(ctx, dataGatherCR, metav1.UpdateOptions{})
+	conditions = append(conditions, status.DataUploadedCondition(metav1.ConditionTrue, "AsExpected", ""))
+
+	_, err = updateDataGatherStatus(ctx, *insightClient, dataGatherCR, insightsv1alpha1.Completed, conditions)
 	if err != nil {
 		klog.Error(err)
 		return err
@@ -254,4 +253,42 @@ func mapToArray(m map[string]gather.GathererFunctionReport) []gather.GathererFun
 		a = append(a, v)
 	}
 	return a
+}
+
+// record is a helper function recording the archive metadata as well as data.
+// Returns last known Insights archive and an error when recording failed.
+func record(functionReports []gather.GathererFunctionReport,
+	rec *recorder.Recorder, recdriver *diskrecorder.DiskRecorder, anonymizer *anonymization.Anonymizer) (*insightsclient.Source, error) {
+	err := gather.RecordArchiveMetadata(functionReports, rec, anonymizer)
+	if err != nil {
+		return nil, err
+	}
+	err = rec.Flush()
+	if err != nil {
+		return nil, err
+	}
+	return recdriver.LastArchive()
+}
+
+// updateDataGatherStatus updates status' time attributes, state and conditions
+// of the provided DataGather resource
+func updateDataGatherStatus(ctx context.Context,
+	insightsClient insightsv1alpha1cli.InsightsV1alpha1Client,
+	dataGatherCR *insightsv1alpha1.DataGather,
+	newState insightsv1alpha1.DataGatherState, conditions []metav1.Condition) (*insightsv1alpha1.DataGather, error) {
+	switch newState {
+	case insightsv1alpha1.Completed:
+		dataGatherCR.Status.FinishTime = metav1.Now()
+	case insightsv1alpha1.Failed:
+		dataGatherCR.Status.FinishTime = metav1.Now()
+	case insightsv1alpha1.Running:
+		dataGatherCR.Status.StartTime = metav1.Now()
+	case insightsv1alpha1.Pending:
+		// no op
+	}
+	dataGatherCR.Status.State = newState
+	if conditions != nil {
+		dataGatherCR.Status.Conditions = append(dataGatherCR.Status.Conditions, conditions...)
+	}
+	return insightsClient.DataGathers().UpdateStatus(ctx, dataGatherCR, metav1.UpdateOptions{})
 }

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -165,6 +165,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 		reportRetriever := insightsreport.NewWithTechPreview(insightsClient, secretConfigObserver, operatorClient.InsightsOperators())
 		periodicGather = periodic.NewWithTechPreview(reportRetriever, secretConfigObserver,
 			apiConfigObserver, gatherers, kubeClient, insightClient, operatorClient.InsightsOperators())
+		statusReporter.AddSources(periodicGather.Sources()...)
 		go periodicGather.PeriodicPrune(ctx)
 	}
 
@@ -177,7 +178,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 		initialDelay = wait.Jitter(baseInitialDelay, 0.5)
 		klog.Infof("Unable to check insights-operator pod status. Setting initial delay to %s", initialDelay)
 	}
-	go periodicGather.Run(ctx.Done(), initialDelay, tpEnabled)
+	go periodicGather.Run(ctx.Done(), initialDelay)
 
 	if !tpEnabled {
 		// upload results to the provided client - if no client is configured reporting

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -52,6 +52,7 @@ type Controller struct {
 	image               string
 	jobController       *JobController
 	pruneInterval       time.Duration
+	techPreview         bool
 }
 
 func NewWithTechPreview(
@@ -64,6 +65,8 @@ func NewWithTechPreview(
 	insightsOperatorCLI operatorv1client.InsightsOperatorInterface,
 ) *Controller {
 	statuses := make(map[string]controllerstatus.StatusController)
+
+	statuses["tech-preview-test"] = controllerstatus.New("tech-preview-test")
 	jobController := NewJobController(kubeClient)
 	return &Controller{
 		reportRetriever:     reportRetriever,
@@ -76,6 +79,7 @@ func NewWithTechPreview(
 		jobController:       jobController,
 		insightsOperatorCLI: insightsOperatorCLI,
 		pruneInterval:       1 * time.Hour,
+		techPreview:         true,
 	}
 }
 
@@ -120,7 +124,7 @@ func (c *Controller) Sources() []controllerstatus.StatusController {
 	return sources
 }
 
-func (c *Controller) Run(stopCh <-chan struct{}, initialDelay time.Duration, techPreview bool) {
+func (c *Controller) Run(stopCh <-chan struct{}, initialDelay time.Duration) {
 	defer utilruntime.HandleCrash()
 	defer klog.Info("Shutting down")
 
@@ -130,21 +134,21 @@ func (c *Controller) Run(stopCh <-chan struct{}, initialDelay time.Duration, tec
 		case <-stopCh:
 			return
 		case <-time.After(initialDelay):
-			if techPreview {
+			if c.techPreview {
 				c.GatherJob()
 			} else {
 				c.Gather()
 			}
 		}
 	} else {
-		if techPreview {
+		if c.techPreview {
 			c.GatherJob()
 		} else {
 			c.Gather()
 		}
 	}
 
-	go wait.Until(func() { c.periodicTrigger(stopCh, techPreview) }, time.Second, stopCh)
+	go wait.Until(func() { c.periodicTrigger(stopCh) }, time.Second, stopCh)
 
 	<-stopCh
 }
@@ -217,7 +221,7 @@ func (c *Controller) Gather() {
 
 // Periodically starts the gathering.
 // If there is an initialDelay set then it waits that much for the first gather to happen.
-func (c *Controller) periodicTrigger(stopCh <-chan struct{}, techPreview bool) {
+func (c *Controller) periodicTrigger(stopCh <-chan struct{}) {
 	configCh, closeFn := c.secretConfigurator.ConfigChanged()
 	defer closeFn()
 
@@ -237,7 +241,7 @@ func (c *Controller) periodicTrigger(stopCh <-chan struct{}, techPreview bool) {
 			klog.Infof("Gathering cluster info every %s", interval)
 
 		case <-time.After(interval):
-			if techPreview {
+			if c.techPreview {
 				c.GatherJob()
 			} else {
 				c.Gather()
@@ -288,8 +292,15 @@ func (c *Controller) GatherJob() {
 		klog.Error(err)
 	}
 	klog.Infof("Job completed %s", gj.Name)
+
+	dataGatheredOK := c.wasDataGatherSuccessfull(dataGatherCR)
+	if !dataGatheredOK {
+		klog.Error("Last data gathering %v was not successful", dataGatherCR.Name)
+		return
+	}
+
 	c.reportRetriever.RetrieveReport()
-	_, err = c.copyDataGatherStatusToOperatorStatus(ctx, dataGatherCR.Name)
+	_, err = c.copyDataGatherStatusToOperatorStatus(ctx, dataGatherCR)
 	if err != nil {
 		klog.Errorf("Failed to copy the last DataGather status to \"cluster\" operator status: %v", err)
 		return
@@ -298,18 +309,14 @@ func (c *Controller) GatherJob() {
 }
 
 // copyDataGatherStatusToOperatorStatus gets the "cluster" "insightsoperator.operator.openshift.io" resource
-// and updates its status with values from the provided "dgName" "datagather.insights.openshift.io" resource.
-func (c *Controller) copyDataGatherStatusToOperatorStatus(ctx context.Context, dgName string) (*v1.InsightsOperator, error) {
+// and updates its status with values from the provided "datagather.insights.openshift.io" resource.
+func (c *Controller) copyDataGatherStatusToOperatorStatus(ctx context.Context,
+	dataGather *insightsv1alpha1.DataGather) (*v1.InsightsOperator, error) {
 	operator, err := c.insightsOperatorCLI.Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 	statusToUpdate := operator.Status.DeepCopy()
-
-	dataGather, err := c.dataGatherClient.DataGathers().Get(ctx, dgName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
 	statusToUpdate.GatherStatus = status.DataGatherStatusToOperatorGatherStatus(&dataGather.Status)
 	operator.Status = *statusToUpdate
 
@@ -491,6 +498,27 @@ func (c *Controller) createDataGatherAttributeValues() ([]string, insightsv1alph
 		}
 	}
 	return disabledGatherers, dp
+}
+
+// wasDataGatherSuccessfull reads status conditions of the provided "dataGather" "datagather.insights.openshift.io"
+// custom resource and checks whether the data was successfully uploaded or not and updates status accordingly
+func (c *Controller) wasDataGatherSuccessfull(dataGather *insightsv1alpha1.DataGather) bool {
+	for _, con := range dataGather.Status.Conditions {
+		if con.Type == status.DataUploaded && con.Status == metav1.ConditionFalse {
+			c.statuses["tech-preview-test"].UpdateStatus(controllerstatus.Summary{
+				Operation: controllerstatus.Uploading,
+				Healthy:   false,
+				Reason:    con.Reason,
+				Message:   con.Message,
+			})
+			return false
+		}
+	}
+	c.statuses["tech-preview-test"].UpdateStatus(controllerstatus.Summary{
+		Operation: controllerstatus.Uploading,
+		Healthy:   true,
+	})
+	return true
 }
 
 func mapToArray(m map[string]gather.GathererFunctionReport) []gather.GathererFunctionReport {

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -263,8 +263,8 @@ func (c *Controller) GatherJob() {
 		c.image = image
 	}
 
-	// create a new datagather.insights.openshift.io custom resource
 	disabledGatherers, dp := c.createDataGatherAttributeValues()
+	// create a new datagather.insights.openshift.io custom resource
 	dataGatherCR, err := c.createNewDataGatherCR(ctx, disabledGatherers, dp)
 	if err != nil {
 		klog.Errorf("Failed to create a new DataGather resource: %v", err)

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -79,7 +79,7 @@ func Test_Controller_Run(t *testing.T) {
 			}, 1*time.Hour)
 			assert.NoError(t, err)
 			stopCh := make(chan struct{})
-			go c.Run(stopCh, tt.initialDelay, false)
+			go c.Run(stopCh, tt.initialDelay)
 			if _, ok := <-time.After(tt.waitTime); ok {
 				stopCh <- struct{}{}
 			}
@@ -116,7 +116,7 @@ func Test_Controller_periodicTrigger(t *testing.T) {
 			}, tt.interval)
 			assert.NoError(t, err)
 			stopCh := make(chan struct{})
-			go c.periodicTrigger(stopCh, false)
+			go c.periodicTrigger(stopCh)
 			if _, ok := <-time.After(tt.waitTime); ok {
 				stopCh <- struct{}{}
 			}
@@ -298,13 +298,13 @@ func TestCreateNewDataGatherCR(t *testing.T) {
 func TestCopyDataGatherStatusToOperatorStatus(t *testing.T) {
 	tests := []struct {
 		name                   string
-		testedDataGather       v1alpha1.DataGather
+		testedDataGather       *v1alpha1.DataGather
 		testedInsightsOperator operatorv1.InsightsOperator
 		expected               *operatorv1.InsightsOperator
 	}{
 		{
 			name: "Basic copy status test",
-			testedDataGather: v1alpha1.DataGather{
+			testedDataGather: &v1alpha1.DataGather{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Status: v1alpha1.DataGatherStatus{
 					State:      v1alpha1.Failed,
@@ -424,7 +424,7 @@ func TestCopyDataGatherStatusToOperatorStatus(t *testing.T) {
 		},
 		{
 			name: "InsightsReport attribute is not updated when copying",
-			testedDataGather: v1alpha1.DataGather{
+			testedDataGather: &v1alpha1.DataGather{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Status: v1alpha1.DataGatherStatus{
 					State:      v1alpha1.Failed,
@@ -532,11 +532,11 @@ func TestCopyDataGatherStatusToOperatorStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dataGatherFakeCS := insightsFakeCli.NewSimpleClientset(&tt.testedDataGather)
+			dataGatherFakeCS := insightsFakeCli.NewSimpleClientset(tt.testedDataGather)
 			operatorFakeCS := fakeOperatorCli.NewSimpleClientset(&tt.testedInsightsOperator)
 			mockController := NewWithTechPreview(nil, nil, nil, nil, nil,
 				dataGatherFakeCS.InsightsV1alpha1(), operatorFakeCS.OperatorV1().InsightsOperators())
-			updatedOperator, err := mockController.copyDataGatherStatusToOperatorStatus(context.Background(), tt.testedDataGather.Name)
+			updatedOperator, err := mockController.copyDataGatherStatusToOperatorStatus(context.Background(), tt.testedDataGather)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, updatedOperator)
 		})

--- a/pkg/controller/status/datagather_conditions.go
+++ b/pkg/controller/status/datagather_conditions.go
@@ -1,0 +1,28 @@
+package status
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+const (
+	DataUploaded = "DataUploaded"
+	DataRecorded = "DataRecorded"
+)
+
+func DataUploadedCondition(status metav1.ConditionStatus, reason, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:               DataUploaded,
+		LastTransitionTime: metav1.Now(),
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+func DataRecordedCondition(status metav1.ConditionStatus, reason, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:               DataRecorded,
+		LastTransitionTime: metav1.Now(),
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+	}
+}

--- a/pkg/controller/status/datagather_conditions.go
+++ b/pkg/controller/status/datagather_conditions.go
@@ -7,6 +7,7 @@ const (
 	DataRecorded = "DataRecorded"
 )
 
+// DataUploadedCondition returns new "DataUploaded" status condition with provided status, reason and message
 func DataUploadedCondition(status metav1.ConditionStatus, reason, message string) metav1.Condition {
 	return metav1.Condition{
 		Type:               DataUploaded,
@@ -17,6 +18,7 @@ func DataUploadedCondition(status metav1.ConditionStatus, reason, message string
 	}
 }
 
+// DataRecordedCondition returns new "DataRecorded" status condition with provided status, reason and message
 func DataRecordedCondition(status metav1.ConditionStatus, reason, message string) metav1.Condition {
 	return metav1.Condition{
 		Type:               DataRecorded,

--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -66,6 +66,13 @@ func (s *Simple) UpdateStatus(summary Summary) { //nolint: gocritic
 		s.summary.LastTransitionTime = time.Now()
 	}
 
+	// this is an ugly hack for tech preview with gathering jobs. The reason is that we don't want to count
+	// the attempts in this case, because the attempts (e.g upload) happens in the job
+	if summary.Count > 0 {
+		s.summary = summary
+		return
+	}
+
 	if s.summary.Healthy != summary.Healthy {
 		klog.V(2).Infof("name=%s healthy=%t reason=%s message=%s", s.name, summary.Healthy, summary.Reason, summary.Message)
 		s.summary = summary


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This implements the status conditions for the new CRD/CR `datagather.insights.openshift.io`. The CRs will have two basic conditions:

- `DataRecorded` - tells whether the Insights data was recorded correctly or not
- `DataUploaded` - tells whether the Insights data was uploaded or not

The status of the last `datagather` is propagated/copied into the `insightsoperator.operator.openshift.io` cluster CR.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

this wil required official OCP documentation update

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/periodic/periodic_test.go` - updated and extended

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
