### PR TITLE
check new processing status endpoint after uploading data in the job

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -12,6 +12,7 @@ pull_report:
   delay: "60s"
   timeout: "3000s"
   min_retry: "30s"
+processingStatusEndpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/status
 ocm:
   scaEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/certificates
   scaInterval: "8h"

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -92,6 +92,7 @@ func NewGatherAndUpload() *cobra.Command {
 			ReportPullingDelay:          60 * time.Second,
 			ReportMinRetryTime:          10 * time.Second,
 			ReportPullingTimeout:        30 * time.Minute,
+			ProcessingStatusEndpoint:    "https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/status",
 		},
 	}
 	cfg := controllercmd.NewControllerCommandConfig("openshift-insights-operator", version.Get(), nil)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,8 @@ type Serialized struct {
 		ClusterTransferEndpoint string `json:"clusterTransferEndpoint"`
 		ClusterTransferInterval string `json:"clusterTransferInterval"`
 	} `json:"ocm"`
-	DisableInsightsAlerts bool `json:"disableInsightsAlerts"`
+	DisableInsightsAlerts    bool   `json:"disableInsightsAlerts"`
+	ProcessingStatusEndpoint string `json:"processingStatusEndpoint"`
 }
 
 // Controller defines the standard config for this operator.
@@ -58,7 +59,8 @@ type Controller struct {
 	OCMConfig  OCMConfig
 
 	// DisableInsightsAlerts disabled exposing of Insights recommendations as Prometheus info alerts
-	DisableInsightsAlerts bool
+	DisableInsightsAlerts    bool
+	ProcessingStatusEndpoint string
 }
 
 // HTTPConfig configures http proxy and exception settings if they come from config
