### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/manifests/06-deployment-ibm-cloud-managed.yaml
+++ b/manifests/06-deployment-ibm-cloud-managed.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: insights-operator

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         app: insights-operator
     spec:


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR pins the required SCC to the `insights-operator` workload.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

None; `restricted-v2` is the SCC that the pod is currently admitted with.

## References
<!-- What are related references for this PR? -->
https://issues.redhat.com/browse/AUTH-482