### PR TITLE
OCPBUGS-32233: Not able to enable repositories during entitled build in OCP Cluster on IBM-Z

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -268,9 +268,9 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 		return fmt.Errorf("unable to set initial cluster status: %v", err)
 	}
 
-	scaController := sca.New(ctx, kubeClient.CoreV1(), configAggregator, insightsClient)
+	scaController := sca.New(kubeClient.CoreV1(), configAggregator, insightsClient)
 	statusReporter.AddSources(scaController)
-	go scaController.Run()
+	go scaController.Run(ctx)
 
 	clusterTransferController := clustertransfer.New(ctx, kubeClient.CoreV1(), configAggregator, insightsClient)
 	statusReporter.AddSources(clusterTransferController)

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -33,7 +33,7 @@ import (
 const (
 	responseBodyLogLen = 1024
 	insightsReqId      = "x-rh-insights-request-id"
-	scaArchPayload     = `{"type": "sca","arch": "x86_64"}`
+	scaArchPayload     = `{"type": "sca","arch": "%s"}`
 )
 
 type Client struct {

--- a/pkg/insights/insightsclient/requests.go
+++ b/pkg/insights/insightsclient/requests.go
@@ -180,7 +180,7 @@ func (c *Client) RecvReport(ctx context.Context, endpoint string) (*http.Respons
 	return nil, fmt.Errorf("report response status code: %d", resp.StatusCode)
 }
 
-func (c *Client) RecvSCACerts(_ context.Context, endpoint string) ([]byte, error) {
+func (c *Client) RecvSCACerts(_ context.Context, endpoint string, architecture string) ([]byte, error) {
 	cv, err := c.GetClusterVersion()
 	if apierrors.IsNotFound(err) {
 		return nil, ErrWaitingForVersion
@@ -192,7 +192,8 @@ func (c *Client) RecvSCACerts(_ context.Context, endpoint string) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(scaArchPayload)))
+	payload := fmt.Sprintf(scaArchPayload, architecture)
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer([]byte(payload)))
 	if err != nil {
 		return nil, err
 	}
@@ -200,6 +201,7 @@ func (c *Client) RecvSCACerts(_ context.Context, endpoint string) ([]byte, error
 	c.client.Transport = clientTransport(c.authorizer)
 	authHeader := fmt.Sprintf("AccessToken %s:%s", cv.Spec.ClusterID, token)
 	req.Header.Set("Authorization", authHeader)
+	klog.Infof("Asking for SCA certificate for %s architecture", architecture)
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/pkg/ocm/sca/sca_test.go
+++ b/pkg/ocm/sca/sca_test.go
@@ -19,13 +19,13 @@ var (
 func Test_SCAController_SecretIsCreated(t *testing.T) {
 	kube := kubefake.NewSimpleClientset()
 	coreClient := kube.CoreV1()
-	scaController := New(context.TODO(), coreClient, nil, nil)
+	scaController := New(coreClient, nil, nil)
 
 	testRes := &Response{
 		Key:  "secret key",
 		Cert: "secret cert",
 	}
-	err := scaController.checkSecret(testRes)
+	err := scaController.checkSecret(context.Background(), testRes)
 	assert.NoError(t, err, "failed to check the secret")
 
 	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
@@ -52,12 +52,12 @@ func Test_SCAController_SecretIsUpdated(t *testing.T) {
 	}
 	_, err := coreClient.Secrets(targetNamespaceName).Create(context.Background(), existingSec, metav1.CreateOptions{})
 	assert.NoError(t, err)
-	scaController := New(context.TODO(), coreClient, nil, nil)
+	scaController := New(coreClient, nil, nil)
 	testRes := &Response{
 		Key:  "new secret testing key",
 		Cert: "new secret testing cert",
 	}
-	err = scaController.checkSecret(testRes)
+	err = scaController.checkSecret(context.Background(), testRes)
 	assert.NoError(t, err, "failed to check the secret")
 
 	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})


### PR DESCRIPTION
## Categories
- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
N/A

## Documentation
N/A

## Unit Tests
N/A

## Privacy
Yes. There is no new data collected.

## Changelog

## Breaking Changes
No

## References
https://issues.redhat.com/browse/OCPBUGS-32233
