### PR TITLE
NO-JIRA: delete all active jobs during restart

### DIFF
--- a/pkg/controller/periodic/job.go
+++ b/pkg/controller/periodic/job.go
@@ -131,6 +131,10 @@ func (j *JobController) WaitForJobCompletion(ctx context.Context, job *batchv1.J
 				return fmt.Errorf("watcher channel was closed unexpectedly")
 			}
 
+			if event.Type == apiWatch.Deleted {
+				return nil
+			}
+
 			if event.Type != apiWatch.Modified {
 				continue
 			}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is adding logic (in techpreview) that after start removes all the active Jobs with `periodic-gathering-` prefix (I think it's not very nice to kill job spawned by user). This is to prevent potential race condition for the future remote configuration (rapid recommendations) based on the OCP version. What can theoretically happen is the following:

- operator creates a job with OCP version 1.2.3 (so the remote configuration is in version 1.2.3 too)
- CVO updates the operator to OCP version 1.2.4 (which leads to re-redeployment), but the job still uses the older OCP version 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->


## Documentation
<!-- Are these changes reflected in documentation? -->



## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->


## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
