### PR TITLE
[release-4.11] OCPBUGS-15506: gather PDBs only from openshift namespaces

### DIFF
--- a/pkg/gatherers/clusterconfig/pod_disruption_budgets_test.go
+++ b/pkg/gatherers/clusterconfig/pod_disruption_budgets_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -12,48 +13,98 @@ import (
 )
 
 func Test_PodDisruptionBudgets_Gather(t *testing.T) {
-	coreClient := kubefake.NewSimpleClientset()
+	tests := []struct {
+		name string
+		// namespace -> pdb
+		pdbsToNamespace map[string]string
+		// pdb -> minAvailable
+		minAvailableToPdb map[string]int
+		expCount          int
+	}{
+		{
+			name:              "no PDB",
+			pdbsToNamespace:   nil,
+			minAvailableToPdb: nil,
+			expCount:          0,
+		},
+		{
+			name: "one openshift PDB",
+			pdbsToNamespace: map[string]string{
+				"openshift-test": "testT",
+			},
+			minAvailableToPdb: map[string]int{
+				"testT": 1,
+			},
+			expCount: 1,
+		},
+		{
+			name: "one random PDB",
+			pdbsToNamespace: map[string]string{
+				"random": "testR",
+			},
+			minAvailableToPdb: map[string]int{
+				"testR": 1,
+			},
+			expCount: 0,
+		},
+		{
+			name: "one openshift, one random PDB",
+			pdbsToNamespace: map[string]string{
+				"openshift-test": "testT",
+				"random":         "testR",
+			},
+			minAvailableToPdb: map[string]int{
+				"testT": 1,
+				"testR": 1,
+			},
+			expCount: 1,
+		},
+		{
+			name: "multiple openshift PDBs",
+			pdbsToNamespace: map[string]string{
+				"openshift-test":    "testT",
+				"openshift-default": "testD",
+			},
+			minAvailableToPdb: map[string]int{
+				"testT": 1,
+				"testD": 2,
+			},
+			expCount: 2,
+		},
+	}
 
-	fakeNamespace := "fake-namespace"
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			coreClient := kubefake.NewSimpleClientset()
 
-	// name -> MinAvailabel
-	fakePDBs := map[string]string{
-		"pdb-four":  "4",
-		"pdb-eight": "8",
-		"pdb-ten":   "10",
-	}
-	for name, minAvailable := range fakePDBs {
-		_, err := coreClient.PolicyV1().
-			PodDisruptionBudgets(fakeNamespace).
-			Create(context.Background(), &policyv1.PodDisruptionBudget{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: fakeNamespace,
-					Name:      name,
-				},
-				Spec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: &intstr.IntOrString{StrVal: minAvailable},
-				},
-			}, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("unable to create fake pdbs: %v", err)
-		}
-	}
-	ctx := context.Background()
-	records, errs := gatherPodDisruptionBudgets(ctx, coreClient.PolicyV1())
-	if len(errs) > 0 {
-		t.Errorf("unexpected errors: %#v", errs)
-		return
-	}
-	if len(records) != len(fakePDBs) {
-		t.Fatalf("unexpected number of records gathered: %d (expected %d)", len(records), len(fakePDBs))
-	}
-	pdba, ok := records[0].Item.(record.ResourceMarshaller).Resource.(*policyv1.PodDisruptionBudget)
-	if !ok {
-		t.Fatal("pdb item has invalid type")
-	}
-	name := pdba.ObjectMeta.Name
-	minAvailable := pdba.Spec.MinAvailable.StrVal
-	if pdba.Spec.MinAvailable.StrVal != fakePDBs[name] {
-		t.Fatalf("pdb item has mismatched MinAvailable value, %q != %q", fakePDBs[name], minAvailable)
+			for namespace, name := range test.pdbsToNamespace {
+				_, err := coreClient.PolicyV1().
+					PodDisruptionBudgets(namespace).
+					Create(context.Background(), &policyv1.PodDisruptionBudget{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      name,
+						},
+						Spec: policyv1.PodDisruptionBudgetSpec{
+							MinAvailable: &intstr.IntOrString{IntVal: int32(test.minAvailableToPdb[name])},
+						},
+					}, metav1.CreateOptions{})
+				assert.NoErrorf(t, err, "unable to create fake pdbs: %v", err)
+			}
+			ctx := context.Background()
+			records, errs := gatherPodDisruptionBudgets(ctx, coreClient.PolicyV1())
+			assert.Emptyf(t, errs, "unexpected errors: %#v", errs)
+			assert.Equal(t, test.expCount, len(records))
+			for i := range records {
+				pdba, ok := records[i].Item.(record.ResourceMarshaller).Resource.(*policyv1.PodDisruptionBudget)
+				assert.True(t, ok, "pdb item has invalid type")
+				name := pdba.ObjectMeta.Name
+				namespace := pdba.ObjectMeta.Namespace
+				assert.Equal(t, test.pdbsToNamespace[namespace], name)
+				assert.Equal(t, test.minAvailableToPdb[name], pdba.Spec.MinAvailable.IntValue())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Backport of PR#780 

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `/pkg/gatherers/clusterconfig/pod_disruption_budgets_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-15506
