### PR TITLE
OCPBUGS-38727: Enable Insight Operator entitlements for multi arch clusters

### DIFF
--- a/pkg/ocm/sca/architectures_gather.go
+++ b/pkg/ocm/sca/architectures_gather.go
@@ -1,0 +1,23 @@
+package sca
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// gatherArchitectures connects to K8S API to retrieve the list of
+// nodes and create a set of the present architectures
+func (c *Controller) gatherArchitectures(ctx context.Context) (map[string]struct{}, error) {
+	nodes, err := c.coreClient.Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	architectures := make(map[string]struct{})
+	for i := range nodes.Items {
+		nodeArch := nodes.Items[i].Status.NodeInfo.Architecture
+		architectures[nodeArch] = struct{}{}
+	}
+	return architectures, nil
+}


### PR DESCRIPTION
This PR implements a new mechanism to gather a set of architectures used by nodes in the current cluster.

This set of architectures is not used yet, but if Insights Operator is not able to retrieve it, it will make the entitlements retrieval process to fail

## Categories
- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive

The archive won't change with this feature

## Documentation
No documentation update

## Unit Tests
No tests were updated

## Privacy
Yes. There are no sensitive data in the newly collected information.

## Changelog
No

## Breaking Changes
No

## References
https://issues.redhat.com/browse/OCPBUGS-38727
