### PR TITLE
CCXDEV-11652: update related objects in the DataGather CR in techpreview

### DIFF
--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -345,7 +345,7 @@ func TestUpdateNewDataGatherCRStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cs := insightsFakeCli.NewSimpleClientset(tt.testedDataGather)
 			mockController := NewWithTechPreview(nil, nil, nil, nil, nil, cs.InsightsV1alpha1(), nil, nil)
-			err := mockController.updateNewDataGatherCRStatus(context.Background(), tt.testedDataGather.Name)
+			err := mockController.updateNewDataGatherCRStatus(context.Background(), tt.testedDataGather, &batchv1.Job{})
 			assert.NoError(t, err)
 			updatedDataGather, err := cs.InsightsV1alpha1().DataGathers().Get(context.Background(), tt.testedDataGather.Name, metav1.GetOptions{})
 			assert.NoError(t, err)
@@ -1138,12 +1138,12 @@ func TestDataGatherState(t *testing.T) {
 				insightsCs = insightsFakeCli.NewSimpleClientset(tt.dataGather)
 			}
 			mockController := NewWithTechPreview(nil, nil, nil, nil, nil, insightsCs.InsightsV1alpha1(), nil, nil)
-			state, err := mockController.dataGatherState(context.Background(), tt.dataGatherName)
+			dataGather, err := mockController.getDataGather(context.Background(), tt.dataGatherName)
 			if tt.err != nil {
 				assert.Equal(t, tt.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.dataGather.Status.State, state)
+				assert.Equal(t, tt.dataGather.Status.State, dataGather.Status.State)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This sets the related objects in the DataGather resource status. 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- no new data

## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
