### PR TITLE
download Insights analysis report from a new endpoint (using Insights request ID)

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -13,6 +13,7 @@ pull_report:
   timeout: "3000s"
   min_retry: "30s"
 processingStatusEndpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/status
+reportEndpointTechPreview: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/report
 ocm:
   scaEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/certificates
   scaInterval: "8h"

--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -93,6 +93,7 @@ func NewGatherAndUpload() *cobra.Command {
 			ReportMinRetryTime:          10 * time.Second,
 			ReportPullingTimeout:        30 * time.Minute,
 			ProcessingStatusEndpoint:    "https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/status",
+			ReportEndpointTechPreview:   "https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/report",
 		},
 	}
 	cfg := controllercmd.NewControllerCommandConfig("openshift-insights-operator", version.Get(), nil)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,8 +31,9 @@ type Serialized struct {
 		ClusterTransferEndpoint string `json:"clusterTransferEndpoint"`
 		ClusterTransferInterval string `json:"clusterTransferInterval"`
 	} `json:"ocm"`
-	DisableInsightsAlerts    bool   `json:"disableInsightsAlerts"`
-	ProcessingStatusEndpoint string `json:"processingStatusEndpoint"`
+	DisableInsightsAlerts     bool   `json:"disableInsightsAlerts"`
+	ProcessingStatusEndpoint  string `json:"processingStatusEndpoint"`
+	ReportEndpointTechPreview string `json:"reportEndpointTechPreview"`
 }
 
 // Controller defines the standard config for this operator.
