### PR TITLE
OCPBUGS-17428: workload info gatherer, add external image repo

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1957,6 +1957,6 @@ None
 None
 
 ### Changes
-None
+- Image repository is now collected if it comes from outside the Red Hat domain
 
 

--- a/docs/insights-archive-sample/config/workload_info.json
+++ b/docs/insights-archive-sample/config/workload_info.json
@@ -23,7 +23,7 @@
       ],
       "firstCommand": "icTsn2s_EIax",
       "firstArg": "2v1NneeWoS_9",
-      "repository":"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a16c19e8f7372bec6e2b62f1eae6d4796d6aec8435679c7821fdc267fa667140"
+      "repository":"2W0Xq9hxQzho"
     },
     "sha256:7c6d0a0fed7ddb95550623aa23c434446fb99abef18e6d57b8b12add606efde8": {
       "layerIDs": [

--- a/docs/insights-archive-sample/config/workload_info.json
+++ b/docs/insights-archive-sample/config/workload_info.json
@@ -22,7 +22,8 @@
         "sha256:1bd85e07834910cad1fda7967cfd86ada69377ba0baf875683e7739d8de6d1b0"
       ],
       "firstCommand": "icTsn2s_EIax",
-      "firstArg": "2v1NneeWoS_9"
+      "firstArg": "2v1NneeWoS_9",
+      "repository":"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:a16c19e8f7372bec6e2b62f1eae6d4796d6aec8435679c7821fdc267fa667140"
     },
     "sha256:7c6d0a0fed7ddb95550623aa23c434446fb99abef18e6d57b8b12add606efde8": {
       "layerIDs": [

--- a/pkg/gatherers/workloads/gather_workloads_info.go
+++ b/pkg/gatherers/workloads/gather_workloads_info.go
@@ -512,8 +512,11 @@ func calculateWorkloadInfo(h hash.Hash, image *imagev1.Image) workloadImage {
 
 	info := workloadImage{
 		LayerIDs: layers,
-		//RepoURL: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:5710554c08735126986b7c553cdb9a31bf97071c7adceda20f7aa116f35e867f",
-		Repository: getExternalImageRepo(image.DockerImageReference),
+	}
+
+	// we only need repo URLs from outside RH
+	if repo := getExternalImageRepo(image.DockerImageReference); repo != "" {
+		info.Repository = workloadHashString(h, repo)
 	}
 
 	if err := imageutil.ImageWithMetadata(image); err != nil {

--- a/pkg/gatherers/workloads/gather_workloads_info_test.go
+++ b/pkg/gatherers/workloads/gather_workloads_info_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
 )
 
 // nolint: funlen, gocyclo, gosec
@@ -147,5 +148,34 @@ func Test_gatherWorkloadInfo(t *testing.T) {
 			float64(totalImagesWithData)/float64(pods.ImageCount)*100,
 			workloadImageLRU.Len(),
 		)
+	}
+}
+
+func Test_getExternalImageRepo(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "Image repository under the Red Hat domain will be ignored",
+			url:      "registry.redhat.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc",
+			expected: "",
+		},
+		{
+			name:     "Image repository outside the Red Hat domain is returned",
+			url:      "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc",
+			expected: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// When
+			test := getExternalImageRepo(testCase.url)
+
+			// Assert
+			assert.Equal(t, testCase.expected, test)
+		})
 	}
 }

--- a/pkg/gatherers/workloads/types.go
+++ b/pkg/gatherers/workloads/types.go
@@ -36,6 +36,9 @@ type workloadImage struct {
 	// FirstArg is a hash of the first value in the command array, if any
 	// was set. Normalized to be consistent with pods
 	FirstArg string `json:"firstArg,omitempty"`
+	// Repository is a URL of an external image
+	// It is gathered when the image is not from Red Hat domain
+	Repository string `json:"repository,omitempty"`
 }
 
 // Empty returns true if the image has no contents and can be ignored.


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to [Workload info gatherer](https://github.com/openshift/insights-operator/blob/master/pkg/gatherers/workloads/gather_workloads_info.go) to add image repository to the archive. The repository image is only collected if it's from outside of Red Hat domain. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/workload_info.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/workloads/gather_workloads_info_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-11505
https://issues.redhat.com/browse/OCPBUGS-17428