### PR TITLE
OCPBUGS-14771: run an extra config informer in the tech preview

### DIFF
--- a/pkg/anonymization/anonymizer.go
+++ b/pkg/anonymization/anonymizer.go
@@ -88,7 +88,7 @@ type Anonymizer struct {
 	ipNetworkRegex     *regexp.Regexp
 	secretsClient      corev1client.SecretInterface
 	secretConfigurator configobserver.Configurator
-	apiConfigurator    configobserver.APIConfigObserver
+	apiConfigurator    configobserver.InsightsDataGatherObserver
 	configClient       configv1client.ConfigV1Interface
 	networkClient      networkv1client.NetworkV1Interface
 	gatherKubeClient   kubernetes.Interface
@@ -104,7 +104,7 @@ func NewAnonymizer(clusterBaseDomain string,
 	networks []string,
 	secretsClient corev1client.SecretInterface,
 	secretConfigurator configobserver.Configurator,
-	apiConfigurator configobserver.APIConfigObserver) (*Anonymizer, error) {
+	apiConfigurator configobserver.InsightsDataGatherObserver) (*Anonymizer, error) {
 	cidrs, err := k8snet.ParseCIDRs(networks)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func NewAnonymizerFromConfigClient(
 	configClient configv1client.ConfigV1Interface,
 	networkClient networkv1client.NetworkV1Interface,
 	secretConfigurator configobserver.Configurator,
-	apiConfigurator configobserver.APIConfigObserver,
+	apiConfigurator configobserver.InsightsDataGatherObserver,
 ) (*Anonymizer, error) {
 	baseDomain, err := utils.GetClusterBaseDomain(ctx, configClient)
 	if err != nil {
@@ -322,7 +322,7 @@ func NewAnonymizerFromConfig(
 	gatherProtoKubeConfig *rest.Config,
 	protoKubeConfig *rest.Config,
 	secretConfigurator configobserver.Configurator,
-	apiConfigurator configobserver.APIConfigObserver,
+	apiConfigurator configobserver.InsightsDataGatherObserver,
 ) (*Anonymizer, error) {
 	kubeClient, err := kubernetes.NewForConfig(protoKubeConfig)
 	if err != nil {

--- a/pkg/config/configobserver/insighgtsdatagather_observer.go
+++ b/pkg/config/configobserver/insighgtsdatagather_observer.go
@@ -15,32 +15,30 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type APIConfigObserver interface {
+type InsightsDataGatherObserver interface {
 	factory.Controller
 	GatherConfig() *v1alpha1.GatherConfig
 	GatherDataPolicy() *v1alpha1.DataPolicy
 	GatherDisabled() bool
 }
 
-type APIConfigController struct {
+type insightsDataGatherController struct {
 	factory.Controller
 	lock              sync.Mutex
-	listeners         map[chan *v1alpha1.GatherConfig]struct{}
 	configV1Alpha1Cli *configCliv1alpha1.ConfigV1alpha1Client
 	gatherConfig      *v1alpha1.GatherConfig
 }
 
-func NewAPIConfigObserver(kubeConfig *rest.Config,
+func NewInsightsDataGatherObserver(kubeConfig *rest.Config,
 	eventRecorder events.Recorder,
-	configInformer configinformers.SharedInformerFactory) (APIConfigObserver, error) {
+	configInformer configinformers.SharedInformerFactory) (InsightsDataGatherObserver, error) {
 	inf := configInformer.Config().V1alpha1().InsightsDataGathers().Informer()
 	configV1Alpha1Cli, err := configCliv1alpha1.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	c := &APIConfigController{
+	c := &insightsDataGatherController{
 		configV1Alpha1Cli: configV1Alpha1Cli,
-		listeners:         make(map[chan *v1alpha1.GatherConfig]struct{}),
 	}
 
 	insightDataGatherConf, err := c.configV1Alpha1Cli.InsightsDataGathers().Get(context.Background(), "cluster", metav1.GetOptions{})
@@ -51,42 +49,42 @@ func NewAPIConfigObserver(kubeConfig *rest.Config,
 
 	ctrl := factory.New().WithInformers(inf).
 		WithSync(c.sync).
-		ToController("InsightConfigController", eventRecorder)
+		ToController("InsightsDataGatherObserver", eventRecorder)
 	c.Controller = ctrl
 	return c, nil
 }
 
-func (a *APIConfigController) sync(ctx context.Context, _ factory.SyncContext) error {
-	insightDataGatherConf, err := a.configV1Alpha1Cli.InsightsDataGathers().Get(ctx, "cluster", metav1.GetOptions{})
+func (i *insightsDataGatherController) sync(ctx context.Context, scx factory.SyncContext) error {
+	insightDataGatherConf, err := i.configV1Alpha1Cli.InsightsDataGathers().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
-	a.gatherConfig = &insightDataGatherConf.Spec.GatherConfig
+	i.gatherConfig = &insightDataGatherConf.Spec.GatherConfig
 	return nil
 }
 
 // GatherConfig provides the complete gather config in a thread-safe way.
-func (a *APIConfigController) GatherConfig() *v1alpha1.GatherConfig {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-	return a.gatherConfig
+func (i *insightsDataGatherController) GatherConfig() *v1alpha1.GatherConfig {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return i.gatherConfig
 }
 
 // GatherDisabled tells whether data gathering is disabled or not
-func (a *APIConfigController) GatherDisabled() bool {
-	a.lock.Lock()
-	defer a.lock.Unlock()
+func (i *insightsDataGatherController) GatherDisabled() bool {
+	i.lock.Lock()
+	defer i.lock.Unlock()
 
-	if utils.StringInSlice("all", a.gatherConfig.DisabledGatherers) ||
-		utils.StringInSlice("ALL", a.gatherConfig.DisabledGatherers) {
+	if utils.StringInSlice("all", i.gatherConfig.DisabledGatherers) ||
+		utils.StringInSlice("ALL", i.gatherConfig.DisabledGatherers) {
 		return true
 	}
 	return false
 }
 
 // GatherDataPolicy provides DataPolicy attribute value defined in the API
-func (a *APIConfigController) GatherDataPolicy() *v1alpha1.DataPolicy {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-	return &a.gatherConfig.DataPolicy
+func (i *insightsDataGatherController) GatherDataPolicy() *v1alpha1.DataPolicy {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return &i.gatherConfig.DataPolicy
 }

--- a/pkg/config/configobserver/insighgtsdatagather_observer.go
+++ b/pkg/config/configobserver/insighgtsdatagather_observer.go
@@ -3,6 +3,7 @@ package configobserver
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/openshift/api/config/v1alpha1"
 	configCliv1alpha1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1alpha1"
@@ -49,6 +50,7 @@ func NewInsightsDataGatherObserver(kubeConfig *rest.Config,
 
 	ctrl := factory.New().WithInformers(inf).
 		WithSync(c.sync).
+		ResyncEvery(2*time.Minute).
 		ToController("InsightsDataGatherObserver", eventRecorder)
 	c.Controller = ctrl
 	return c, nil

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -120,13 +120,17 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 			return fmt.Errorf("can't create --path: %v", err)
 		}
 	}
-	var apiConfigObserver configobserver.APIConfigObserver
+	var insightsDataGatherObserver configobserver.InsightsDataGatherObserver
 	if insightsConfigAPIEnabled {
-		apiConfigObserver, err = configobserver.NewAPIConfigObserver(gatherKubeConfig, controller.EventRecorder, configInformers)
+		configInformersForTechPreview := configv1informers.NewSharedInformerFactory(configClient, 10*time.Minute)
+		insightsDataGatherObserver, err = configobserver.NewInsightsDataGatherObserver(gatherKubeConfig,
+			controller.EventRecorder, configInformersForTechPreview)
 		if err != nil {
 			return err
 		}
-		go apiConfigObserver.Run(ctx, 1)
+
+		go insightsDataGatherObserver.Run(ctx, 1)
+		go configInformersForTechPreview.Start(ctx.Done())
 	}
 
 	// secretConfigObserver synthesizes all config into the status reporter controller
@@ -135,11 +139,11 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 
 	// the status controller initializes the cluster operator object and retrieves
 	// the last sync time, if any was set
-	statusReporter := status.NewController(configClient.ConfigV1(), secretConfigObserver, apiConfigObserver, os.Getenv("POD_NAMESPACE"))
+	statusReporter := status.NewController(configClient.ConfigV1(), secretConfigObserver, insightsDataGatherObserver, os.Getenv("POD_NAMESPACE"))
 
 	// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
 	anonymizer, err := anonymization.NewAnonymizerFromConfig(ctx, gatherKubeConfig,
-		gatherProtoKubeConfig, controller.ProtoKubeConfig, secretConfigObserver, apiConfigObserver)
+		gatherProtoKubeConfig, controller.ProtoKubeConfig, secretConfigObserver, insightsDataGatherObserver)
 	if err != nil {
 		// in case of an error anonymizer will be nil and anonymization will be just skipped
 		klog.Errorf(anonymization.UnableToCreateAnonymizerErrorMessage, err)
@@ -170,7 +174,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,
 		secretConfigObserver, insightsClient,
 	)
-	periodicGather := periodic.New(secretConfigObserver, rec, gatherers, anonymizer, operatorClient.InsightsOperators(), apiConfigObserver)
+	periodicGather := periodic.New(secretConfigObserver, rec, gatherers, anonymizer, operatorClient.InsightsOperators(), insightsDataGatherObserver)
 	statusReporter.AddSources(periodicGather.Sources()...)
 
 	// check we can read IO container status and we are not in crash loop
@@ -186,7 +190,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 
 	// upload results to the provided client - if no client is configured reporting
 	// is permanently disabled, but if a client does exist the server may still disable reporting
-	uploader := insightsuploader.New(recdriver, insightsClient, secretConfigObserver, apiConfigObserver, statusReporter, initialDelay)
+	uploader := insightsuploader.New(recdriver, insightsClient, secretConfigObserver, insightsDataGatherObserver, statusReporter, initialDelay)
 	statusReporter.AddSources(uploader)
 
 	// start reporting status now that all controller loops are added as sources

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -40,7 +40,7 @@ const (
 // and flushes the recorder to create archives
 type Controller struct {
 	secretConfigurator  configobserver.Configurator
-	apiConfigurator     configobserver.APIConfigObserver
+	apiConfigurator     configobserver.InsightsDataGatherObserver
 	recorder            recorder.FlushInterface
 	gatherers           []gatherers.Interface
 	statuses            map[string]controllerstatus.StatusController
@@ -56,7 +56,7 @@ func New(
 	listGatherers []gatherers.Interface,
 	anonymizer *anonymization.Anonymizer,
 	insightsOperatorCLI operatorv1client.InsightsOperatorInterface,
-	apiConfigurator configobserver.APIConfigObserver,
+	apiConfigurator configobserver.InsightsDataGatherObserver,
 ) *Controller {
 	statuses := make(map[string]controllerstatus.StatusController)
 

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -56,7 +56,7 @@ type Controller struct {
 
 	statusCh           chan struct{}
 	secretConfigurator configobserver.Configurator
-	apiConfigurator    configobserver.APIConfigObserver
+	apiConfigurator    configobserver.InsightsDataGatherObserver
 
 	sources  map[string]controllerstatus.StatusController
 	reported Reported
@@ -70,7 +70,7 @@ type Controller struct {
 // NewController creates a statusMessage controller, responsible for monitoring the operators statusMessage and updating its cluster statusMessage accordingly.
 func NewController(client configv1client.ConfigV1Interface,
 	secretConfigurator configobserver.Configurator,
-	apiConfigurator configobserver.APIConfigObserver,
+	apiConfigurator configobserver.InsightsDataGatherObserver,
 	namespace string) *Controller {
 	c := &Controller{
 		name:               "insights",

--- a/pkg/insights/insightsuploader/insightsuploader.go
+++ b/pkg/insights/insightsuploader/insightsuploader.go
@@ -36,7 +36,7 @@ type Controller struct {
 	summarizer         Summarizer
 	client             *insightsclient.Client
 	secretConfigurator configobserver.Configurator
-	apiConfigurator    configobserver.APIConfigObserver
+	apiConfigurator    configobserver.InsightsDataGatherObserver
 	reporter           StatusReporter
 	archiveUploaded    chan struct{}
 	initialDelay       time.Duration
@@ -45,7 +45,7 @@ type Controller struct {
 func New(summarizer Summarizer,
 	client *insightsclient.Client,
 	secretconfigurator configobserver.Configurator,
-	apiConfigurator configobserver.APIConfigObserver,
+	apiConfigurator configobserver.InsightsDataGatherObserver,
 	statusReporter StatusReporter,
 	initialDelay time.Duration) *Controller {
 


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
https://github.com/openshift/insights-operator/pull/779 changed the logic in `operator.go` so that the `configinformer` runs every time (and not only in the techpreview). This caused the problem (unable to sync cache -> restart every 10 min) in the techpreview, because it doesn't seem to be possible to add an additional informer, when it's already started. 

This creates (and starts) a new extra config informer only in the techpreview when the feature is enabled. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

-no new data
## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-14771
