### PR TITLE
OCPBUGS-20320: fix error message when the data processing was not suc…

### DIFF
--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -329,12 +329,16 @@ func wasDataProcessed(ctx context.Context,
 		if err != nil {
 			return false, err
 		}
-		if resp.StatusCode == http.StatusOK || retryCounter == 2 {
-			return true, nil
+		if resp.StatusCode != http.StatusOK {
+			if retryCounter == 2 {
+				err := fmt.Errorf("HTTP status message: %s", http.StatusText(resp.StatusCode))
+				return false, err
+			}
+			klog.Infof("Received HTTP status code %d, trying again in %s", resp.StatusCode, delay)
+			retryCounter++
+			return false, nil
 		}
-		klog.Infof("Received HTTP status code %d, trying again in %s", resp.StatusCode, delay)
-		retryCounter++
-		return false, nil
+		return true, nil
 	})
 
 	if err != nil {

--- a/pkg/controller/gather_commands_test.go
+++ b/pkg/controller/gather_commands_test.go
@@ -52,7 +52,19 @@ func TestWasDataProcessed(t *testing.T) {
 				err: nil,
 			},
 			expectedProcessed: false,
-			expectedErr:       nil,
+			expectedErr:       fmt.Errorf("HTTP status message: %s", http.StatusText(http.StatusNotFound)),
+		},
+		{
+			name: "HTTP 404 response and existing body",
+			mockClient: MockProcessingStatusClient{
+				response: &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("test message")),
+				},
+				err: nil,
+			},
+			expectedProcessed: false,
+			expectedErr:       fmt.Errorf("HTTP status message: %s", http.StatusText(http.StatusNotFound)),
 		},
 		{
 			name: "data not processed",


### PR DESCRIPTION
…cessful

<!-- Short description of the PR. What does it do? -->

This provides better and more meaningful error message when the techpreview datagather job receives non-HTTP-200 response code from the processing status endpoint - info whether the archive was processed or not in console dot. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-19387
https://access.redhat.com/solutions/???
