### PR TITLE
extends obfuscation options in the configmap

### DIFF
--- a/pkg/anonymization/anonymizer_test.go
+++ b/pkg/anonymization/anonymizer_test.go
@@ -120,11 +120,15 @@ func getAnonymizer(t *testing.T) *Anonymizer {
 		"127.0.0.0/8",
 		"192.168.0.0/16",
 	}
-	mockSecretConfigurator := config.NewMockSecretConfigurator(&config.Controller{
-		EnableGlobalObfuscation: true,
+	mockConfigMapConfigurator := config.NewMockConfigMapConfigurator(&config.InsightsConfiguration{
+		DataReporting: config.DataReporting{
+			Obfuscation: config.Obfuscation{
+				config.Networking,
+			},
+		},
 	})
 	anonymizer, err := NewAnonymizer(clusterBaseDomain,
-		networks, kubefake.NewSimpleClientset().CoreV1().Secrets(secretNamespace), mockSecretConfigurator, v1alpha1.ObfuscateNetworking)
+		networks, kubefake.NewSimpleClientset().CoreV1().Secrets(secretNamespace), mockConfigMapConfigurator, v1alpha1.ObfuscateNetworking)
 	assert.NoError(t, err)
 
 	return anonymizer
@@ -321,15 +325,22 @@ func TestAnonymizer_NewAnonymizerFromConfigClient(t *testing.T) {
 
 	// test that everything was initialized correctly
 
+	mockConfigMapConfigurator := config.NewMockConfigMapConfigurator(&config.InsightsConfiguration{
+		DataReporting: config.DataReporting{
+			Obfuscation: config.Obfuscation{
+				config.Networking,
+			},
+		},
+	})
+
 	anonymizer, err := NewAnonymizerFromConfigClient(
-		context.TODO(),
+		context.Background(),
 		kubeClient,
 		kubeClient,
 		configClient,
 		networkClient,
-		config.NewMockSecretConfigurator(&config.Controller{
-			EnableGlobalObfuscation: true,
-		}), v1alpha1.ObfuscateNetworking,
+		mockConfigMapConfigurator,
+		v1alpha1.ObfuscateNetworking,
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, anonymizer)

--- a/pkg/config/configobserver/config_aggregator.go
+++ b/pkg/config/configobserver/config_aggregator.go
@@ -130,6 +130,10 @@ func (c *ConfigAggregator) merge(defaultCfg, newCfg *config.InsightsConfiguratio
 	if newCfg.DataReporting.StoragePath != "" {
 		defaultCfg.DataReporting.StoragePath = newCfg.DataReporting.StoragePath
 	}
+
+	if len(newCfg.DataReporting.Obfuscation) > 0 {
+		defaultCfg.DataReporting.Obfuscation = append(defaultCfg.DataReporting.Obfuscation, newCfg.DataReporting.Obfuscation...)
+	}
 	c.config = defaultCfg
 }
 
@@ -186,6 +190,11 @@ func (c *ConfigAggregator) ConfigChanged() (configCh <-chan struct{}, closeFn fu
 
 func (c *ConfigAggregator) legacyConfigToInsightsConfiguration() *config.InsightsConfiguration {
 	legacyConfig := c.legacyConfigurator.Config()
+	var obfuscation config.Obfuscation
+	if legacyConfig.EnableGlobalObfuscation {
+		obfuscation = config.Obfuscation{config.Networking}
+	}
+
 	return &config.InsightsConfiguration{
 		DataReporting: config.DataReporting{
 			Interval:                    legacyConfig.Interval,
@@ -200,6 +209,7 @@ func (c *ConfigAggregator) legacyConfigToInsightsConfiguration() *config.Insight
 			Enabled:            legacyConfig.Report,
 			StoragePath:        legacyConfig.StoragePath,
 			ReportPullingDelay: legacyConfig.ReportPullingDelay,
+			Obfuscation:        obfuscation,
 		},
 	}
 }

--- a/pkg/config/configobserver/config_aggregator_test.go
+++ b/pkg/config/configobserver/config_aggregator_test.go
@@ -29,6 +29,7 @@ func TestMergeStatically(t *testing.T) {
 				ReportEndpoint:              "http://reportendpoint.here",
 				Interval:                    2 * time.Hour,
 				ConditionalGathererEndpoint: "http://conditionalendpoint.here",
+				EnableGlobalObfuscation:     true,
 			},
 			expectedConfig: &config.InsightsConfiguration{
 				DataReporting: config.DataReporting{
@@ -38,6 +39,7 @@ func TestMergeStatically(t *testing.T) {
 					DownloadEndpoint:            "http://reportendpoint.here",
 					Interval:                    2 * time.Hour,
 					ConditionalGathererEndpoint: "http://conditionalendpoint.here",
+					Obfuscation:                 config.Obfuscation{config.Networking},
 				},
 			},
 		},
@@ -57,7 +59,9 @@ dataReporting:
   downloadEndpoint: https://overriden.download/endpoint
   conditionalGathererEndpoint: https://overriden.conditional/endpoint
   processingStatusEndpoint: https://overriden.status/endpoint
-  downloadEndpointTechPreview: https://overriden.downloadtechpreview/endpoint`,
+  downloadEndpointTechPreview: https://overriden.downloadtechpreview/endpoint
+  obfuscation:
+  - workload_names`,
 				},
 			},
 			legacyConfig: config.Controller{
@@ -69,6 +73,7 @@ dataReporting:
 				ConditionalGathererEndpoint: "http://conditionalendpoint.here",
 				ProcessingStatusEndpoint:    "http://statusendpoint.here",
 				ReportEndpointTechPreview:   "http://downloadtpendpoint.here",
+				EnableGlobalObfuscation:     true,
 			},
 			expectedConfig: &config.InsightsConfiguration{
 				DataReporting: config.DataReporting{
@@ -80,6 +85,7 @@ dataReporting:
 					ConditionalGathererEndpoint: "https://overriden.conditional/endpoint",
 					ProcessingStatusEndpoint:    "https://overriden.status/endpoint",
 					DownloadEndpointTechPreview: "https://overriden.downloadtechpreview/endpoint",
+					Obfuscation:                 config.Obfuscation{config.Networking, config.WorkloadNames},
 				},
 			},
 		},
@@ -144,6 +150,7 @@ func TestMergeUsingInformer(t *testing.T) {
 				ReportEndpoint:              "http://reportendpoint.here",
 				Interval:                    2 * time.Hour,
 				ConditionalGathererEndpoint: "http://conditionalendpoint.here",
+				EnableGlobalObfuscation:     true,
 			},
 			expectedConfig: &config.InsightsConfiguration{
 				DataReporting: config.DataReporting{
@@ -153,6 +160,7 @@ func TestMergeUsingInformer(t *testing.T) {
 					DownloadEndpoint:            "http://reportendpoint.here",
 					Interval:                    2 * time.Hour,
 					ConditionalGathererEndpoint: "http://conditionalendpoint.here",
+					Obfuscation:                 config.Obfuscation{config.Networking},
 				},
 			},
 		},
@@ -165,6 +173,7 @@ func TestMergeUsingInformer(t *testing.T) {
 					StoragePath:                 "/var/lib/test",
 					DownloadEndpoint:            "https://overriden.download/endpoint",
 					ConditionalGathererEndpoint: "https://overriden.conditional/endpoint",
+					Obfuscation:                 config.Obfuscation{config.WorkloadNames},
 				},
 			},
 			legacyConfig: config.Controller{
@@ -174,6 +183,7 @@ func TestMergeUsingInformer(t *testing.T) {
 				ReportEndpoint:              "http://reportendpoint.here",
 				Interval:                    2 * time.Hour,
 				ConditionalGathererEndpoint: "http://conditionalendpoint.here",
+				EnableGlobalObfuscation:     true,
 			},
 			expectedConfig: &config.InsightsConfiguration{
 				DataReporting: config.DataReporting{
@@ -183,6 +193,7 @@ func TestMergeUsingInformer(t *testing.T) {
 					DownloadEndpoint:            "https://overriden.download/endpoint",
 					Interval:                    1 * time.Hour,
 					ConditionalGathererEndpoint: "https://overriden.conditional/endpoint",
+					Obfuscation:                 config.Obfuscation{config.Networking, config.WorkloadNames},
 				},
 			},
 		},

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -17,13 +17,14 @@ type InsightsConfigurationSerialized struct {
 }
 
 type DataReportingSerialized struct {
-	Interval                    string `json:"interval,omitempty"`
-	UploadEndpoint              string `json:"uploadEndpoint,omitempty"`
-	DownloadEndpoint            string `json:"downloadEndpoint,omitempty"`
-	DownloadEndpointTechPreview string `json:"downloadEndpointTechPreview,omitempty"`
-	StoragePath                 string `json:"storagePath,omitempty"`
-	ConditionalGathererEndpoint string `json:"conditionalGathererEndpoint,omitempty"`
-	ProcessingStatusEndpoint    string `json:"processingStatusEndpoint"`
+	Interval                    string      `json:"interval,omitempty"`
+	UploadEndpoint              string      `json:"uploadEndpoint,omitempty"`
+	DownloadEndpoint            string      `json:"downloadEndpoint,omitempty"`
+	DownloadEndpointTechPreview string      `json:"downloadEndpointTechPreview,omitempty"`
+	StoragePath                 string      `json:"storagePath,omitempty"`
+	ConditionalGathererEndpoint string      `json:"conditionalGathererEndpoint,omitempty"`
+	ProcessingStatusEndpoint    string      `json:"processingStatusEndpoint,omitempty"`
+	Obfuscation                 Obfuscation `json:"obfuscation,omitempty"`
 }
 
 // InsightsConfiguration is a type representing actual Insights
@@ -46,7 +47,17 @@ type DataReporting struct {
 	ConditionalGathererEndpoint string
 	ReportPullingDelay          time.Duration
 	ProcessingStatusEndpoint    string
+	Obfuscation                 Obfuscation
 }
+
+const (
+	Networking    ObfuscationValue = "networking"
+	WorkloadNames ObfuscationValue = "workload_names"
+)
+
+type ObfuscationValue string
+
+type Obfuscation []ObfuscationValue
 
 // ToConfig reads and pareses the actual serialized configuration from "InsightsConfigurationSerialized"
 // and returns the "InsightsConfiguration".
@@ -59,6 +70,7 @@ func (i *InsightsConfigurationSerialized) ToConfig() *InsightsConfiguration {
 			StoragePath:                 i.DataReporting.StoragePath,
 			ConditionalGathererEndpoint: i.DataReporting.ConditionalGathererEndpoint,
 			ProcessingStatusEndpoint:    i.DataReporting.ProcessingStatusEndpoint,
+			Obfuscation:                 i.DataReporting.Obfuscation,
 		},
 	}
 	if i.DataReporting.Interval != "" {
@@ -75,16 +87,18 @@ func (i *InsightsConfigurationSerialized) ToConfig() *InsightsConfiguration {
 }
 
 func (i *InsightsConfiguration) String() string {
-	s := fmt.Sprintf(`interval=%s, 
-		upload_endpoint=%s,
-		storage_path=%s, 
-		download_endpoint=%s, 
-		conditional_gatherer_endpoint=%s`,
+	s := fmt.Sprintf(`upload_interval=%s, 
+	upload_endpoint=%s,
+	storage_path=%s, 
+	download_endpoint=%s, 
+	conditional_gatherer_endpoint=%s,
+	obfuscation=%s`,
 		i.DataReporting.Interval,
 		i.DataReporting.UploadEndpoint,
 		i.DataReporting.StoragePath,
 		i.DataReporting.DownloadEndpoint,
 		i.DataReporting.ConditionalGathererEndpoint,
+		i.DataReporting.Obfuscation,
 	)
 	return s
 }

--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -73,7 +73,7 @@ func (g *GatherJob) Gather(ctx context.Context, kubeConfig, protoKubeConfig *res
 
 	// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
 	anonymizer, err := anonymization.NewAnonymizerFromConfig(
-		ctx, gatherKubeConfig, gatherProtoKubeConfig, protoKubeConfig, configObserver, "")
+		ctx, gatherKubeConfig, gatherProtoKubeConfig, protoKubeConfig, configAggregator, "")
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (g *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 	configAggregator := configobserver.NewStaticConfigAggregator(configObserver, kubeClient)
 	// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
 	anonymizer, err := anonymization.NewAnonymizerFromConfig(
-		ctx, gatherKubeConfig, gatherProtoKubeConfig, protoKubeConfig, configObserver, dataGatherCR.Spec.DataPolicy)
+		ctx, gatherKubeConfig, gatherProtoKubeConfig, protoKubeConfig, configAggregator, dataGatherCR.Spec.DataPolicy)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -178,7 +178,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	if !insightsConfigAPIEnabled {
 		// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
 		anonymizer, err = anonymization.NewAnonymizerFromConfig(ctx, gatherKubeConfig,
-			gatherProtoKubeConfig, controller.ProtoKubeConfig, secretConfigObserver, "")
+			gatherProtoKubeConfig, controller.ProtoKubeConfig, configAggregator, "")
 		if err != nil {
 			// in case of an error anonymizer will be nil and anonymization will be just skipped
 			klog.Errorf(anonymization.UnableToCreateAnonymizerErrorMessage, err)

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -207,10 +207,6 @@ func Test_Controller_FailingGatherer(t *testing.T) {
 }
 
 func getMocksForPeriodicTest(listGatherers []gatherers.Interface, interval time.Duration) (*Controller, *recorder.MockRecorder, error) {
-	mockConfigurator := config.MockSecretConfigurator{Conf: &config.Controller{
-		Report:   true,
-		Interval: interval,
-	}}
 	mockConfigMapConfigurator := config.NewMockConfigMapConfigurator(&config.InsightsConfiguration{
 		DataReporting: config.DataReporting{
 			Enabled:  true,
@@ -218,7 +214,7 @@ func getMocksForPeriodicTest(listGatherers []gatherers.Interface, interval time.
 		},
 	})
 	mockRecorder := recorder.MockRecorder{}
-	mockAnonymizer, err := anonymization.NewAnonymizer("", []string{}, nil, &mockConfigurator, "")
+	mockAnonymizer, err := anonymization.NewAnonymizer("", []string{}, nil, mockConfigMapConfigurator, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -316,10 +316,14 @@ func TestCollectAndRecordGatherer(t *testing.T) {
 		SomeField: "some_value",
 	}
 	mockRecorder := &recorder.MockRecorder{}
-	mockSecretConfigurator := config.NewMockSecretConfigurator(&config.Controller{
-		EnableGlobalObfuscation: true,
+	mockConfigMapConfigurator := config.NewMockConfigMapConfigurator(&config.InsightsConfiguration{
+		DataReporting: config.DataReporting{
+			Obfuscation: config.Obfuscation{
+				config.Networking,
+			},
+		},
 	})
-	anonymizer, err := anonymization.NewAnonymizer("", nil, nil, mockSecretConfigurator, "")
+	anonymizer, err := anonymization.NewAnonymizer("", nil, nil, mockConfigMapConfigurator, "")
 	assert.NoError(t, err)
 
 	functionReports, err := CollectAndRecordGatherer(context.Background(), gatherer, mockRecorder, nil)
@@ -417,7 +421,8 @@ func TestCollectAndRecordGathererError(t *testing.T) {
 		err,
 		`function "errors" failed with an error`,
 	)
-	anonymizer, err := anonymization.NewAnonymizer("", []string{}, nil, config.NewMockSecretConfigurator(nil), "")
+	anonymizer, err := anonymization.NewAnonymizer("", []string{}, nil,
+		config.NewMockConfigMapConfigurator(&config.InsightsConfiguration{}), "")
 	assert.NoError(t, err)
 	err = RecordArchiveMetadata(functionReports, mockRecorder, anonymizer)
 	assert.NoError(t, err)
@@ -507,7 +512,8 @@ func TestCollectAndRecordGathererDuplicateRecords(t *testing.T) {
 		}},
 	}}
 	mockDriver := &MockDriver{}
-	anonymizer, err := anonymization.NewAnonymizer("", []string{}, nil, config.NewMockSecretConfigurator(nil), "")
+	anonymizer, err := anonymization.NewAnonymizer("", []string{}, nil,
+		config.NewMockConfigMapConfigurator(&config.InsightsConfiguration{}), "")
 	assert.NoError(t, err)
 	rec := recorder.New(mockDriver, time.Second, anonymizer)
 

--- a/pkg/gatherers/clusterconfig/gather_cluster_operator_pods_and_events.go
+++ b/pkg/gatherers/clusterconfig/gather_cluster_operator_pods_and_events.go
@@ -90,8 +90,8 @@ func (g *Gatherer) GatherClusterOperatorPodsAndEvents(ctx context.Context) ([]re
 	if err != nil {
 		return nil, []error{err}
 	}
-
-	records, err := gatherClusterOperatorPodsAndEvents(ctx, gatherConfigClient, gatherKubeClient.CoreV1(), g.interval)
+	interval := g.config().DataReporting.Interval
+	records, err := gatherClusterOperatorPodsAndEvents(ctx, gatherConfigClient, gatherKubeClient.CoreV1(), interval)
 	if err != nil {
 		return records, []error{err}
 	}

--- a/pkg/gatherers/clusterconfig/gather_cluster_version.go
+++ b/pkg/gatherers/clusterconfig/gather_cluster_version.go
@@ -62,8 +62,8 @@ func (g *Gatherer) GatherClusterVersion(ctx context.Context) ([]record.Record, [
 	if err != nil {
 		return nil, []error{err}
 	}
-
-	return getClusterVersion(ctx, gatherConfigClient, gatherKubeClient.CoreV1(), g.interval)
+	interval := g.config().DataReporting.Interval
+	return getClusterVersion(ctx, gatherConfigClient, gatherKubeClient.CoreV1(), interval)
 }
 
 func getClusterVersion(ctx context.Context,

--- a/pkg/gatherers/clusterconfig/gather_openshift_machine_api_events.go
+++ b/pkg/gatherers/clusterconfig/gather_openshift_machine_api_events.go
@@ -38,7 +38,8 @@ func (g *Gatherer) GatherOpenshiftMachineAPIEvents(ctx context.Context) ([]recor
 	if err != nil {
 		return nil, []error{err}
 	}
-	records, err := gatherOpenshiftMachineAPIEvents(ctx, gatherKubeClient.CoreV1(), g.interval)
+	interval := g.config().DataReporting.Interval
+	records, err := gatherOpenshiftMachineAPIEvents(ctx, gatherKubeClient.CoreV1(), interval)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -62,8 +62,14 @@ func (d *driverMock) Prune(time.Time) error {
 func newRecorder(maxArchiveSize int64, clusterBaseDomain string) (*Recorder, error) {
 	driver := driverMock{}
 	driver.On("Save").Return(nil, nil)
-	mockSecretConfigurator := config.NewMockSecretConfigurator(&config.Controller{EnableGlobalObfuscation: true})
-	anonymizer, err := anonymization.NewAnonymizer(clusterBaseDomain, nil, nil, mockSecretConfigurator, v1alpha1.ObfuscateNetworking)
+	mockConfigMapConfigurator := config.NewMockConfigMapConfigurator(&config.InsightsConfiguration{
+		DataReporting: config.DataReporting{
+			Obfuscation: config.Obfuscation{
+				config.Networking,
+			},
+		},
+	})
+	anonymizer, err := anonymization.NewAnonymizer(clusterBaseDomain, nil, nil, mockConfigMapConfigurator, v1alpha1.ObfuscateNetworking)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR adds a new `obfuscation` option to the new `insights-config` config map. This option allows you to enable the "legacy global obfuscation" as well as the new `workloads_names` obfuscation, which is currently only used for DVO metrics. 

Example can look like:

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: insights-config
  namespace: openshift-insights
immutable: false
data:
  config.yaml: |
    dataReporting:
       obfuscation:
       - workload_names
       - networking
```
 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
