### PR TITLE
add retry logic to the DVO metrics gatherer

### DIFF
--- a/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
+++ b/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
@@ -183,16 +183,16 @@ func gatherDVOMetricsFromEndpoint(
 // timeout is 2 seconds and interval is 0.5 seconds.
 func queryMetricsService(ctx context.Context, client *rest.RESTClient) (io.ReadCloser, error) {
 	var dataReader io.ReadCloser
-	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		dataReader, err = client.Get().AbsPath("metrics").Stream(ctx)
 		if err != nil {
-			klog.Warning("Failed to read DVO metrics. Trying again.")
+			klog.Warning("Failed to read the DVO metrics. Trying again.")
 			return false, nil
 		}
 		return true, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read the data from the DVO metrics service: %v", err)
 	}
 	return dataReader, nil
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This adds retry logic (with context timeout of 2 seconds) to the DVO metrics gatherer

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
