### PR TITLE
[release-4.12] OCPBUGS-19405: workload info gatherer, add external image repo

### DIFF
--- a/docs/insights-archive-sample/config/workload_info.json
+++ b/docs/insights-archive-sample/config/workload_info.json
@@ -22,7 +22,8 @@
         "sha256:1bd85e07834910cad1fda7967cfd86ada69377ba0baf875683e7739d8de6d1b0"
       ],
       "firstCommand": "icTsn2s_EIax",
-      "firstArg": "2v1NneeWoS_9"
+      "firstArg": "2v1NneeWoS_9",
+      "repository": "2W0Xq9hxQzho"
     },
     "sha256:7c6d0a0fed7ddb95550623aa23c434446fb99abef18e6d57b8b12add606efde8": {
       "layerIDs": [

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// nolint: funlen
 func TestLoadConfig(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/gatherers/workloads/types.go
+++ b/pkg/gatherers/workloads/types.go
@@ -36,6 +36,9 @@ type workloadImage struct {
 	// FirstArg is a hash of the first value in the command array, if any
 	// was set. Normalized to be consistent with pods
 	FirstArg string `json:"firstArg,omitempty"`
+	// Repository is a hash of an external image URL
+	// It is gathered when the image is not from Red Hat domain
+	Repository string `json:"repository,omitempty"`
 }
 
 // Empty returns true if the image has no contents and can be ignored.

--- a/pkg/gatherers/workloads/workloads_info.go
+++ b/pkg/gatherers/workloads/workloads_info.go
@@ -493,8 +493,14 @@ func calculateWorkloadInfo(h hash.Hash, image *imagev1.Image) workloadImage {
 	for _, layer := range image.DockerImageLayers {
 		layers = append(layers, layer.Name)
 	}
+
 	info := workloadImage{
 		LayerIDs: layers,
+	}
+
+	// we only need repo URLs from outside RH
+	if repo := getExternalImageRepo(image.DockerImageReference); repo != "" {
+		info.Repository = workloadHashString(h, repo)
 	}
 
 	if err := imageutil.ImageWithMetadata(image); err != nil {
@@ -570,4 +576,12 @@ func workloadImageAdd(imageID string, image workloadImage) {
 	workloadSizeLock.Lock()
 	defer workloadSizeLock.Unlock()
 	workloadImageLRU.Add(imageID, image)
+}
+
+// getExternalImageRepo returns image URLs if they are not from Red Hat domain
+func getExternalImageRepo(s string) (repo string) {
+	if !strings.Contains(s, "redhat") {
+		repo = s
+	}
+	return
 }

--- a/pkg/gatherers/workloads/workloads_info_test.go
+++ b/pkg/gatherers/workloads/workloads_info_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
 )
 
 // nolint: funlen, gocyclo, gosec
@@ -147,5 +148,34 @@ func Test_gatherWorkloadInfo(t *testing.T) {
 			float64(totalImagesWithData)/float64(pods.ImageCount)*100,
 			workloadImageLRU.Len(),
 		)
+	}
+}
+
+func Test_getExternalImageRepo(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "Image repository under the Red Hat domain will be ignored",
+			url:      "registry.redhat.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc",
+			expected: "",
+		},
+		{
+			name:     "Image repository outside the Red Hat domain is returned",
+			url:      "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc",
+			expected: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// When
+			test := getExternalImageRepo(testCase.url)
+
+			// Assert
+			assert.Equal(t, testCase.expected, test)
+		})
 	}
 }


### PR DESCRIPTION
This is manual cherry-pick of https://github.com/openshift/insights-operator/pull/811