### PR TITLE
OCPBUGS-31210: insights client is hard coded to x86_64

### DIFF
--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -33,7 +33,7 @@ import (
 const (
 	responseBodyLogLen = 1024
 	insightsReqId      = "x-rh-insights-request-id"
-	scaArchPayload     = `{"type": "sca","arch": "x86_64"}`
+	scaArchPayload     = `{"type": "sca","arch": "%s"}`
 )
 
 type Client struct {

--- a/pkg/insights/insightsclient/requests.go
+++ b/pkg/insights/insightsclient/requests.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"runtime"
 
 	"k8s.io/klog/v2"
 
@@ -192,7 +193,16 @@ func (c *Client) RecvSCACerts(_ context.Context, endpoint string) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(scaArchPayload)))
+	arch := runtime.GOARCH
+	klog.Infof("Arch at run time %s", arch)
+	if runtime.GOARCH == "amd64" {
+		arch = "x86_64"
+		klog.Infof("Arch at if condition %s", arch)
+	} else if runtime.GOARCH == "arm64" {
+		arch = "aarch64"
+		klog.Infof("Arch at elif condition %s", arch)
+	}
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(fmt.Sprintf(scaArchPayload, arch))))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Downloads the correct certificates for etc-pki-entitlement for the target architecture

## Categories
<!-- Select the categories that your PR better fits on -->

- [x] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-31210 
https://docs.openshift.com/container-platform/4.16/cicd/builds/running-entitled-builds.html
https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