@@ -90,7 +92,8 @@ func (c *Controller) ToString() string {
 		"reportEndpoint=%s "+
 		"initialPollingDelay=%s "+
 		"minRetryTime=%s "+
-		"pollingTimeout=%s",
+		"pollingTimeout=%s "+
+		"processingStatusEndpoint=%s",
 		c.Report,
 		c.Endpoint,
 		c.ConditionalGathererEndpoint,
@@ -100,7 +103,8 @@ func (c *Controller) ToString() string {
 		c.ReportEndpoint,
 		c.ReportPullingDelay,
 		c.ReportMinRetryTime,
-		c.ReportPullingTimeout)
+		c.ReportPullingTimeout,
+		c.ProcessingStatusEndpoint)
 }
 
 func (c *Controller) MergeWith(cfg *Controller) {
@@ -111,6 +115,7 @@ func (c *Controller) MergeWith(cfg *Controller) {
 	c.mergeReport(cfg)
 	c.mergeOCM(cfg)
 	c.mergeHTTP(cfg)
+	c.mergeProcessingStatusEndpoint(cfg)
 }
 
 func (c *Controller) mergeCredentials(cfg *Controller) {
@@ -121,6 +126,12 @@ func (c *Controller) mergeCredentials(cfg *Controller) {
 func (c *Controller) mergeEndpoint(cfg *Controller) {
 	if len(cfg.Endpoint) > 0 {
 		c.Endpoint = cfg.Endpoint
+	}
+}
+
+func (c *Controller) mergeProcessingStatusEndpoint(cfg *Controller) {
+	if len(cfg.ProcessingStatusEndpoint) > 0 {
+		c.ProcessingStatusEndpoint = cfg.ProcessingStatusEndpoint
 	}
 }
 
@@ -187,6 +198,7 @@ func ToController(s *Serialized, cfg *Controller) (*Controller, error) { // noli
 	cfg.Impersonate = s.Impersonate
 	cfg.EnableGlobalObfuscation = s.EnableGlobalObfuscation
 	cfg.DisableInsightsAlerts = s.DisableInsightsAlerts
+	cfg.ProcessingStatusEndpoint = s.ProcessingStatusEndpoint
 
 	if len(s.Interval) > 0 {
 		d, err := time.ParseDuration(s.Interval)

--- a/pkg/config/configobserver/config.go
+++ b/pkg/config/configobserver/config.go
@@ -30,6 +30,7 @@ func LoadConfigFromSecret(secret *v1.Secret) (config.Controller, error) {
 	cfg.loadHTTP(secret.Data)
 	cfg.loadReport(secret.Data)
 	cfg.loadOCM(secret.Data)
+	cfg.loadProcessingStatusEndpoint(secret.Data)
 
 	if intervalString, ok := secret.Data["interval"]; ok {
 		var duration time.Duration
@@ -162,5 +163,11 @@ func (c *Config) loadOCM(data map[string][]byte) {
 				clusterTransferInterval,
 			)
 		}
+	}
+}
+
+func (c *Config) loadProcessingStatusEndpoint(data map[string][]byte) {
+	if endpoint, ok := data["processingStatusEndpoint"]; ok {
+		c.ProcessingStatusEndpoint = string(endpoint)
 	}
 }

--- a/pkg/controller/gather_commands_test.go
+++ b/pkg/controller/gather_commands_test.go
@@ -1,0 +1,93 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openshift/insights-operator/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockProcessingStatusClient struct {
+	err      error
+	response *http.Response
+}
+
+func (m *MockProcessingStatusClient) GetDataProcessingStatus(_ context.Context, _, _ string) (*http.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return m.response, nil
+}
+
+func TestWasDataProcessed(t *testing.T) {
+	tests := []struct {
+		name              string
+		mockClient        MockProcessingStatusClient
+		expectedProcessed bool
+		expectedErr       error
+	}{
+		{
+			name: "no response with error",
+			mockClient: MockProcessingStatusClient{
+				response: nil,
+				err:      fmt.Errorf("no response received"),
+			},
+			expectedProcessed: false,
+			expectedErr:       fmt.Errorf("no response received"),
+		},
+		{
+			name: "HTTP 404 response and no body",
+			mockClient: MockProcessingStatusClient{
+				response: &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       http.NoBody,
+				},
+				err: nil,
+			},
+			expectedProcessed: false,
+			expectedErr:       nil,
+		},
+		{
+			name: "data not processed",
+			mockClient: MockProcessingStatusClient{
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{\"cluster\":\"test-uid\",\"status\":\"unknown\"}")),
+				},
+				err: nil,
+			},
+			expectedProcessed: false,
+			expectedErr:       nil,
+		},
+		{
+			name: "data processed",
+			mockClient: MockProcessingStatusClient{
+				response: &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{\"cluster\":\"test-uid\",\"status\":\"processed\"}")),
+				},
+				err: nil,
+			},
+			expectedProcessed: true,
+			expectedErr:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfCtrl := &config.Controller{
+				ReportPullingDelay: 10 * time.Millisecond,
+			}
+			processed, err := wasDataProcessed(context.Background(), &tt.mockClient, "empty", mockConfCtrl)
+			assert.Equal(t, tt.expectedErr, err)
+			assert.Equal(t, tt.expectedProcessed, processed)
+		})
+	}
+}

--- a/pkg/controller/status/datagather_status.go
+++ b/pkg/controller/status/datagather_status.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	DataUploaded = "DataUploaded"
-	DataRecorded = "DataRecorded"
+	DataUploaded  = "DataUploaded"
+	DataRecorded  = "DataRecorded"
+	DataProcessed = "DataProcessed"
 )
 
 // DataUploadedCondition returns new "DataUploaded" status condition with provided status, reason and message
