### PR TITLE
[release-4.14] OCPBUGS-36475: properly encode the URL for the advisor links

### DIFF
--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -44,7 +44,7 @@ func main() {
 		return
 	}
 	defer mdf.Close()
-	cleanRoot := "./"
+	cleanRoot := "./" // nolint: goconst
 
 	md := map[string]*DocBlock{}
 	err = walkDir(cleanRoot, md)

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
 	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
 	insightsv1alpha1 "github.com/openshift/api/insights/v1alpha1"
 	v1 "github.com/openshift/api/operator/v1"
@@ -395,12 +396,17 @@ func (c *Controller) runJobAndCheckResults(ctx context.Context, dataGatherName s
 func (c *Controller) updateInsightsReportInDataGather(ctx context.Context,
 	report *types.InsightsAnalysisReport, dg *insightsv1alpha1.DataGather) error {
 	for _, recommendation := range report.Recommendations {
+		advisorLink, err := insights.CreateInsightsAdvisorLink(configv1.ClusterID(report.ClusterID),
+			recommendation.RuleFQDN, recommendation.ErrorKey)
+		if err != nil {
+			klog.Errorf("Failed to create console.redhat.com link: %v", err)
+			continue
+		}
 		healthCheck := insightsv1alpha1.HealthCheck{
 			Description: recommendation.Description,
 			TotalRisk:   int32(recommendation.TotalRisk),
 			State:       insightsv1alpha1.HealthCheckEnabled,
-			AdvisorURI: fmt.Sprintf("https://console.redhat.com/openshift/insights/advisor/clusters/%s?first=%s|%s",
-				report.ClusterID, recommendation.RuleFQDN, recommendation.ErrorKey),
+			AdvisorURI:  advisorLink,
 		}
 		dg.Status.InsightsReport.HealthChecks = append(dg.Status.InsightsReport.HealthChecks, healthCheck)
 	}

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -1040,13 +1040,13 @@ func TestUpdateInsightsReportInDataGather(t *testing.T) {
 					{
 						Description: "lorem-ipsum",
 						TotalRisk:   1,
-						AdvisorURI:  "https://console.redhat.com/openshift/insights/advisor/clusters/test-cluster-id?first=test.fqdn.key1|test-error-key-1",
+						AdvisorURI:  "https://console.redhat.com/openshift/insights/advisor/clusters/test-cluster-id?first=test.fqdn.key1%7Ctest-error-key-1",
 						State:       v1alpha1.HealthCheckEnabled,
 					},
 					{
 						Description: "lorem-ipsum bla bla test",
 						TotalRisk:   4,
-						AdvisorURI:  "https://console.redhat.com/openshift/insights/advisor/clusters/test-cluster-id?first=test.fqdn.key2|test-error-key-2",
+						AdvisorURI:  "https://console.redhat.com/openshift/insights/advisor/clusters/test-cluster-id?first=test.fqdn.key2%7Ctest-error-key-2",
 						State:       v1alpha1.HealthCheckEnabled,
 					},
 				},

--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -430,12 +430,18 @@ func (c *Controller) updateOperatorStatusCR(report types.SmartProxyReport, repor
 			klog.Errorf("Unable to extract recommendation's error key: %v", err)
 			continue
 		}
+
 		ruleIDStr := strings.TrimSuffix(string(rule.RuleID), ".report")
+		advisorLink, err := insights.CreateInsightsAdvisorLink(insights.RecommendationCollector.ClusterID(), ruleIDStr, errorKey)
+		if err != nil {
+			klog.Errorf("Failed to create console.redhat.com link: %v", err)
+			continue
+		}
 		healthCheck := v1.HealthCheck{
 			Description: rule.Description,
 			TotalRisk:   int32(rule.TotalRisk),
 			State:       v1.HealthCheckEnabled,
-			AdvisorURI:  fmt.Sprintf("https://console.redhat.com/openshift/insights/advisor/clusters/%s?first=%s|%s", insights.RecommendationCollector.ClusterID(), ruleIDStr, errorKey),
+			AdvisorURI:  advisorLink,
 		}
 
 		if rule.Disabled {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->


## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-36475
https://access.redhat.com/solutions/???