@@ -43,6 +44,7 @@ type Controller struct {
 	Endpoint                    string
 	ConditionalGathererEndpoint string
 	ReportEndpoint              string
+	ReportEndpointTechPreview   string
 	ReportPullingDelay          time.Duration
 	ReportMinRetryTime          time.Duration
 	ReportPullingTimeout        time.Duration
@@ -116,6 +118,7 @@ func (c *Controller) MergeWith(cfg *Controller) {
 	c.mergeOCM(cfg)
 	c.mergeHTTP(cfg)
 	c.mergeProcessingStatusEndpoint(cfg)
+	c.mergeReportEndpointTechPreview(cfg)
 }
 
 func (c *Controller) mergeCredentials(cfg *Controller) {
@@ -132,6 +135,12 @@ func (c *Controller) mergeEndpoint(cfg *Controller) {
 func (c *Controller) mergeProcessingStatusEndpoint(cfg *Controller) {
 	if len(cfg.ProcessingStatusEndpoint) > 0 {
 		c.ProcessingStatusEndpoint = cfg.ProcessingStatusEndpoint
+	}
+}
+
+func (c *Controller) mergeReportEndpointTechPreview(cfg *Controller) {
+	if len(cfg.ReportEndpointTechPreview) > 0 {
+		c.ReportEndpointTechPreview = cfg.ReportEndpointTechPreview
 	}
 }
 
@@ -199,6 +208,7 @@ func ToController(s *Serialized, cfg *Controller) (*Controller, error) { // noli
 	cfg.EnableGlobalObfuscation = s.EnableGlobalObfuscation
 	cfg.DisableInsightsAlerts = s.DisableInsightsAlerts
 	cfg.ProcessingStatusEndpoint = s.ProcessingStatusEndpoint
+	cfg.ReportEndpointTechPreview = s.ReportEndpointTechPreview
 
 	if len(s.Interval) > 0 {
 		d, err := time.ParseDuration(s.Interval)

--- a/pkg/config/configobserver/config.go
+++ b/pkg/config/configobserver/config.go
@@ -31,6 +31,7 @@ func LoadConfigFromSecret(secret *v1.Secret) (config.Controller, error) {
 	cfg.loadReport(secret.Data)
 	cfg.loadOCM(secret.Data)
 	cfg.loadProcessingStatusEndpoint(secret.Data)
+	cfg.loadReportEndpointTechPreview(secret.Data)
 
 	if intervalString, ok := secret.Data["interval"]; ok {
 		var duration time.Duration
@@ -169,5 +170,11 @@ func (c *Config) loadOCM(data map[string][]byte) {
 func (c *Config) loadProcessingStatusEndpoint(data map[string][]byte) {
 	if endpoint, ok := data["processingStatusEndpoint"]; ok {
 		c.ProcessingStatusEndpoint = string(endpoint)
+	}
+}
+
+func (c *Config) loadReportEndpointTechPreview(data map[string][]byte) {
+	if endpoint, ok := data["reportEndpointTechPreview"]; ok {
+		c.ReportEndpointTechPreview = string(endpoint)
 	}
 }

--- a/pkg/config/mock_configurator.go
+++ b/pkg/config/mock_configurator.go
@@ -55,10 +55,3 @@ func (mc *MockAPIConfigurator) GatherDisabled() bool {
 	}
 	return false
 }
-
-func (mc *MockAPIConfigurator) GatherDataPolicy() *v1alpha1.DataPolicy {
-	if mc.config != nil {
-		return &mc.config.DataPolicy
-	}
-	return nil
-}

--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -39,7 +39,7 @@ type GatherJob struct {
 // processingStatusClient is an interface to call the "processingStatusEndpoint" in
 // the "insights-results-aggregator" service running in console.redhat.com
 type processingStatusClient interface {
-	GetDataProcessingStatus(ctx context.Context, endpoint, requestID string) (*http.Response, error)
+	GetWithPathParams(ctx context.Context, endpoint, requestID string) (*http.Response, error)
 }
 
 // Gather runs a single gather and stores the generated archive, without uploading it.
@@ -308,7 +308,7 @@ func wasDataProcessed(ctx context.Context,
 
 	var resp *http.Response
 	err := wait.PollUntilContextCancel(ctx, delay, false, func(ctx context.Context) (done bool, err error) {
-		resp, err = insightsCli.GetDataProcessingStatus(ctx, // nolint: bodyclose
+		resp, err = insightsCli.GetWithPathParams(ctx, // nolint: bodyclose
 			controllerConf.ProcessingStatusEndpoint, insightsRequestID) // response body is closed later
 		if err != nil {
 			return false, err

--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -253,7 +253,11 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 	// check if the archive/data was processed
 	processed, err := wasDataProcessed(ctx, insightsHTTPCli, insightsRequestID, configObserver.Config())
 	if err != nil || !processed {
-		klog.Error(err)
+		msg := fmt.Sprintf("Data was not processed in the console.redhat.com pipeline for the request %s", insightsRequestID)
+		if err != nil {
+			msg = fmt.Sprintf("%s: %v", msg, err)
+		}
+		klog.Info(msg)
 		conditions = append(conditions,
 			status.DataProcessedCondition(metav1.ConditionFalse, "Failure", fmt.Sprintf("failed to process data in the given time: %v", err)))
 	} else {

--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
 	"github.com/openshift/insights-operator/pkg/controller/status"
 	"github.com/openshift/insights-operator/pkg/gather"
+	"github.com/openshift/insights-operator/pkg/gatherers"
 	"github.com/openshift/insights-operator/pkg/insights/insightsclient"
 	"github.com/openshift/insights-operator/pkg/insights/insightsuploader"
 	"github.com/openshift/insights-operator/pkg/recorder"
@@ -48,7 +49,7 @@ type processingStatusClient interface {
 // 3. Initiates the recorder
 // 4. Executes a Gather
 // 5. Flushes the results
-func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *rest.Config) error {
+func (g *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *rest.Config) error {
 	klog.Infof("Starting insights-operator %s", version.Get().String())
 	// these are operator clients
 	kubeClient, err := kubernetes.NewForConfig(protoKubeConfig)
@@ -57,18 +58,17 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	}
 
 	gatherProtoKubeConfig, gatherKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig := prepareGatherConfigs(
-		protoKubeConfig, kubeConfig, d.Impersonate,
+		protoKubeConfig, kubeConfig, g.Impersonate,
 	)
 
 	// ensure the insight snapshot directory exists
-	if _, err = os.Stat(d.StoragePath); err != nil && os.IsNotExist(err) {
-		if err = os.MkdirAll(d.StoragePath, 0777); err != nil {
-			return fmt.Errorf("can't create --path: %v", err)
-		}
+	err = g.storagePathExists()
+	if err != nil {
+		return err
 	}
 
 	// configobserver synthesizes all config into the status reporter controller
-	configObserver := configobserver.New(d.Controller, kubeClient)
+	configObserver := configobserver.New(g.Controller, kubeClient)
 
 	// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
 	anonymizer, err := anonymization.NewAnonymizerFromConfig(
@@ -78,8 +78,8 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	}
 
 	// the recorder stores the collected data and we flush at the end.
-	recdriver := diskrecorder.New(d.StoragePath)
-	rec := recorder.New(recdriver, d.Interval, anonymizer)
+	recdriver := diskrecorder.New(g.StoragePath)
+	rec := recorder.New(recdriver, g.Interval, anonymizer)
 	defer func() {
 		if err = rec.Flush(); err != nil {
 			klog.Error(err)
@@ -97,13 +97,13 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 	}
 
 	insightsClient := insightsclient.New(nil, 0, "default", authorizer, gatherConfigClient)
-	gatherers := gather.CreateAllGatherers(
+	createdGatherers := gather.CreateAllGatherers(
 		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,
 		configObserver, insightsClient,
 	)
 
 	allFunctionReports := make(map[string]gather.GathererFunctionReport)
-	for _, gatherer := range gatherers {
+	for _, gatherer := range createdGatherers {
 		functionReports, err := gather.CollectAndRecordGatherer(ctx, gatherer, rec, nil)
 		if err != nil {
 			klog.Errorf("unable to process gatherer %v, error: %v", gatherer.GetName(), err)
@@ -125,7 +125,7 @@ func (d *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 // 5. Recodrd the data into the Insights archive
 // 6. Get the latest archive and upload it
 // 7. Updates the status of the corresponding "datagathers.insights.openshift.io" resource continuously
-func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) error { // nolint: funlen, gocyclo
+func (g *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) error { // nolint: funlen
 	klog.Info("Starting data gathering")
 	kubeClient, err := kubernetes.NewForConfig(protoKubeConfig)
 	if err != nil {
@@ -138,34 +138,25 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 	}
 
 	gatherProtoKubeConfig, gatherKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig := prepareGatherConfigs(
-		protoKubeConfig, kubeConfig, d.Impersonate,
+		protoKubeConfig, kubeConfig, g.Impersonate,
 	)
 
 	// The reason for using longer context is that the upload can fail and then there is the exponential backoff
 	// See the insightsuploader Upload method
-	ctx, cancel := context.WithTimeout(context.Background(), d.Interval*4)
+	ctx, cancel := context.WithTimeout(context.Background(), g.Interval*4)
 	defer cancel()
 	dataGatherCR, err := insightsV1alphaCli.DataGathers().Get(ctx, os.Getenv("DATAGATHER_NAME"), metav1.GetOptions{})
 	if err != nil {
 		klog.Error("failed to get coresponding DataGather custom resource: %v", err)
 		return err
 	}
-
-	dataGatherCR, err = status.UpdateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR.DeepCopy(), insightsv1alpha1.Pending, nil)
+	// ensure the insight snapshot directory exists
+	err = g.storagePathExists()
 	if err != nil {
-		klog.Error("failed to update coresponding DataGather custom resource: %v", err)
 		return err
 	}
-
-	// ensure the insight snapshot directory exists
-	if _, err = os.Stat(d.StoragePath); err != nil && os.IsNotExist(err) {
-		if err = os.MkdirAll(d.StoragePath, 0777); err != nil {
-			return fmt.Errorf("can't create --path: %v", err)
-		}
-	}
-
 	// configobserver synthesizes all config into the status reporter controller
-	configObserver := configobserver.New(d.Controller, kubeClient)
+	configObserver := configobserver.New(g.Controller, kubeClient)
 	// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
 	anonymizer, err := anonymization.NewAnonymizerFromConfig(
 		ctx, gatherKubeConfig, gatherProtoKubeConfig, protoKubeConfig, configObserver, dataGatherCR.Spec.DataPolicy)
@@ -174,8 +165,8 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 	}
 
 	// the recorder stores the collected data and we flush at the end.
-	recdriver := diskrecorder.New(d.StoragePath)
-	rec := recorder.New(recdriver, d.Interval, anonymizer)
+	recdriver := diskrecorder.New(g.StoragePath)
+	rec := recorder.New(recdriver, g.Interval, anonymizer)
 	authorizer := clusterauthorizer.New(configObserver)
 
 	configClient, err := configv1client.NewForConfig(gatherKubeConfig)
@@ -184,19 +175,80 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 	}
 	insightsHTTPCli := insightsclient.New(nil, 0, "default", authorizer, configClient)
 
-	gatherers := gather.CreateAllGatherers(
+	createdGatherers := gather.CreateAllGatherers(
 		gatherKubeConfig, gatherProtoKubeConfig, metricsGatherKubeConfig, alertsGatherKubeConfig, anonymizer,
 		configObserver, insightsHTTPCli,
 	)
 	uploader := insightsuploader.New(nil, insightsHTTPCli, configObserver, nil, nil, 0)
 
-	dataGatherCR, err = status.UpdateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR, insightsv1alpha1.Running, nil)
+	dataGatherCR, err = status.UpdateDataGatherState(ctx, insightsV1alphaCli, dataGatherCR, insightsv1alpha1.Running)
 	if err != nil {
 		klog.Error("failed to update coresponding DataGather custom resource: %v", err)
 		return err
 	}
+
+	allFunctionReports := gatherAndReporFunctions(ctx, createdGatherers, dataGatherCR, rec)
+
+	// record data
+	dataRecordedCon := status.DataRecordedCondition(metav1.ConditionTrue, "AsExpected", "")
+	lastArchive, err := record(mapToArray(allFunctionReports), rec, recdriver, anonymizer)
+	if err != nil {
+		klog.Error("Failed to record data archive: %v", err)
+		dataRecordedCon.Status = metav1.ConditionFalse
+		dataRecordedCon.Reason = "RecordingFailed"
+		dataRecordedCon.Message = fmt.Sprintf("Failed to record data: %v", err)
+		updateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR, &dataRecordedCon, insightsv1alpha1.Failed)
+		return err
+	}
+
+	dataGatherCR, err = status.UpdateDataGatherConditions(ctx, insightsV1alphaCli, dataGatherCR, &dataRecordedCon)
+	if err != nil {
+		klog.Error(err)
+	}
+
+	// upload data
+	insightsRequestID, statusCode, err := uploader.Upload(ctx, lastArchive)
+	reason := fmt.Sprintf("HttpStatus%d", statusCode)
+	dataUploadedCon := status.DataUploadedCondition(metav1.ConditionTrue, reason, "")
+	if err != nil {
+		klog.Error("Failed to upload data archive: %v", err)
+		dataUploadedCon.Status = metav1.ConditionFalse
+		dataUploadedCon.Reason = reason
+		dataUploadedCon.Message = fmt.Sprintf("Failed to upload data: %v", err)
+		updateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR, &dataUploadedCon, insightsv1alpha1.Failed)
+		return err
+	}
+	klog.Infof("Insights archive successfully uploaded with InsightsRequestID: %s", insightsRequestID)
+
+	dataGatherCR.Status.InsightsRequestID = insightsRequestID
+	dataGatherCR, err = status.UpdateDataGatherConditions(ctx, insightsV1alphaCli, dataGatherCR, &dataUploadedCon)
+	if err != nil {
+		klog.Error(err)
+	}
+
+	// check if the archive/data was processed
+	processed, err := wasDataProcessed(ctx, insightsHTTPCli, insightsRequestID, configObserver.Config())
+	dataProcessedCon := status.DataProcessedCondition(metav1.ConditionTrue, "Processed", "")
+	if err != nil || !processed {
+		msg := fmt.Sprintf("Data was not processed in the console.redhat.com pipeline for the request %s", insightsRequestID)
+		if err != nil {
+			msg = fmt.Sprintf("%s: %v", msg, err)
+		}
+		klog.Info(msg)
+		dataProcessedCon.Status = metav1.ConditionFalse
+		dataProcessedCon.Reason = "Failure"
+		dataProcessedCon.Message = fmt.Sprintf("failed to process data in the given time: %v", err)
+	}
+	updateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR, &dataProcessedCon, insightsv1alpha1.Completed)
+	return nil
+}
+
+// gatherAndReporFunctions calls all the defined gatherers, calculates their status and returns map of resulting
+// gatherer functions reports
+func gatherAndReporFunctions(ctx context.Context, gatherersToRun []gatherers.Interface,
+	dataGatherCR *insightsv1alpha1.DataGather, rec *recorder.Recorder) map[string]gather.GathererFunctionReport {
 	allFunctionReports := make(map[string]gather.GathererFunctionReport)
-	for _, gatherer := range gatherers {
+	for _, gatherer := range gatherersToRun {
 		functionReports, err := gather.CollectAndRecordGatherer(ctx, gatherer, rec, dataGatherCR.Spec.Gatherers) // nolint: govet
 		if err != nil {
 			klog.Errorf("unable to process gatherer %v, error: %v", gatherer.GetName(), err)
@@ -217,58 +269,22 @@ func (d *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 		gs := status.CreateDataGatherGathererStatus(&fr)
 		dataGatherCR.Status.Gatherers = append(dataGatherCR.Status.Gatherers, gs)
 	}
+	return allFunctionReports
+}
 
-	// record data
-	conditions := []metav1.Condition{}
-	lastArchive, err := record(mapToArray(allFunctionReports), rec, recdriver, anonymizer)
+// updateDataGatherStatus updates DataGather status conditions with provided condition definition as well as
+// the DataGather state
+func updateDataGatherStatus(ctx context.Context, insightsClient insightsv1alpha1cli.InsightsV1alpha1Interface,
+	dataGatherCR *insightsv1alpha1.DataGather, conditionToUpdate *metav1.Condition, state insightsv1alpha1.DataGatherState) {
+	dataGatherUpdated, err := status.UpdateDataGatherState(ctx, insightsClient, dataGatherCR, state)
 	if err != nil {
-		conditions = append(conditions, status.DataRecordedCondition(metav1.ConditionFalse, "RecordingFailed",
-			fmt.Sprintf("Failed to record data: %v", err)))
-		_, recErr := status.UpdateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR, insightsv1alpha1.Failed, conditions)
-		if recErr != nil {
-			klog.Error("data recording failed and the update of DataGaher resource status failed as well: %v", recErr)
-		}
-		return err
+		klog.Error("Failed to update DataGather resource %s state: %v", dataGatherCR.Name, err)
 	}
-	conditions = append(conditions, status.DataRecordedCondition(metav1.ConditionTrue, "AsExpected", ""))
 
-	// upload data
-	insightsRequestID, statusCode, err := uploader.Upload(ctx, lastArchive)
-	reason := fmt.Sprintf("HttpStatus%d", statusCode)
+	_, err = status.UpdateDataGatherConditions(ctx, insightsClient, dataGatherUpdated, conditionToUpdate)
 	if err != nil {
-		klog.Error(err)
-		conditions = append(conditions, status.DataUploadedCondition(metav1.ConditionFalse, reason,
-			fmt.Sprintf("Failed to upload data: %v", err)))
-		_, updateErr := status.UpdateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR, insightsv1alpha1.Failed, conditions)
-		if updateErr != nil {
-			klog.Error("data upload failed and the update of DataGaher resource status failed as well: %v", updateErr)
-		}
-		return err
+		klog.Error("Failed to update DataGather resource %s conditions: %v", dataGatherCR.Name, err)
 	}
-	klog.Infof("Insights archive successfully uploaded with InsightsRequestID: %s", insightsRequestID)
-
-	dataGatherCR.Status.InsightsRequestID = insightsRequestID
-	conditions = append(conditions, status.DataUploadedCondition(metav1.ConditionTrue, reason, ""))
-
-	// check if the archive/data was processed
-	processed, err := wasDataProcessed(ctx, insightsHTTPCli, insightsRequestID, configObserver.Config())
-	if err != nil || !processed {
-		msg := fmt.Sprintf("Data was not processed in the console.redhat.com pipeline for the request %s", insightsRequestID)
-		if err != nil {
-			msg = fmt.Sprintf("%s: %v", msg, err)
-		}
-		klog.Info(msg)
-		conditions = append(conditions,
-			status.DataProcessedCondition(metav1.ConditionFalse, "Failure", fmt.Sprintf("failed to process data in the given time: %v", err)))
-	} else {
-		conditions = append(conditions, status.DataProcessedCondition(metav1.ConditionTrue, "Processed", ""))
-	}
-	_, err = status.UpdateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR, insightsv1alpha1.Completed, conditions)
-	if err != nil {
-		klog.Error(err)
-		return err
-	}
-	return nil
 }
 
 func mapToArray(m map[string]gather.GathererFunctionReport) []gather.GathererFunctionReport {
@@ -345,4 +361,15 @@ func wasDataProcessed(ctx context.Context,
 	}
 
 	return processingResp.Status == "processed", nil
+}
+
+// storagePathExists checks if the configured storagePath exists or not.
+// If not, non-nill error is returned.
+func (g *GatherJob) storagePathExists() error {
+	if _, err := os.Stat(g.StoragePath); err != nil && os.IsNotExist(err) {
+		if err = os.MkdirAll(g.StoragePath, 0777); err != nil {
+			return fmt.Errorf("can't create --path: %v", err)
+		}
+	}
+	return nil
 }

--- a/pkg/controller/gather_commands_test.go
+++ b/pkg/controller/gather_commands_test.go
@@ -18,7 +18,7 @@ type MockProcessingStatusClient struct {
 	response *http.Response
 }
 
-func (m *MockProcessingStatusClient) GetDataProcessingStatus(_ context.Context, _, _ string) (*http.Response, error) {
+func (m *MockProcessingStatusClient) GetWithPathParams(_ context.Context, _, _ string) (*http.Response, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -194,7 +194,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 			operatorClient.InsightsOperators(), kubeClient)
 		statusReporter.AddSources(periodicGather.Sources()...)
 	} else {
-		reportRetriever := insightsreport.NewWithTechPreview(insightsClient, secretConfigObserver, operatorClient.InsightsOperators())
+		reportRetriever := insightsreport.NewWithTechPreview(insightsClient, secretConfigObserver)
 		periodicGather = periodic.NewWithTechPreview(reportRetriever, secretConfigObserver,
 			insightsDataGatherObserver, gatherers, kubeClient, insightClient, operatorClient.InsightsOperators())
 		statusReporter.AddSources(periodicGather.Sources()...)

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -424,7 +424,7 @@ func TestCopyDataGatherStatusToOperatorStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "InsightsReport attribute is not updated when copying",
+			name: "InsightsReport attribute is updated when copying",
 			testedDataGather: &v1alpha1.DataGather{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Status: v1alpha1.DataGatherStatus{
@@ -444,6 +444,23 @@ func TestCopyDataGatherStatusToOperatorStatus(t *testing.T) {
 							},
 						},
 					},
+					InsightsReport: v1alpha1.InsightsReport{
+						DownloadedAt: metav1.Date(2020, 5, 13, 2, 40, 0, 0, time.UTC),
+						HealthChecks: []v1alpha1.HealthCheck{
+							{
+								Description: "healtheck ABC",
+								TotalRisk:   1,
+								State:       v1alpha1.HealthCheckEnabled,
+								AdvisorURI:  "test-uri",
+							},
+							{
+								Description: "healtheck XYZ",
+								TotalRisk:   2,
+								State:       v1alpha1.HealthCheckEnabled,
+								AdvisorURI:  "test-uri-1",
+							},
+						},
+					},
 				},
 			},
 			testedInsightsOperator: operatorv1.InsightsOperator{
@@ -451,22 +468,7 @@ func TestCopyDataGatherStatusToOperatorStatus(t *testing.T) {
 					Name: "cluster",
 				},
 				Status: operatorv1.InsightsOperatorStatus{
-					InsightsReport: operatorv1.InsightsReport{
-						DownloadedAt: metav1.Date(2020, 5, 13, 2, 40, 0, 0, time.UTC),
-						HealthChecks: []operatorv1.HealthCheck{
-							{
-								Description: "healtheck ABC",
-								TotalRisk:   1,
-								State:       operatorv1.HealthCheckEnabled,
-								AdvisorURI:  "test-uri",
-							},
-							{
-								Description: "healtheck XYZ",
-								TotalRisk:   2,
-								State:       operatorv1.HealthCheckEnabled,
-							},
-						},
-					},
+					InsightsReport: operatorv1.InsightsReport{},
 					GatherStatus: operatorv1.GatherStatus{
 						LastGatherTime:     metav1.Date(2020, 5, 12, 2, 0, 0, 0, time.UTC),
 						LastGatherDuration: metav1.Duration{Duration: 5 * time.Minute},
@@ -504,6 +506,7 @@ func TestCopyDataGatherStatusToOperatorStatus(t *testing.T) {
 								Description: "healtheck XYZ",
 								TotalRisk:   2,
 								State:       operatorv1.HealthCheckEnabled,
+								AdvisorURI:  "test-uri-1",
 							},
 						},
 					},
@@ -877,7 +880,7 @@ func TestWasDataGatherSuccessful(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockController := NewWithTechPreview(nil, nil, nil, nil, nil, nil, nil)
-			successful := mockController.wasDataGatherSuccessful(tt.testedDataGather)
+			successful := mockController.wasDataUploaded(tt.testedDataGather)
 			assert.Equal(t, tt.expectSuccessful, successful)
 			summary, _ := mockController.Sources()[0].CurrentStatus()
 			assert.Equal(t, tt.expectedSummary, summary)

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -798,11 +798,10 @@ func TestPeriodicPrune(t *testing.T) {
 	}
 }
 
-func TestWasDataGatherSuccessful(t *testing.T) {
+func TestWasDataUploaded(t *testing.T) {
 	tests := []struct {
 		name             string
 		testedDataGather *v1alpha1.DataGather
-		expectSuccessful bool
 		expectedSummary  controllerstatus.Summary
 	}{
 		{
@@ -818,11 +817,9 @@ func TestWasDataGatherSuccessful(t *testing.T) {
 					},
 				},
 			},
-			expectSuccessful: true,
 			expectedSummary: controllerstatus.Summary{
 				Operation: controllerstatus.Uploading,
 				Healthy:   true,
-				Count:     1,
 			},
 		},
 		{
@@ -839,7 +836,6 @@ func TestWasDataGatherSuccessful(t *testing.T) {
 					},
 				},
 			},
-			expectSuccessful: false,
 			expectedSummary: controllerstatus.Summary{
 				Operation: controllerstatus.Uploading,
 				Healthy:   false,
@@ -865,12 +861,11 @@ func TestWasDataGatherSuccessful(t *testing.T) {
 					},
 				},
 			},
-			expectSuccessful: false,
 			expectedSummary: controllerstatus.Summary{
 				Operation: controllerstatus.Uploading,
 				Healthy:   false,
 				Count:     5,
-				Reason:    "DataUploadedConditionNotAvailable",
+				Reason:    dataUplodedConditionNotAvailable,
 				Message: fmt.Sprintf("did not find any %q condition in the test-dg dataGather resource",
 					status.DataUploaded),
 			},
@@ -880,9 +875,7 @@ func TestWasDataGatherSuccessful(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockController := NewWithTechPreview(nil, nil, nil, nil, nil, nil, nil)
-			successful := mockController.wasDataUploaded(tt.testedDataGather)
-			assert.Equal(t, tt.expectSuccessful, successful)
-			summary, _ := mockController.Sources()[0].CurrentStatus()
+			summary := mockController.dataUploadStatus(tt.testedDataGather)
 			assert.Equal(t, tt.expectedSummary, summary)
 		})
 	}

--- a/pkg/insights/insightsclient/requests.go
+++ b/pkg/insights/insightsclient/requests.go
@@ -303,7 +303,9 @@ func (c *Client) RecvClusterTransfer(endpoint string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
-func (c *Client) GetDataProcessingStatus(ctx context.Context, endpoint, requestID string) (*http.Response, error) {
+// GetWithPathParams makes an HTTP GET request to the specified endpoint using the specified "requestID" as
+// a part of the endpoint path
+func (c *Client) GetWithPathParams(ctx context.Context, endpoint, requestID string) (*http.Response, error) {
 	cv, err := c.GetClusterVersion()
 	if apierrors.IsNotFound(err) {
 		return nil, ErrWaitingForVersion

--- a/pkg/insights/insightsclient/requests.go
+++ b/pkg/insights/insightsclient/requests.go
@@ -315,8 +315,7 @@ func (c *Client) GetWithPathParams(ctx context.Context, endpoint, requestID stri
 	}
 
 	endpoint = fmt.Sprintf(endpoint, cv.Spec.ClusterID, requestID)
-	klog.Infof("Checking data processing status for request ID: %s", requestID)
-	klog.Infof("Endpoint: %s", endpoint)
+	klog.Infof("Making HTTP GET request at: %s", endpoint)
 
 	req, err := c.prepareRequest(ctx, http.MethodGet, endpoint, cv)
 	if err != nil {

--- a/pkg/insights/insightsreport/insightsreport_test.go
+++ b/pkg/insights/insightsreport/insightsreport_test.go
@@ -1,13 +1,17 @@
 package insightsreport
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/insights-operator/pkg/config"
+	"github.com/openshift/insights-operator/pkg/controllerstatus"
 	"github.com/openshift/insights-operator/pkg/insights/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -309,9 +313,131 @@ func Test_extractErrorKeyFromRuleData(t *testing.T) {
 	}
 }
 
+func TestPullReportTechpreview(t *testing.T) {
+	tests := []struct {
+		name          string
+		report        *types.InsightsAnalysisReport
+		statusCode    int
+		conf          *config.Controller
+		statusSummary controllerstatus.Summary
+		mockClientErr error
+		expectedErr   error
+	}{
+		{
+			name: "Insights Analysis Report retrieved",
+			report: &types.InsightsAnalysisReport{
+				ClusterID: "test-cluster-ID",
+				RequestID: "test-request-ID",
+				Recommendations: []types.Recommendation{
+					{
+						ErrorKey:    "test-error-key-1",
+						Description: "lorem ipsum description",
+						TotalRisk:   1,
+						RuleFQDN:    "test.err.key1",
+					},
+					{
+						ErrorKey:    "test-error-key-2",
+						Description: "lorem ipsum description",
+						TotalRisk:   2,
+						RuleFQDN:    "test.err.key2",
+					},
+					{
+						ErrorKey:    "test-error-key-3",
+						Description: "lorem ipsum description",
+						TotalRisk:   3,
+						RuleFQDN:    "test.err.key3",
+					},
+				},
+			},
+			statusCode: http.StatusOK,
+			conf: &config.Controller{
+				ReportEndpointTechPreview: "non-empty-endpoint",
+			},
+			statusSummary: controllerstatus.Summary{
+				Healthy: true,
+			},
+			mockClientErr: nil,
+			expectedErr:   nil,
+		},
+		{
+			name:       "Empty report endpoint",
+			report:     nil,
+			statusCode: 0,
+			conf: &config.Controller{
+				ReportEndpointTechPreview: "",
+			},
+			statusSummary: controllerstatus.Summary{
+				Healthy: true,
+			},
+			mockClientErr: nil,
+			expectedErr:   nil,
+		},
+		{
+			name:       "Insights Analysis Report not retrieved, because of error",
+			report:     nil,
+			statusCode: 0,
+			conf: &config.Controller{
+				ReportEndpointTechPreview: "non-empty-endpoint",
+			},
+			statusSummary: controllerstatus.Summary{
+				Healthy: false,
+			},
+			mockClientErr: fmt.Errorf("test error"),
+			expectedErr:   fmt.Errorf("test error"),
+		},
+		{
+			name:       "Insights Analysis Report not retrieved, because of HTTP 404 response",
+			report:     nil,
+			statusCode: http.StatusNotFound,
+			conf: &config.Controller{
+				ReportEndpointTechPreview: "non-empty-endpoint",
+			},
+			statusSummary: controllerstatus.Summary{
+				Healthy: false,
+			},
+			mockClientErr: nil,
+			expectedErr:   fmt.Errorf("Failed to download the latest report: HTTP 404 Not Found"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.report)
+			assert.NoError(t, err)
+			testController := Controller{
+				client: &mockInsightsClient{
+					response: http.Response{
+						StatusCode: tt.statusCode,
+						Status:     http.StatusText(tt.statusCode),
+						Body:       io.NopCloser(bytes.NewReader(data)),
+					},
+					err: tt.mockClientErr,
+				},
+				configurator: &config.MockSecretConfigurator{
+					Conf: tt.conf,
+				},
+				StatusController: controllerstatus.New("test-insightsreport"),
+			}
+
+			report, err := testController.PullReportTechpreview("test-request-id")
+			assert.Equal(t, tt.expectedErr, err)
+			summary, _ := testController.StatusController.CurrentStatus()
+			assert.Equal(t, tt.statusSummary.Healthy, summary.Healthy)
+			if report == nil || report.Recommendations == nil {
+				return
+			}
+			assert.Equal(t, tt.report.Recommendations, report.Recommendations)
+			assert.Equal(t, tt.report.ClusterID, report.ClusterID)
+			assert.Equal(t, tt.report.RequestID, report.RequestID)
+		})
+	}
+}
+
 type mockInsightsClient struct {
 	clusterVersion *v1.ClusterVersion
 	metricsName    string
+	response       http.Response
+	err            error
 }
 
 func (c *mockInsightsClient) GetClusterVersion() (*v1.ClusterVersion, error) {
@@ -326,5 +452,5 @@ func (c *mockInsightsClient) RecvReport(_ context.Context, _ string) (*http.Resp
 }
 
 func (c *mockInsightsClient) GetWithPathParams(ctx context.Context, endpoint, requestID string) (*http.Response, error) {
-	return nil, nil
+	return &c.response, c.err
 }

--- a/pkg/insights/insightsreport/insightsreport_test.go
+++ b/pkg/insights/insightsreport/insightsreport_test.go
@@ -324,3 +324,7 @@ func (c *mockInsightsClient) IncrementRecvReportMetric(_ int) {
 func (c *mockInsightsClient) RecvReport(_ context.Context, _ string) (*http.Response, error) {
 	return nil, nil
 }
+
+func (c *mockInsightsClient) GetWithPathParams(ctx context.Context, endpoint, requestID string) (*http.Response, error) {
+	return nil, nil
+}

--- a/pkg/insights/types/types.go
+++ b/pkg/insights/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 // Timestamp represents any timestamp in a form gathered from database
 type Timestamp string
 
@@ -11,6 +13,11 @@ type ErrorKey string
 
 // UserVote is a type for user's vote
 type UserVote int
+
+// Response represents the Smart Proxy report response structure
+type Response struct {
+	Report SmartProxyReport `json:"report"`
+}
 
 // ReportResponseMeta contains metadata about the report
 type ReportResponseMeta struct {
@@ -56,4 +63,21 @@ type InsightsRecommendation struct {
 	ErrorKey    string
 	Description string
 	TotalRisk   int
+}
+
+type Recommendation struct {
+	ErrorKey    string `json:"error_key"`
+	Description string `json:"description"`
+	TotalRisk   int    `json:"total_risk"`
+	RuleFQDN    string `json:"rule_fqdn"`
+}
+
+// InsightsAnalysisReport is a type reflecting json structure
+// of the insights-results-aggregator response. This is currently
+// used only in TechPreview
+type InsightsAnalysisReport struct {
+	DownloadedAt    metav1.Time
+	ClusterID       string           `json:"cluster"`
+	Recommendations []Recommendation `json:"report"`
+	RequestID       string           `json:"requestID"`
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This introduces a new `reportEndpointTechPreview` attribute, which replaces the endpoint for donwloading the Insights analysis reports in the techpreview. First we check if the data was processed, and if it was, it tries to download the corresponding Insights analytics report immediately (the Insights request ID is used), if not, we do nothing. 

The response from the new endpoint is different (acutally more light) so there are new types defined (to be able to unmarshal the data). The Insights report is updated in the corresponding DataGather custom resource as well as in the `cluster` `insightsoperator.operator.openshift.io` resource.  

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->



## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
