### PR TITLE
[release-4.14] OCPBUGS-23445: DVO gatherer - add retry logic (#861)

### DIFF
--- a/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
+++ b/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -133,15 +135,21 @@ func gatherDVOMetricsFromEndpoint(
 		http.DefaultClient,
 	)
 	if err != nil {
-		klog.Warningf("Unable to load metrics client, no metrics will be collected: %v", err)
+		klog.Errorf("Unable to load metrics client, no metrics will be collected: %v", err)
+		return nil, err
+	}
+
+	err = metricsServiceUp(ctx, metricsRESTClient, apiURL)
+	if err != nil {
 		return nil, err
 	}
 
 	dataReader, err := metricsRESTClient.Get().AbsPath("metrics").Stream(ctx)
 	if err != nil {
-		klog.Warningf("Unable to retrieve most recent metrics: %v", err)
+		klog.Errorf("Failed to stream data from the DVO service: %v", err)
 		return nil, err
 	}
+
 	defer func() {
 		// The error variable must have a more unique name to satisfy govet.
 		if closeErr := dataReader.Close(); closeErr != nil {
@@ -175,4 +183,24 @@ func gatherDVOMetricsFromEndpoint(
 	}
 
 	return prefixedLines, nil
+}
+
+// metricsServiceUp queries the DVO metrics service with poll in case of an error. Polling
+// timeout is 5 seconds and interval is 1 second.
+func metricsServiceUp(ctx context.Context, client *rest.RESTClient, apiURL *url.URL) error {
+	timeout := 5 * time.Second
+	dvoMetricsURL := fmt.Sprintf("http://%s/metrics", apiURL.Host)
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
+		resp, err := client.Client.Head(dvoMetricsURL) //nolint: noctx
+		if err != nil || resp.StatusCode != 200 {
+			klog.Warning("Failed to read the DVO metrics. Trying again.")
+			return false, nil
+		}
+		defer resp.Body.Close()
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("DVO metrics service was not available within the %s timeout: %v", timeout, err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-23445
https://access.redhat.com/solutions/???
