### PR TITLE
test: fix helmchart gather unit test

### DIFF
--- a/pkg/gatherers/workloads/types_test.go
+++ b/pkg/gatherers/workloads/types_test.go
@@ -88,8 +88,6 @@ func TestAddItem(t *testing.T) {
 	for _, testCase := range tests {
 		tt := testCase
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			helmList := newHelmChartInfoList()
 			for namespace, resources := range tt.info {
 				for resource, charts := range resources {
@@ -99,7 +97,12 @@ func TestAddItem(t *testing.T) {
 				}
 			}
 
-			assert.Equal(t, tt.expectedList, helmList.Namespaces, "expected '%v', got '%v'", tt.expectedList, helmList.Namespaces)
+			// check equality of elements in slices, ignoring order
+			for namespace, expectedCharts := range tt.expectedList {
+				actualCharts, ok := helmList.Namespaces[namespace]
+				assert.True(t, ok, "expected namespace '%s' not found", namespace)
+				assert.ElementsMatch(t, expectedCharts, actualCharts, "unexpected charts for namespace '%s'", namespace)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR fixes some inconsistency at the Helm chart gatherer unit tests (comparing unsorted map).

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
