### PR TITLE
update registration of the metrics to work in techpreview too

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -180,7 +180,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 		return err
 	}
 
-	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherConfigClient)
+	insightsClient := insightsclient.New(nil, 0, "insights", authorizer, gatherConfigClient)
 
 	var periodicGather *periodic.Controller
 	// the gatherers are periodically called to collect the data from the cluster
@@ -198,6 +198,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 		periodicGather = periodic.NewWithTechPreview(reportRetriever, secretConfigObserver,
 			insightsDataGatherObserver, gatherers, kubeClient, insightClient, operatorClient.InsightsOperators())
 		statusReporter.AddSources(periodicGather.Sources()...)
+		statusReporter.AddSources(reportRetriever)
 		go periodicGather.PeriodicPrune(ctx)
 	}
 

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -248,10 +248,6 @@ func (c *Client) createAndWriteMIMEHeader(source *Source, mw *multipart.Writer, 
 }
 
 var (
-	counterRequestSend = metrics.NewCounterVec(&metrics.CounterOpts{
-		Name: "insightsclient_request_send_total",
-		Help: "Tracks the number of archives sent",
-	}, []string{"client", "status_code"})
 	counterRequestRecvReport = metrics.NewCounterVec(&metrics.CounterOpts{
 		Name: "insightsclient_request_recvreport_total",
 		Help: "Tracks the number of insights reports received/downloaded",
@@ -259,5 +255,5 @@ var (
 )
 
 func init() {
-	insights.MustRegisterMetrics(counterRequestSend, counterRequestRecvReport)
+	insights.MustRegisterMetrics(counterRequestRecvReport)
 }

--- a/pkg/insights/insightsclient/requests.go
+++ b/pkg/insights/insightsclient/requests.go
@@ -12,21 +12,22 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/insights-operator/pkg/authorizer"
+	"github.com/openshift/insights-operator/pkg/insights"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-func (c *Client) SendAndGetID(ctx context.Context, endpoint string, source Source) (string, error) {
+func (c *Client) SendAndGetID(ctx context.Context, endpoint string, source Source) (string, int, error) {
 	cv, err := c.GetClusterVersion()
 	if apierrors.IsNotFound(err) {
-		return "", ErrWaitingForVersion
+		return "", 0, ErrWaitingForVersion
 	}
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	req, err := c.prepareRequest(ctx, http.MethodPost, endpoint, cv)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 
 	bytesRead := make(chan int64, 1)
@@ -42,9 +43,9 @@ func (c *Client) SendAndGetID(ctx context.Context, endpoint string, source Sourc
 	resp, err := c.client.Do(req)
 	if err != nil {
 		klog.V(4).Infof("Unable to build a request, possible invalid token: %v", err)
-		// if the request is not build, for example because of invalid endpoint,(maybe some problem with DNS), we want to have recorded about it in metrics as well.
-		counterRequestSend.WithLabelValues(c.metricsName, "0").Inc()
-		return "", fmt.Errorf("unable to build request to connect to Insights server: %v", err)
+		// if the request is not build, for example because of invalid endpoint,(maybe some problem with DNS), we want to have record about it in metrics as well.
+		insights.IncrementCounterRequestSend("0")
+		return "", 0, fmt.Errorf("unable to build request to connect to Insights server: %v", err)
 	}
 
 	requestID := resp.Header.Get(insightsReqId)
@@ -58,36 +59,36 @@ func (c *Client) SendAndGetID(ctx context.Context, endpoint string, source Sourc
 		}
 	}()
 
-	counterRequestSend.WithLabelValues(c.metricsName, strconv.Itoa(resp.StatusCode)).Inc()
+	insights.IncrementCounterRequestSend(strconv.Itoa(resp.StatusCode))
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		klog.V(2).Infof("gateway server %s returned 401, %s=%s", resp.Request.URL, insightsReqId, requestID)
-		return "", authorizer.Error{Err: fmt.Errorf("your Red Hat account is not enabled for remote support or your token has expired: %s", responseBody(resp))}
+		return "", resp.StatusCode, authorizer.Error{Err: fmt.Errorf("your Red Hat account is not enabled for remote support or your token has expired: %s", responseBody(resp))}
 	}
 
 	if resp.StatusCode == http.StatusForbidden {
 		klog.V(2).Infof("gateway server %s returned 403, %s=%s", resp.Request.URL, insightsReqId, requestID)
-		return "", authorizer.Error{Err: fmt.Errorf("your Red Hat account is not enabled for remote support")}
+		return "", resp.StatusCode, authorizer.Error{Err: fmt.Errorf("your Red Hat account is not enabled for remote support")}
 	}
 
 	if resp.StatusCode == http.StatusBadRequest {
-		return "", fmt.Errorf("gateway server bad request: %s (request=%s): %s", resp.Request.URL, requestID, responseBody(resp))
+		return "", resp.StatusCode, fmt.Errorf("gateway server bad request: %s (request=%s): %s", resp.Request.URL, requestID, responseBody(resp))
 	}
 
 	if resp.StatusCode >= 300 || resp.StatusCode < 200 {
-		return "", fmt.Errorf("gateway server reported unexpected error code: %d (request=%s): %s", resp.StatusCode, requestID, responseBody(resp))
+		return "", resp.StatusCode, fmt.Errorf("gateway server reported unexpected error code: %d (request=%s): %s", resp.StatusCode, requestID, responseBody(resp))
 	}
 
 	if len(requestID) > 0 {
 		klog.V(2).Infof("Successfully reported id=%s %s=%s, wrote=%d", source.ID, insightsReqId, requestID, <-bytesRead)
 	}
 
-	return requestID, nil
+	return requestID, resp.StatusCode, nil
 }
 
 // Send uploads archives to Ingress service
 func (c *Client) Send(ctx context.Context, endpoint string, source Source) error {
-	_, err := c.SendAndGetID(ctx, endpoint, source)
+	_, _, err := c.SendAndGetID(ctx, endpoint, source)
 	return err
 }
 

--- a/pkg/insights/insightsclient/requests.go
+++ b/pkg/insights/insightsclient/requests.go
@@ -24,15 +24,15 @@ var (
 func (c *Client) SendAndGetID(ctx context.Context, endpoint string, source Source) (string, int, error) {
 	cv, err := c.GetClusterVersion()
 	if apierrors.IsNotFound(err) {
-		return "", 0, ErrWaitingForVersion
+		return "", noHttpStatusCode, ErrWaitingForVersion
 	}
 	if err != nil {
-		return "", 0, err
+		return "", noHttpStatusCode, err
 	}
 
 	req, err := c.prepareRequest(ctx, http.MethodPost, endpoint, cv)
 	if err != nil {
-		return "", 0, err
+		return "", noHttpStatusCode, err
 	}
 
 	bytesRead := make(chan int64, 1)

--- a/pkg/insights/insightsreport/insightsreport_test.go
+++ b/pkg/insights/insightsreport/insightsreport_test.go
@@ -242,10 +242,9 @@ func Test_readInsightsReport(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			activeRecommendations, healthStatus, gatherTime := tc.testController.readInsightsReport(tc.report)
+			activeRecommendations, healthStatus := tc.testController.readInsightsReport(tc.report)
 			assert.Equal(t, tc.expectedActiveRecommendations, activeRecommendations)
 			assert.Equal(t, tc.expectedHealthStatus, healthStatus)
-			assert.Equal(t, tc.expectedGatherTime, gatherTime.String())
 		})
 	}
 }
@@ -286,7 +285,7 @@ func Test_extractErrorKeyFromRuleData(t *testing.T) {
 				},
 			},
 			expectedErrorKey: "",
-			expectedError:    fmt.Errorf("TemplateData of rule \"%s\" does not contain error_key", testRuleID),
+			expectedError:    fmt.Errorf("templateData of rule \"%s\" does not contain error_key", testRuleID),
 		},
 		{
 			name: "Rule response with wrong error_key type",

--- a/pkg/insights/metrics.go
+++ b/pkg/insights/metrics.go
@@ -17,6 +17,10 @@ var (
 	RecommendationCollector = &Collector{
 		metricName: "insights_recommendation_active",
 	}
+	counterRequestSend = metrics.NewCounterVec(&metrics.CounterOpts{
+		Name: "insightsclient_request_send_total",
+		Help: "Tracks the number of archives sent",
+	}, []string{"client", "status_code"})
 )
 
 // MustRegisterMetrics registers provided registrables in the Insights metrics registry.
@@ -32,7 +36,11 @@ func MustRegisterMetrics(registrables ...metrics.Registerable) {
 }
 
 func init() {
-	MustRegisterMetrics(RecommendationCollector)
+	MustRegisterMetrics(RecommendationCollector, counterRequestSend)
+}
+
+func IncrementCounterRequestSend(status string) {
+	counterRequestSend.WithLabelValues("insights", status).Inc()
 }
 
 // Collector collects insights recommendations

--- a/pkg/insights/metrics.go
+++ b/pkg/insights/metrics.go
@@ -2,6 +2,7 @@ package insights
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -39,8 +40,9 @@ func init() {
 	MustRegisterMetrics(RecommendationCollector, counterRequestSend)
 }
 
-func IncrementCounterRequestSend(status string) {
-	counterRequestSend.WithLabelValues("insights", status).Inc()
+func IncrementCounterRequestSend(status int) {
+	statusCodeString := strconv.Itoa(status)
+	counterRequestSend.WithLabelValues("insights", statusCodeString).Inc()
 }
 
 // Collector collects insights recommendations


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR updates the logic of Prometheus metrics registration to work in techpreview (when data gathering runs in a job) as well. The registration and incrementation of the `insightsclient_request_send_total` metric is moved from the uploader and the metric in the techpreview is updated based on the conditions of the latest `datagather` CR (which provides information including HTTP status code in its conditions).  

This also removes the `insightsclient_last_gather_time` metric. This data is available in the Insights CRs. 

This also removes  

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
