### PR TITLE
CCXDEV-11152: docs(openshift_apiserver_operator_logs): explicit namespace at archiv…

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1370,7 +1370,7 @@ Collects logs from `openshift-apiserver-operator` with following substrings:
 - [docs/insights-archive-sample/config/pod/openshift-apiserver-operator/logs/openshift-apiserver-operator-6ddb679b87-4kn55/errors.log](./insights-archive-sample/config/pod/openshift-apiserver-operator/logs/openshift-apiserver-operator-6ddb679b87-4kn55/errors.log)
 
 ### Location in archive
-- `config/pod/{namespace-name}/logs/{pod-name}/errors.log`
+- `config/pod/openshift-apiserver-operator/logs/{pod-name}/errors.log`
 
 ### Config ID
 `clusterconfig/openshift_apiserver_operator_logs`

--- a/pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_apiserver_operator_logs.go
@@ -21,7 +21,7 @@ import (
 // - docs/insights-archive-sample/config/pod/openshift-apiserver-operator/logs/openshift-apiserver-operator-6ddb679b87-4kn55/errors.log
 //
 // ### Location in archive
-// - `config/pod/{namespace-name}/logs/{pod-name}/errors.log`
+// - `config/pod/openshift-apiserver-operator/logs/{pod-name}/errors.log`
 //
 // ### Config ID
 // `clusterconfig/openshift_apiserver_operator_logs`


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR updates the documentation about the gatherer resources to explicit some gathered namespace at the documentation.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

N/A

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `docs/gathered-data.md`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-11152
