### PR TITLE
[release-4.13] OCPBUGS-36745: properly encode the URL for the advisor links (#962)

### DIFF
--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -44,7 +44,7 @@ func main() {
 		return
 	}
 	defer mdf.Close()
-	cleanRoot := "./"
+	cleanRoot := "./" // nolint: goconst
 
 	md := map[string]*DocBlock{}
 	err = walkDir(cleanRoot, md)

--- a/pkg/insights/insightsreport/insightsreport.go
+++ b/pkg/insights/insightsreport/insightsreport.go
@@ -349,12 +349,18 @@ func (c *Controller) updateOperatorStatusCR(report types.SmartProxyReport, repor
 			klog.Errorf("Unable to extract recommendation's error key: %v", err)
 			continue
 		}
+
 		ruleIDStr := strings.TrimSuffix(string(rule.RuleID), ".report")
+		advisorLink, err := insights.CreateInsightsAdvisorLink(insights.RecommendationCollector.ClusterID(), ruleIDStr, errorKey)
+		if err != nil {
+			klog.Errorf("Failed to create console.redhat.com link: %v", err)
+			continue
+		}
 		healthCheck := v1.HealthCheck{
 			Description: rule.Description,
 			TotalRisk:   int32(rule.TotalRisk),
 			State:       v1.HealthCheckEnabled,
-			AdvisorURI:  fmt.Sprintf("https://console.redhat.com/openshift/insights/advisor/clusters/%s?first=%s|%s", insights.RecommendationCollector.ClusterID(), ruleIDStr, errorKey),
+			AdvisorURI:  advisorLink,
 		}
 
 		if rule.Disabled {

--- a/pkg/insights/metrics.go
+++ b/pkg/insights/metrics.go
@@ -2,6 +2,7 @@ package insights
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	semver "github.com/blang/semver/v4"
@@ -63,16 +64,36 @@ func (c *InsightsRecommendationCollector) Collect(ch chan<- prometheus.Metric) {
 		// There is ".report" at the end of the rule ID for some reason, which
 		// should not be inserted into the URL.
 		ruleIDStr = strings.TrimSuffix(ruleIDStr, ".report")
+
+		consoleURL, err := CreateInsightsAdvisorLink(c.clusterID, ruleIDStr, rec.ErrorKey)
+		if err != nil {
+			klog.Errorf("Failed to create console.redhat.com link: %v", err)
+			continue
+		}
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(c.metricName, "", []string{}, prometheus.Labels{
 				"description": rec.Description,
 				"total_risk":  totalRiskToStr(rec.TotalRisk),
-				"info_link":   fmt.Sprintf("https://console.redhat.com/openshift/insights/advisor/clusters/%s?first=%s|%s", c.clusterID, ruleIDStr, rec.ErrorKey),
+				"info_link":   consoleURL,
 			}),
 			prometheus.GaugeValue,
 			1,
 		)
 	}
+}
+
+// createURL parses, creates and encodes all the necessary parameters for the Insights recommendation
+// link to the Insights advisor
+func CreateInsightsAdvisorLink(clusterID v1.ClusterID, ruleID, errorKey string) (string, error) {
+	consoleURL, err := url.Parse("https://console.redhat.com/openshift/insights/advisor/clusters")
+	if err != nil {
+		return "", err
+	}
+	consoleURL = consoleURL.JoinPath(string(clusterID))
+	params := url.Values{}
+	params.Add("first", fmt.Sprintf("%s|%s", ruleID, errorKey))
+	consoleURL.RawQuery = params.Encode()
+	return consoleURL.String(), nil
 }
 
 func (c *InsightsRecommendationCollector) ClearState() {


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->


## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-36475
https://access.redhat.com/solutions/???
