### PR TITLE
OCPBUGS-23616: changelog script - parse arguments as time

### DIFF
--- a/cmd/changelog/main.go
+++ b/cmd/changelog/main.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // norevive
@@ -100,8 +101,14 @@ func main() {
 	var releaseBlocks map[ReleaseVersion]MarkdownReleaseBlock
 	if len(os.Args) == 3 {
 		releaseBlocks = make(map[ReleaseVersion]MarkdownReleaseBlock)
-		after := os.Args[1]
-		until := os.Args[2]
+		after, err := time.Parse(time.DateOnly, os.Args[1])
+		if err != nil {
+			log.Fatalf("Failed to parse time arguments: %v", err)
+		}
+		until, err := time.Parse(time.DateOnly, os.Args[2])
+		if err != nil {
+			log.Fatalf("Failed to parse time arguments: %v", err)
+		}
 		gitLog = timeFrameReverseGitLog(after, until)
 	} else {
 		releaseBlocks = readCHANGELOG()
@@ -336,7 +343,7 @@ func findEarliestRelease(releases ReleaseVersions) ReleaseVersion {
 	return releases[0]
 }
 
-func timeFrameReverseGitLog(after, until string) []string {
+func timeFrameReverseGitLog(after, until time.Time) []string {
 	// nolint: gosec
 	out, err := exec.Command(
 		"git",


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is attempt to fix the SAST warning:
```
 Unsanitized input from a CLI argument flows into net.http.NewRequestWithContext, where it is used as an URL to perform a request. This may result in a Server-Side Request Forgery vulnerability.
```

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->
no new data

## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-23616
https://access.redhat.com/solutions/???
