### PR TITLE
[release-4.12] OCPBUGS-15459: gather PDBs only from openshift namespaces

### DIFF
--- a/pkg/gatherers/clusterconfig/pod_disruption_budgets.go
+++ b/pkg/gatherers/clusterconfig/pod_disruption_budgets.go
@@ -20,25 +20,13 @@ const (
 // The Kubernetes api https://github.com/kubernetes/client-go/blob/v11.0.0/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go#L80
 // Response see https://docs.okd.io/latest/rest_api/policy_apis/poddisruptionbudget-policy-v1beta1.html
 //
-// ### Sample data
-// - docs/insights-archive-sample/config/pdbs/openshift-machine-config-operator/etcd-quorum-guard.json
-//
-// ### Location in archive
-// - `config/pdbs/{namespace}/{name}.json`
-//
-// ### Config ID
-// `clusterconfig/pdbs`
-//
-// ### Released version
-// - 4.6.0
-//
-// ### Backported versions
-// - 4.4.30+
-// - 4.5.15+
-//
-// ### Changes
-// - The gatherer was changed to gather pdbs only from namespaces with "openshift" prefix
-// and the limit of gathered records to 100 since 4.14.
+// * Location in archive: config/pdbs/
+// * See: docs/insights-archive-sample/config/pdbs
+// * Id in config: clusterconfig/pdbs
+// * Since versions:
+//   - 4.4.30+
+//   - 4.5.34+
+//   - 4.6+
 func (g *Gatherer) GatherPodDisruptionBudgets(ctx context.Context) ([]record.Record, []error) {
 	gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
 	if err != nil {

--- a/pkg/gatherers/clusterconfig/pod_disruption_budgets.go
+++ b/pkg/gatherers/clusterconfig/pod_disruption_budgets.go
@@ -3,6 +3,7 @@ package clusterconfig
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1"
@@ -11,7 +12,7 @@ import (
 )
 
 const (
-	gatherPodDisruptionBudgetLimit = 5000
+	gatherPodDisruptionBudgetLimit = 100
 )
 
 // GatherPodDisruptionBudgets gathers the cluster's PodDisruptionBudgets.
@@ -19,13 +20,25 @@ const (
 // The Kubernetes api https://github.com/kubernetes/client-go/blob/v11.0.0/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go#L80
 // Response see https://docs.okd.io/latest/rest_api/policy_apis/poddisruptionbudget-policy-v1beta1.html
 //
-// * Location in archive: config/pdbs/
-// * See: docs/insights-archive-sample/config/pdbs
-// * Id in config: clusterconfig/pdbs
-// * Since versions:
-//   - 4.4.30+
-//   - 4.5.34+
-//   - 4.6+
+// ### Sample data
+// - docs/insights-archive-sample/config/pdbs/openshift-machine-config-operator/etcd-quorum-guard.json
+//
+// ### Location in archive
+// - `config/pdbs/{namespace}/{name}.json`
+//
+// ### Config ID
+// `clusterconfig/pdbs`
+//
+// ### Released version
+// - 4.6.0
+//
+// ### Backported versions
+// - 4.4.30+
+// - 4.5.15+
+//
+// ### Changes
+// - The gatherer was changed to gather pdbs only from namespaces with "openshift" prefix
+// and the limit of gathered records to 100 since 4.14.
 func (g *Gatherer) GatherPodDisruptionBudgets(ctx context.Context) ([]record.Record, []error) {
 	gatherPolicyClient, err := policyclient.NewForConfig(g.gatherKubeConfig)
 	if err != nil {
@@ -36,20 +49,23 @@ func (g *Gatherer) GatherPodDisruptionBudgets(ctx context.Context) ([]record.Rec
 }
 
 func gatherPodDisruptionBudgets(ctx context.Context, policyClient policyclient.PolicyV1Interface) ([]record.Record, []error) {
-	pdbs, err := policyClient.PodDisruptionBudgets("").List(ctx, metav1.ListOptions{Limit: gatherPodDisruptionBudgetLimit})
+	pdbs, err := policyClient.PodDisruptionBudgets("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, []error{err}
 	}
 	var records []record.Record
 	for i := range pdbs.Items {
-		recordName := fmt.Sprintf("config/pdbs/%s", pdbs.Items[i].GetName())
-		if pdbs.Items[i].GetNamespace() != "" {
-			recordName = fmt.Sprintf("config/pdbs/%s/%s", pdbs.Items[i].GetNamespace(), pdbs.Items[i].GetName())
+		item := &pdbs.Items[i]
+		if strings.HasPrefix(item.GetNamespace(), "openshift-") {
+			recordName := fmt.Sprintf("config/pdbs/%s/%s", item.GetNamespace(), item.GetName())
+			records = append(records, record.Record{
+				Name: recordName,
+				Item: record.ResourceMarshaller{Resource: item},
+			})
+			if len(records) == gatherPodDisruptionBudgetLimit {
+				break
+			}
 		}
-		records = append(records, record.Record{
-			Name: recordName,
-			Item: record.ResourceMarshaller{Resource: &pdbs.Items[i]},
-		})
 	}
 	return records, nil
 }

--- a/pkg/gatherers/clusterconfig/pod_disruption_budgets_test.go
+++ b/pkg/gatherers/clusterconfig/pod_disruption_budgets_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -12,48 +13,98 @@ import (
 )
 
 func Test_PodDisruptionBudgets_Gather(t *testing.T) {
-	coreClient := kubefake.NewSimpleClientset()
+	tests := []struct {
+		name string
+		// namespace -> pdb
+		pdbsToNamespace map[string]string
+		// pdb -> minAvailable
+		minAvailableToPdb map[string]int
+		expCount          int
+	}{
+		{
+			name:              "no PDB",
+			pdbsToNamespace:   nil,
+			minAvailableToPdb: nil,
+			expCount:          0,
+		},
+		{
+			name: "one openshift PDB",
+			pdbsToNamespace: map[string]string{
+				"openshift-test": "testT",
+			},
+			minAvailableToPdb: map[string]int{
+				"testT": 1,
+			},
+			expCount: 1,
+		},
+		{
+			name: "one random PDB",
+			pdbsToNamespace: map[string]string{
+				"random": "testR",
+			},
+			minAvailableToPdb: map[string]int{
+				"testR": 1,
+			},
+			expCount: 0,
+		},
+		{
+			name: "one openshift, one random PDB",
+			pdbsToNamespace: map[string]string{
+				"openshift-test": "testT",
+				"random":         "testR",
+			},
+			minAvailableToPdb: map[string]int{
+				"testT": 1,
+				"testR": 1,
+			},
+			expCount: 1,
+		},
+		{
+			name: "multiple openshift PDBs",
+			pdbsToNamespace: map[string]string{
+				"openshift-test":    "testT",
+				"openshift-default": "testD",
+			},
+			minAvailableToPdb: map[string]int{
+				"testT": 1,
+				"testD": 2,
+			},
+			expCount: 2,
+		},
+	}
 
-	fakeNamespace := "fake-namespace"
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			coreClient := kubefake.NewSimpleClientset()
 
-	// name -> MinAvailabel
-	fakePDBs := map[string]string{
-		"pdb-four":  "4",
-		"pdb-eight": "8",
-		"pdb-ten":   "10",
-	}
-	for name, minAvailable := range fakePDBs {
-		_, err := coreClient.PolicyV1().
-			PodDisruptionBudgets(fakeNamespace).
-			Create(context.Background(), &policyv1.PodDisruptionBudget{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: fakeNamespace,
-					Name:      name,
-				},
-				Spec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: &intstr.IntOrString{StrVal: minAvailable},
-				},
-			}, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("unable to create fake pdbs: %v", err)
-		}
-	}
-	ctx := context.Background()
-	records, errs := gatherPodDisruptionBudgets(ctx, coreClient.PolicyV1())
-	if len(errs) > 0 {
-		t.Errorf("unexpected errors: %#v", errs)
-		return
-	}
-	if len(records) != len(fakePDBs) {
-		t.Fatalf("unexpected number of records gathered: %d (expected %d)", len(records), len(fakePDBs))
-	}
-	pdba, ok := records[0].Item.(record.ResourceMarshaller).Resource.(*policyv1.PodDisruptionBudget)
-	if !ok {
-		t.Fatal("pdb item has invalid type")
-	}
-	name := pdba.ObjectMeta.Name
-	minAvailable := pdba.Spec.MinAvailable.StrVal
-	if pdba.Spec.MinAvailable.StrVal != fakePDBs[name] {
-		t.Fatalf("pdb item has mismatched MinAvailable value, %q != %q", fakePDBs[name], minAvailable)
+			for namespace, name := range test.pdbsToNamespace {
+				_, err := coreClient.PolicyV1().
+					PodDisruptionBudgets(namespace).
+					Create(context.Background(), &policyv1.PodDisruptionBudget{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      name,
+						},
+						Spec: policyv1.PodDisruptionBudgetSpec{
+							MinAvailable: &intstr.IntOrString{IntVal: int32(test.minAvailableToPdb[name])},
+						},
+					}, metav1.CreateOptions{})
+				assert.NoErrorf(t, err, "unable to create fake pdbs: %v", err)
+			}
+			ctx := context.Background()
+			records, errs := gatherPodDisruptionBudgets(ctx, coreClient.PolicyV1())
+			assert.Emptyf(t, errs, "unexpected errors: %#v", errs)
+			assert.Equal(t, test.expCount, len(records))
+			for i := range records {
+				pdba, ok := records[i].Item.(record.ResourceMarshaller).Resource.(*policyv1.PodDisruptionBudget)
+				assert.True(t, ok, "pdb item has invalid type")
+				name := pdba.ObjectMeta.Name
+				namespace := pdba.ObjectMeta.Namespace
+				assert.Equal(t, test.pdbsToNamespace[namespace], name)
+				assert.Equal(t, test.minAvailableToPdb[name], pdba.Spec.MinAvailable.IntValue())
+			}
+		})
 	}
 }


### PR DESCRIPTION
backport of PR##786

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `/pkg/gatherers/clusterconfig/pod_disruption_budgets_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-15459
