### PR TITLE
CCXDEV-12194: read configmap during configmap observer init

### DIFF
--- a/pkg/config/configobserver/configmapobserver.go
+++ b/pkg/config/configobserver/configmapobserver.go
@@ -62,12 +62,12 @@ func NewConfigMapObserver(ctx context.Context, kubeConfig *rest.Config,
 	ctrl.Controller = factoryCtrl
 	cm, err := getConfigMap(ctx, kubeClient)
 	if err != nil {
-		klog.Warning("Cannot get the configuration config map: %v. Default configuration is used", err)
+		klog.Warningf("Cannot get the configuration config map: %v. Default configuration is used.", err)
 		return ctrl, nil
 	}
 	insightsConfig, err := readConfigAndDecode(cm)
 	if err != nil {
-		klog.Warning("Failed to read the configuration during start: %v Default configuration is used.", err)
+		klog.Warningf("Failed to read the configuration during start: %v. Default configuration is used.", err)
 		return ctrl, nil
 	}
 	ctrl.insightsConfig = insightsConfig

--- a/pkg/config/configobserver/configmapobserver.go
+++ b/pkg/config/configobserver/configmapobserver.go
@@ -40,7 +40,7 @@ type ConfigMapObserver struct {
 	listeners      map[chan struct{}]struct{}
 }
 
-func NewConfigMapObserver(kubeConfig *rest.Config,
+func NewConfigMapObserver(ctx context.Context, kubeConfig *rest.Config,
 	eventRecorder events.Recorder,
 	kubeInformer v1helpers.KubeInformersForNamespaces) (ConfigMapInformer, error) {
 	cmInformer := kubeInformer.InformersFor(insightsNamespaceName).Core().V1().ConfigMaps().Informer()
@@ -60,6 +60,17 @@ func NewConfigMapObserver(kubeConfig *rest.Config,
 		ToController("ConfigController", eventRecorder)
 
 	ctrl.Controller = factoryCtrl
+	cm, err := getConfigMap(ctx, kubeClient)
+	if err != nil {
+		klog.Warning("Cannot get the configuration config map: %v. Default configuration is used", err)
+		return ctrl, nil
+	}
+	insightsConfig, err := readConfigAndDecode(cm)
+	if err != nil {
+		klog.Warning("Failed to read the configuration during start: %v Default configuration is used.", err)
+		return ctrl, nil
+	}
+	ctrl.insightsConfig = insightsConfig
 	return ctrl, nil
 }
 

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -152,7 +152,7 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	}
 
 	kubeInf := v1helpers.NewKubeInformersForNamespaces(kubeClient, "openshift-insights")
-	configMapObserver, err := configobserver.NewConfigMapObserver(gatherKubeConfig, controller.EventRecorder, kubeInf)
+	configMapObserver, err := configobserver.NewConfigMapObserver(ctx, gatherKubeConfig, controller.EventRecorder, kubeInf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This is adding the logic to try to read the new configuration config map immediately during the configmap observer initialization (and not wait for the first informer sync or re-sync)

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data 

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