@@ -28,6 +29,17 @@ func DataUploadedCondition(status metav1.ConditionStatus, reason, message string
 func DataRecordedCondition(status metav1.ConditionStatus, reason, message string) metav1.Condition {
 	return metav1.Condition{
 		Type:               DataRecorded,
+		LastTransitionTime: metav1.Now(),
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+// DataProcessedCondition returns new "DataProcessed" status condition with provided status, reason and message
+func DataProcessedCondition(status metav1.ConditionStatus, reason, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:               DataProcessed,
 		LastTransitionTime: metav1.Now(),
 		Status:             status,
 		Reason:             reason,

--- a/pkg/controller/status/datagather_status_test.go
+++ b/pkg/controller/status/datagather_status_test.go
@@ -12,12 +12,13 @@ import (
 
 func TestUpdateDataGatherStatus(t *testing.T) {
 	tests := []struct {
-		name                    string
-		dataGather              *v1alpha1.DataGather
-		dgState                 v1alpha1.DataGatherState
-		updatingConditions      []metav1.Condition
-		expectedDataRecordedCon metav1.Condition
-		expectedDataUploadedCon metav1.Condition
+		name                     string
+		dataGather               *v1alpha1.DataGather
+		dgState                  v1alpha1.DataGatherState
+		updatingConditions       []metav1.Condition
+		expectedDataRecordedCon  metav1.Condition
+		expectedDataUploadedCon  metav1.Condition
+		expectedDataProcessedCon metav1.Condition
 	}{
 		{
 			name: "updating DataGather to completed state",
@@ -30,6 +31,7 @@ func TestUpdateDataGatherStatus(t *testing.T) {
 			updatingConditions: []metav1.Condition{
 				DataRecordedCondition(metav1.ConditionTrue, "AsExpected", ""),
 				DataUploadedCondition(metav1.ConditionTrue, "HttpStatus200", "testing message"),
+				DataProcessedCondition(metav1.ConditionTrue, "Processed", ""),
 			},
 			expectedDataRecordedCon: metav1.Condition{
 				Type:   DataRecorded,
@@ -41,6 +43,11 @@ func TestUpdateDataGatherStatus(t *testing.T) {
 				Status:  metav1.ConditionTrue,
 				Reason:  "HttpStatus200",
 				Message: "testing message",
+			},
+			expectedDataProcessedCon: metav1.Condition{
+				Type:   DataProcessed,
+				Status: metav1.ConditionTrue,
+				Reason: "Processed",
 			},
 		},
 		{
@@ -54,6 +61,7 @@ func TestUpdateDataGatherStatus(t *testing.T) {
 			updatingConditions: []metav1.Condition{
 				DataRecordedCondition(metav1.ConditionFalse, "Failure", "testing error message"),
 				DataUploadedCondition(metav1.ConditionFalse, "HttpStatus403", "testing message"),
+				DataProcessedCondition(metav1.ConditionFalse, "Failure", "testing error message"),
 			},
 			expectedDataRecordedCon: metav1.Condition{
 				Type:    DataRecorded,
@@ -66,6 +74,12 @@ func TestUpdateDataGatherStatus(t *testing.T) {
 				Status:  metav1.ConditionFalse,
 				Reason:  "HttpStatus403",
 				Message: "testing message",
+			},
+			expectedDataProcessedCon: metav1.Condition{
+				Type:    DataProcessed,
+				Status:  metav1.ConditionFalse,
+				Reason:  "Failure",
+				Message: "testing error message",
 			},
 		},
 	}
@@ -92,6 +106,12 @@ func TestUpdateDataGatherStatus(t *testing.T) {
 			assert.Equal(t, tt.expectedDataUploadedCon.Reason, dataUploadedCon.Reason)
 			assert.Equal(t, tt.expectedDataUploadedCon.Status, dataUploadedCon.Status)
 			assert.Equal(t, tt.expectedDataUploadedCon.Message, dataUploadedCon.Message)
+
+			dataProcessedCon := GetConditionByStatus(updatedDG, DataProcessed)
+			assert.NotNil(t, dataRecordedCon)
+			assert.Equal(t, tt.expectedDataProcessedCon.Reason, dataProcessedCon.Reason)
+			assert.Equal(t, tt.expectedDataProcessedCon.Status, dataProcessedCon.Status)
+			assert.Equal(t, tt.expectedDataProcessedCon.Message, dataProcessedCon.Message)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR implements a new check (HTTP GET) for the `processingStatusEndpoint` (better name suggestions are welcome), which requires cluster ID as well as the Insights request ID (which is part of the data upload HTTP response). 

The endpoint is polled three times (in case of error or response other than HTTP 200) with initial delay of 1 min (same as previously). If the check is successful then the HTTP response body is read and it's used to evaluate whether the data/archive processing was finished or not. The result is provided as the `DataProcessed` condition in the respective `DataGather` CR. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/gather_commands_test.go` - basic test for the new function

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
