### PR TITLE
OCPBUGS-34788: gather aggregated numbers of Pods and Netnamespaces with SDN annotations

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1387,6 +1387,31 @@ with 'x' strings preserving the same length.
 images running on the node.
 
 
+## NumberOfPodsAndNetnamespacesWithSDNAnnotations
+
+Collects number of Pods with the annotation:
+`pod.network.openshift.io/assign-macvlan`
+and also collects number of Netnamespaces with the annotation:
+`netnamespace.network.openshift.io/multicast-enabled: "true"`
+
+### Sample data
+- [docs/insights-archive-sample/aggregated/pods_and_netnamespaces_with_sdn_annotations.json](./insights-archive-sample/aggregated/pods_and_netnamespaces_with_sdn_annotations.json)
+
+### Location in archive
+- `aggregated/pods_and_netnamespaces_with_sdn_annotations.json`
+
+### Config ID
+`clusterconfig/pods_and_netnamespaces_with_sdn_annotations`
+
+### Released version
+- 4.17.0
+
+### Backported versions
+
+### Changes
+None
+
+
 ## OLMOperators
 
 Collects the list of installed OLM operators. Each OLM operator (in the list) contains

--- a/docs/insights-archive-sample/aggregated/pods_and_netnamespaces_with_sdn_annotations.json
+++ b/docs/insights-archive-sample/aggregated/pods_and_netnamespaces_with_sdn_annotations.json
@@ -1,0 +1,1 @@
+{"pods_with_assign-macvlan_annotation":3,"netnamespaces_with_multicast-enabled_annotation":1}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -73,6 +73,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"overlapping_namespace_uids":        (*Gatherer).GatherNamespacesWithOverlappingUIDs,
 	"pdbs":                              (*Gatherer).GatherPodDisruptionBudgets,
 	"pod_network_connectivity_checks":   (*Gatherer).GatherPodNetworkConnectivityChecks,
+	"number_of_pods_and_netnamespaces_with_sdn_annotations": (*Gatherer).GatherNumberOfPodsAndNetnamespacesWithSDNAnnotations,
 	"proxies":                           (*Gatherer).GatherClusterProxy,
 	"sap_config":                        (*Gatherer).GatherSAPConfig,
 	"sap_datahubs":                      (*Gatherer).GatherSAPDatahubs,

--- a/pkg/gatherers/clusterconfig/gather_pod_and_netnamespaces_with_sdn_annotation.go
+++ b/pkg/gatherers/clusterconfig/gather_pod_and_netnamespaces_with_sdn_annotation.go
@@ -1,0 +1,146 @@
+package clusterconfig
+
+import (
+	"context"
+
+	networkv1client "github.com/openshift/client-go/network/clientset/versioned/typed/network/v1"
+	"github.com/openshift/insights-operator/pkg/record"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	assignMacVlanAnn    = "pod.network.openshift.io/assign-macvlan"
+	multicastEnabledAnn = "netnamespace.network.openshift.io/multicast-enabled"
+)
+
+// GatherNumberOfPodsAndNetnamespacesWithSDNAnnotations Collects number of Pods with the annotation:
+// `pod.network.openshift.io/assign-macvlan`
+// and also collects number of Netnamespaces with the annotation:
+// `netnamespace.network.openshift.io/multicast-enabled: "true"`
+//
+// ### Sample data
+// - docs/insights-archive-sample/aggregated/pods_and_netnamespaces_with_sdn_annotations.json
+//
+// ### Location in archive
+// - `aggregated/pods_and_netnamespaces_with_sdn_annotations.json`
+//
+// ### Config ID
+// `clusterconfig/pods_and_netnamespaces_with_sdn_annotations`
+//
+// ### Released version
+// - 4.17.0
+//
+// ### Backported versions
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherNumberOfPodsAndNetnamespacesWithSDNAnnotations(ctx context.Context) ([]record.Record, []error) {
+	networkClient, err := networkv1client.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	kubeCli, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherNumberOfPodsAndNetnamespacesWithSDN(ctx, networkClient, kubeCli)
+}
+
+type dataRecord struct {
+	NumberOfPods          int `json:"pods_with_assign-macvlan_annotation"`
+	NumberOfNetnamespaces int `json:"netnamespaces_with_multicast-enabled_annotation"`
+}
+
+func gatherNumberOfPodsAndNetnamespacesWithSDN(ctx context.Context,
+	networkCli networkv1client.NetworkV1Interface,
+	kubeCli kubernetes.Interface) ([]record.Record, []error) {
+	var errs []error
+
+	numberOfPods, err := getNumberOfPodsWithAnnotation(ctx, assignMacVlanAnn, kubeCli)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	numberOfNetnamespaces, err := getNumberOfNetnamespacesWithAnnotation(ctx, multicastEnabledAnn, networkCli)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if numberOfNetnamespaces == 0 && numberOfPods == 0 {
+		return nil, nil
+	}
+
+	return []record.Record{
+		{
+			Name: "aggregated/pods_and_netnamespaces_with_sdn_annotations",
+			Item: record.JSONMarshaller{Object: dataRecord{
+				NumberOfPods:          numberOfPods,
+				NumberOfNetnamespaces: numberOfNetnamespaces,
+			}},
+		},
+	}, errs
+}
+
+// getNumberOfPodsWithAnnotation lists all the Pods in the cluster and counts the ones with provided annotation
+func getNumberOfPodsWithAnnotation(ctx context.Context, annotation string, kubeCli kubernetes.Interface) (int, error) {
+	var continueValue string
+	var numberOfPods int
+	for {
+		pods, err := kubeCli.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+			Limit:    500,
+			Continue: continueValue,
+		})
+		if err != nil {
+			return 0, err
+		}
+
+		for i := range pods.Items {
+			pod := pods.Items[i]
+			if _, ok := pod.Annotations[annotation]; ok {
+				numberOfPods++
+			}
+		}
+
+		if pods.Continue == "" {
+			break
+		}
+		continueValue = pods.Continue
+	}
+	return numberOfPods, nil
+}
+
+// getNumberOfNetnamespacesWithAnnotation lists all the Netnamespaces in the cluster
+// and counts the ones with provided annotation
+func getNumberOfNetnamespacesWithAnnotation(ctx context.Context,
+	annotation string,
+	networkCli networkv1client.NetworkV1Interface) (int, error) {
+	var numberOfNamespaces int
+	var continueValue string
+
+	for {
+		netNamespaces, err := networkCli.NetNamespaces().List(ctx, metav1.ListOptions{
+			Limit:    500,
+			Continue: continueValue,
+		})
+		if err != nil {
+			return 0, err
+		}
+
+		for i := range netNamespaces.Items {
+			netNamespace := netNamespaces.Items[i]
+			if v, ok := netNamespace.Annotations[annotation]; ok {
+				if v == "true" {
+					numberOfNamespaces++
+				}
+			}
+		}
+
+		if netNamespaces.Continue == "" {
+			break
+		}
+		continueValue = netNamespaces.Continue
+	}
+
+	return numberOfNamespaces, nil
+}

