### PR TITLE
Using the appropriate Bash interpreter on Git hook scripts

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
Minor fix, switching shebang for the Git hook from `sh` to `bash` in order to avoid some minor syntax errors shown when running it from `git commit`.

## Categories
- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
N/A

## Documentation
N/A

## Unit Tests
N/A

## Privacy
N/A

## Changelog
No

## Breaking Changes
No

## References
N/A