### PR TITLE
OCPBUGS-32702: anonymization - externalIP can be nil

### DIFF
--- a/pkg/anonymization/anonymizer.go
+++ b/pkg/anonymization/anonymizer.go
@@ -289,6 +289,11 @@ func getNetworksFromClusterNetworksConfig(networksConfig *configv1.Network) []st
 		networks = append(networks, network.CIDR)
 	}
 	networks = append(networks, networksConfig.Spec.ServiceNetwork...)
+
+	if networksConfig.Spec.ExternalIP == nil {
+		return networks
+	}
+
 	networks = append(networks, networksConfig.Spec.ExternalIP.AutoAssignCIDRs...)
 	networks = append(networks, networksConfig.Spec.ExternalIP.Policy.AllowedCIDRs...)
 	networks = append(networks, networksConfig.Spec.ExternalIP.Policy.RejectedCIDRs...)


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This is a simple fix for the IP anonymizer

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

- 

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-32702
https://access.redhat.com/solutions/???