--- a/pkg/gatherers/clusterconfig/gather_pod_and_netnamespaces_with_sdn_annotation_test.go
+++ b/pkg/gatherers/clusterconfig/gather_pod_and_netnamespaces_with_sdn_annotation_test.go
@@ -1,0 +1,148 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	networkv1 "github.com/openshift/api/network/v1"
+	networkfake "github.com/openshift/client-go/network/clientset/versioned/fake"
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8Testing "k8s.io/client-go/testing"
+)
+
+func TestGatherNumberOfPodsAndNetnamespacesWithSDN(t *testing.T) {
+	tests := []struct {
+		name           string
+		pods           []*v1.Pod
+		netNamespaces  []*networkv1.NetNamespace
+		expctedRecords []record.Record
+	}{
+		{
+			name: "no data found",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod",
+					},
+				},
+			},
+			netNamespaces: []*networkv1.NetNamespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-netnamespace",
+					},
+				},
+			},
+			expctedRecords: nil,
+		},
+		{
+			name: "some data found",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-1",
+						Annotations: map[string]string{
+							"another-annotation": "true",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-2",
+						Annotations: map[string]string{
+							assignMacVlanAnn: "true",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-3",
+						Annotations: map[string]string{
+							assignMacVlanAnn: "",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pod-4",
+						Annotations: map[string]string{
+							assignMacVlanAnn: "false",
+						},
+					},
+				},
+			},
+			netNamespaces: []*networkv1.NetNamespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-netnamespace-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-netnamespace-2",
+						Annotations: map[string]string{
+							multicastEnabledAnn: "true",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-netnamespace-3",
+						Annotations: map[string]string{
+							multicastEnabledAnn: "false",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-netnamespace-4",
+						Annotations: map[string]string{
+							"aother-annotation": "true",
+						},
+					},
+				},
+			},
+			expctedRecords: []record.Record{
+				{
+					Name: "aggregated/pods_and_netnamespaces_with_sdn_annotations",
+					Item: record.JSONMarshaller{
+						Object: dataRecord{
+							NumberOfPods:          3,
+							NumberOfNetnamespaces: 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeCli := kubefake.NewSimpleClientset()
+			err := addObjectsToClientSet(kubeCli, tt.pods)
+			assert.NoError(t, err)
+			networkCli := networkfake.NewSimpleClientset()
+			err = addObjectsToClientSet(networkCli, tt.netNamespaces)
+			assert.NoError(t, err)
+			records, errs := gatherNumberOfPodsAndNetnamespacesWithSDN(context.Background(), networkCli.NetworkV1(), kubeCli)
+			assert.Empty(t, errs)
+			assert.Equal(t, tt.expctedRecords, records)
+		})
+	}
+}
+
+func addObjectsToClientSet[C []T, T runtime.Object](cli k8Testing.FakeClient, obj C) error {
+	for i := range obj {
+		o := obj[i]
+		err := cli.Tracker().Add(o)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This new gatherer aggregates a number of Pods having `pod.network.openshift.io/assign-macvlan` annotation and number of netnamespaces having `netnamespace.network.openshift.io/multicast-enabled: "true"` annotation 

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/aggregated/pods_and_netnamespaces_with_sdn_annotations.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_pod_and_netnamespaces_with_sdn_annotation_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-34788
https://access.redhat.com/solutions/???
