### PR TITLE
[release-4.14] OCPBUGS-22996: adds cluster storageclasses gather (#858)

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1881,6 +1881,32 @@ None
 None
 
 
+## StorageClasses
+
+Collects the cluster `StorageClass` available in cluster.
+
+### API Reference
+- https://docs.openshift.com/container-platform/4.13/rest_api/storage_apis/storageclass-storage-k8s-io-v1.html
+
+### Sample data
+- [docs/insights-archive-sample/config/storage/storageclasses/standard-csi.json](./insights-archive-sample/config/storage/storageclasses/standard-csi.json)
+
+### Location in archive
+- `config/storage/storageclasses/{name}.json`
+
+### Config ID
+`clusterconfig/storage_classes`
+
+### Released version
+- 4.15
+
+### Backported versions
+None
+
+### Changes
+None
+
+
 ## StorageCluster
 
 Collects `storageclusters.ocs.openshift.io` resources

--- a/docs/insights-archive-sample/config/storage/storageclasses/standard-csi.json
+++ b/docs/insights-archive-sample/config/storage/storageclasses/standard-csi.json
@@ -1,0 +1,19 @@
+{
+    "metadata": {
+        "name": "standard-csi",
+        "uid": "325921f8-e18e-4861-96b6-8976bebbf07b",
+        "resourceVersion": "6648",
+        "creationTimestamp": "2023-11-01T12:49:07Z",
+        "annotations": {
+            "storageclass.kubernetes.io/is-default-class": "true"
+        }
+    },
+    "provisioner": "pd.csi.storage.gke.io",
+    "parameters": {
+        "replication-type": "none",
+        "type": "pd-standard"
+    },
+    "reclaimPolicy": "Delete",
+    "allowVolumeExpansion": true,
+    "volumeBindingMode": "WaitForFirstConsumer"
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -83,6 +83,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"scheduler_logs":                    (*Gatherer).GatherSchedulerLogs,
 	"service_accounts":                  (*Gatherer).GatherServiceAccounts,
 	"silenced_alerts":                   (*Gatherer).GatherSilencedAlerts,
+	"storage_classes":                   (*Gatherer).GatherStorageClasses,
 	"storage_cluster":                   (*Gatherer).GatherStorageCluster,
 	"support_secret":                    (*Gatherer).GatherSupportSecret,
 	"tsdb_status":                       (*Gatherer).GatherPrometheusTSDBStatus,

--- a/pkg/gatherers/clusterconfig/gather_storageclass.go
+++ b/pkg/gatherers/clusterconfig/gather_storageclass.go
@@ -1,0 +1,70 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/client-go/kubernetes/typed/storage/v1"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GatherStorageClasses Collects the cluster `StorageClass` available in cluster.
+//
+// ### API Reference
+// - https://docs.openshift.com/container-platform/4.13/rest_api/storage_apis/storageclass-storage-k8s-io-v1.html
+//
+// ### Sample data
+// - docs/insights-archive-sample/config/storage/storageclasses/standard-csi.json
+//
+// ### Location in archive
+// - `config/storage/storageclasses/{name}.json`
+//
+// ### Config ID
+// `clusterconfig/storage_classes`
+//
+// ### Released version
+// - 4.15
+//
+// ### Backported versions
+// None
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherStorageClasses(ctx context.Context) ([]record.Record, []error) {
+	kubeClient, err := kubernetes.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherStorageClasses(ctx, kubeClient.StorageV1())
+}
+
+func gatherStorageClasses(ctx context.Context, storageClient v1.StorageV1Interface) ([]record.Record, []error) {
+	storageClasses, err := listStorageClasses(ctx, storageClient.StorageClasses())
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	var records []record.Record
+	for i := range storageClasses.Items {
+		item := &storageClasses.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("config/storage/storageclasses/%s", item.GetName()),
+			Item: record.ResourceMarshaller{Resource: item},
+		})
+	}
+
+	return records, nil
+}
+
+func listStorageClasses(ctx context.Context, storageClient v1.StorageClassInterface) (*storagev1.StorageClassList, error) {
+	storageClasses, err := storageClient.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return storageClasses, nil
+}

--- a/pkg/gatherers/clusterconfig/gather_storageclass_test.go
+++ b/pkg/gatherers/clusterconfig/gather_storageclass_test.go
@@ -1,0 +1,73 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGatherStorageClasses(t *testing.T) {
+	tests := []struct {
+		name           string
+		storageClasses []storagev1.StorageClass
+		wantRecords    []record.Record
+		wantErrCount   int
+	}{
+		{
+			name: "Successful retrieval of storageclasses",
+			storageClasses: []storagev1.StorageClass{
+				{
+					ObjectMeta:  metav1.ObjectMeta{Name: "standard-csi"},
+					Provisioner: "pd.csi.storage.gke.io",
+					Parameters: map[string]string{
+						"replication-type": "none",
+						"type":             "pd-standard",
+					},
+				},
+			},
+			wantRecords: []record.Record{
+				{
+					Name: "config/storage/storageclasses/standard-csi",
+					Item: record.ResourceMarshaller{
+						Resource: &storagev1.StorageClass{
+							ObjectMeta:  metav1.ObjectMeta{Name: "standard-csi"},
+							Provisioner: "pd.csi.storage.gke.io",
+							Parameters: map[string]string{
+								"replication-type": "none",
+								"type":             "pd-standard",
+							},
+						},
+					},
+				},
+			},
+			wantErrCount: 0,
+		},
+		{
+			name:           "Retrieval no storageclasses items",
+			storageClasses: nil,
+			wantRecords:    nil,
+			wantErrCount:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client and store it in a variable
+			kubeClient := fake.NewSimpleClientset(&storagev1.StorageClassList{
+				Items: tt.storageClasses,
+			})
+
+			// Call the gatherStorageClasses function with the fake client
+			records, errs := gatherStorageClasses(context.Background(), kubeClient.StorageV1())
+
+			// Verify the results
+			assert.Equal(t, tt.wantRecords, records)
+			assert.Len(t, errs, tt.wantErrCount)
+		})
+	}
+}


### PR DESCRIPTION
Backport #858

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/storage/storageclasses/standard-csi.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_cluster_storageclass_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-22996
