### PR TITLE
[release-4.15] OCPBUGS-36805: Set required-scc for openshift workloads

### DIFF
--- a/manifests/06-deployment-ibm-cloud-managed.yaml
+++ b/manifests/06-deployment-ibm-cloud-managed.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: insights-operator

--- a/manifests/06-deployment.yaml
+++ b/manifests/06-deployment.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         app: insights-operator
     spec:


### PR DESCRIPTION
This PR pins the required SCC to the insights-operator workload.
Manual cherry-pick of [#915](https://github.com/openshift/insights-operator/pull/915)

## Categories

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Breaking Changes
None; restricted-v2 is the SCC that the pod is currently admitted with.

## References
https://issues.redhat.com/browse/OCPBUGS-36805
