### PR TITLE
OCPBUGS-18002: DVO metrics gatherer - use UIDs only when DVO deployed in 'openshift-deployment-validation-operator' namespace

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -707,6 +707,9 @@ None
 Collects metrics from the Deployment Validation Operator's
 metrics service. The metrics are fetched via the /metrics endpoint and
 filtered to only include those with a `deployment_validation_operator_` prefix.
+If the DVO service is deployed in a namespace other than `openshift-deployment-validation-operator',
+then the names of the workloads (e.g., namespace, deployment) are collected.
+Otherwise, only the UIDs of those resources are collected.
 
 ### API Reference
 None

--- a/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
+++ b/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
@@ -28,6 +28,9 @@ const (
 // GatherDVOMetrics Collects metrics from the Deployment Validation Operator's
 // metrics service. The metrics are fetched via the /metrics endpoint and
 // filtered to only include those with a `deployment_validation_operator_` prefix.
+// If the DVO service is deployed in a namespace other than `openshift-deployment-validation-operator',
+// then the names of the workloads (e.g., namespace, deployment) are collected.
+// Otherwise, only the UIDs of those resources are collected.
 //
 // ### API Reference
 // None
@@ -76,9 +79,8 @@ func gatherDVOMetrics(
 	for svcIdx := range serviceList.Items {
 		// Use pointer to make gocritic happy and avoid copying the whole Service struct.
 		service := &serviceList.Items[svcIdx]
-		if service.Namespace == managedDVONamespaceName {
-			useUIDs = true
-		}
+		useUIDs = service.Namespace == managedDVONamespaceName
+
 		for _, port := range service.Spec.Ports {
 			apiURL := url.URL{
 				Scheme: "http",


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This is changing the logic for filtering out deployment names, namespace names, etc. to be applied only in case the DVO service is deployed in the `openshift-deployment-validation-operator` namespace.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
