### PR TITLE
OCPBUGS-23097: DVO gatherer - do the retry request as HEAD and not stream

### DIFF
--- a/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
+++ b/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
@@ -137,15 +137,21 @@ func gatherDVOMetricsFromEndpoint(
 		http.DefaultClient,
 	)
 	if err != nil {
-		klog.Warningf("Unable to load metrics client, no metrics will be collected: %v", err)
+		klog.Errorf("Unable to load metrics client, no metrics will be collected: %v", err)
 		return nil, err
 	}
 
-	dataReader, err := queryMetricsService(ctx, metricsRESTClient)
+	err = metricsServiceUp(ctx, metricsRESTClient, apiURL)
 	if err != nil {
-		klog.Warningf("Unable to retrieve DVO metrics: %v", err)
 		return nil, err
 	}
+
+	dataReader, err := metricsRESTClient.Get().AbsPath("metrics").Stream(ctx)
+	if err != nil {
+		klog.Errorf("Failed to stream data from the DVO service: %v", err)
+		return nil, err
+	}
+
 	defer func() {
 		// The error variable must have a more unique name to satisfy govet.
 		if closeErr := dataReader.Close(); closeErr != nil {
@@ -181,22 +187,24 @@ func gatherDVOMetricsFromEndpoint(
 	return prefixedLines, nil
 }
 
-// queryMetricsService queries the DVO metrics service with poll in case of an error. Polling
-// timeout is 2 seconds and interval is 0.5 seconds.
-func queryMetricsService(ctx context.Context, client *rest.RESTClient) (io.ReadCloser, error) {
-	var dataReader io.ReadCloser
-	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
-		dataReader, err = client.Get().AbsPath("metrics").Stream(ctx)
-		if err != nil {
+// metricsServiceUp queries the DVO metrics service with poll in case of an error. Polling
+// timeout is 5 seconds and interval is 1 second.
+func metricsServiceUp(ctx context.Context, client *rest.RESTClient, apiURL *url.URL) error {
+	timeout := 5 * time.Second
+	dvoMetricsURL := fmt.Sprintf("http://%s/metrics", apiURL.Host)
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
+		resp, err := client.Client.Head(dvoMetricsURL) //nolint: noctx
+		if err != nil || resp.StatusCode != 200 {
 			klog.Warning("Failed to read the DVO metrics. Trying again.")
 			return false, nil
 		}
+		defer resp.Body.Close()
 		return true, nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to read the data from the DVO metrics service: %v", err)
+		return fmt.Errorf("DVO metrics service was not available within the %s timeout: %v", timeout, err)
 	}
-	return dataReader, nil
+	return nil
 }
 
 // obfuscateDVOMetrics tells whether DVO metrics should be "obfuscated" or not


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This updates the original `queryMetricsService` function in the DVO gatherer. I think the problem was that the timeout for the context was only 5 seconds and this context was also used for streaming the data. 5 seconds is not enough when streaming larger DVO metrics data. 

This changes the logic to use HEAD request to check whether the DVO service is up and running and then, if it's OK, start reading/streaming the data.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->



## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
