### PR TITLE
NO-JIRA: manifests: bump loglevel of operator to normal

### DIFF
--- a/manifests/06-deployment-ibm-cloud-managed.yaml
+++ b/manifests/06-deployment-ibm-cloud-managed.yaml
@@ -24,7 +24,6 @@ spec:
       containers:
       - args:
         - start
-        - -v=4
         - --config=/etc/insights-operator/server.yaml
         env:
         - name: POD_NAME

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -98,5 +98,4 @@ spec:
           value: "0.0.1-snapshot"
         args:
         - start
-        - -v=4
         - --config=/etc/insights-operator/server.yaml


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

with the https://github.com/openshift/insights-operator/pull/894  loglevel controller has merged, we can remove the loglevel in manifests, which now is already controlled by loglevel controller and is set on Normal by default

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
