### PR TITLE
CCXDEV-14146: insightsclient support for requesting a specific architecture

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -33,7 +33,7 @@ import (
 const (
 	responseBodyLogLen = 1024
 	insightsReqId      = "x-rh-insights-request-id"
-	scaArchPayload     = `{"type": "sca","arch": "x86_64"}`
+	scaArchPayload     = `{"type": "sca","arch": "%s"}`
 )
 
 type Client struct {

--- a/pkg/insights/insightsclient/requests.go
+++ b/pkg/insights/insightsclient/requests.go
@@ -180,7 +180,7 @@ func (c *Client) RecvReport(ctx context.Context, endpoint string) (*http.Respons
 	return nil, fmt.Errorf("report response status code: %d", resp.StatusCode)
 }
 
-func (c *Client) RecvSCACerts(_ context.Context, endpoint string) ([]byte, error) {
+func (c *Client) RecvSCACerts(_ context.Context, endpoint string, architecture string) ([]byte, error) {
 	cv, err := c.GetClusterVersion()
 	if apierrors.IsNotFound(err) {
 		return nil, ErrWaitingForVersion
@@ -192,7 +192,8 @@ func (c *Client) RecvSCACerts(_ context.Context, endpoint string) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(scaArchPayload)))
+	payload := fmt.Sprintf(scaArchPayload, architecture)
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(payload)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/sca/sca.go
+++ b/pkg/ocm/sca/sca.go
@@ -219,7 +219,7 @@ func (c *Controller) requestSCAWithExpBackoff(endpoint string) ([]byte, error) {
 	var data []byte
 	err := wait.ExponentialBackoff(bo, func() (bool, error) {
 		var err error
-		data, err = c.client.RecvSCACerts(c.ctx, endpoint)
+		data, err = c.client.RecvSCACerts(c.ctx, endpoint, "x86_64")
 		if err != nil {
 			// don't try again in case it's not an HTTP error - it could mean we're in disconnected env
 			if !insightsclient.IsHttpError(err) {


### PR DESCRIPTION
The PR provides a way to specify the architecture to perform a SCA request to the OpenShift API, instead of asking for a fixed architecture.

With the PR #979 it will be possible to retrieve the certificate for each node architecture 

## Categories
- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
N/A

## Documentation
N/A

## Unit Tests
N/A

## Privacy
No new information is collected

## Changelog
No

## Breaking Changes
No

## References
https://issues.redhat.com/browse/CCXDEV-14146
