### PR TITLE
OCPBUGS-41932: set the RemoteConfigurationAvailable and RemoteConfigu…

### DIFF
--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -47,6 +47,7 @@ var (
 	trueB                            = true
 	deletePropagationBackground      = metav1.DeletePropagationBackground
 	dataUplodedConditionNotAvailable = "DataUploadedConditionNotAvailable"
+	gatheringDisabledReason          = "GatheringDisabled"
 )
 
 // Controller periodically runs gatherers, records their results to the recorder
@@ -324,20 +325,34 @@ func (c *Controller) onDemandGather(stopCh <-chan struct{}) {
 					klog.Infof("DataGather %s resource state is %s. Not triggering any data gathering", dgName, dataGather.Status.State)
 					return
 				}
+				if c.image == "" {
+					image, err := c.getInsightsImage(ctx)
+					if err != nil {
+						klog.Errorf("Can't get operator image. Gathering will not run: %v", err)
+						return
+					}
+					c.image = image
+				}
+
 				klog.Infof("Starting on-demand data gathering for the %s DataGather resource", dgName)
-				c.runJobAndCheckResults(ctx, dataGather)
+				c.runJobAndCheckResults(ctx, dataGather, c.image)
 			}()
 		}
 	}
 }
 
 func (c *Controller) GatherJob() {
-	if c.isGatheringDisabled() {
-		klog.Info("Gather is disabled by configuration.")
-		return
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), c.configAggregator.Config().DataReporting.Interval*4)
 	defer cancel()
+
+	if c.isGatheringDisabled() {
+		klog.Info("Gather is disabled by configuration.")
+		err := c.setRemoteConfigConditionsWhenDisabled(ctx)
+		if err != nil {
+			klog.Errorf("Failed to update operator's conditions in disabled state: %v ", err)
+		}
+		return
+	}
 
 	if c.image == "" {
 		image, err := c.getInsightsImage(ctx)
@@ -355,7 +370,7 @@ func (c *Controller) GatherJob() {
 		klog.Errorf("Failed to create a new DataGather resource: %v", err)
 		return
 	}
-	c.runJobAndCheckResults(ctx, dataGatherCR)
+	c.runJobAndCheckResults(ctx, dataGatherCR, c.image)
 }
 
 // runJobAndCheckResults creates a new data gathering job in techpreview
@@ -363,9 +378,9 @@ func (c *Controller) GatherJob() {
 // (in the external data pipeline) by reading the corresponding DataGather status conditions.
 // If the processing was successful, a new Insights analysis report is loaded; if not,
 // it returns with the providing the info in the log message.
-func (c *Controller) runJobAndCheckResults(ctx context.Context, dataGather *insightsv1alpha1.DataGather) {
+func (c *Controller) runJobAndCheckResults(ctx context.Context, dataGather *insightsv1alpha1.DataGather, image string) {
 	// create a new periodic gathering job
-	gj, err := c.jobController.CreateGathererJob(ctx, dataGather.Name, c.image, c.configAggregator.Config().DataReporting.StoragePath)
+	gj, err := c.jobController.CreateGathererJob(ctx, dataGather.Name, image, c.configAggregator.Config().DataReporting.StoragePath)
 	if err != nil {
 		klog.Errorf("Failed to create a new job: %v", err)
 		return
@@ -827,4 +842,33 @@ func updateMetrics(dataGather *insightsv1alpha1.DataGather) {
 		}
 	}
 	insights.IncrementCounterRequestSend(statusCode)
+}
+
+// setRemoteConfigConditionsWhenDisabled updates the RemoteConfig clusteroperator conditions
+// in a disabled cluster. It means that the RemoteConfigurationAvailable=False and RemoteConfigurationValid=Unknown.
+func (c *Controller) setRemoteConfigConditionsWhenDisabled(ctx context.Context) error {
+	insightsCo, err := c.openshiftConfCli.ClusterOperators().Get(ctx, "insights", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	raIdx := getClusterOperatorConditionIndexByType(status.RemoteConfigurationAvailable, insightsCo.Status.Conditions)
+	insightsCo.Status.Conditions[raIdx] = v1.ClusterOperatorStatusCondition{
+		Type:               status.RemoteConfigurationAvailable,
+		Status:             v1.ConditionFalse,
+		Reason:             gatheringDisabledReason,
+		Message:            "Data gathering is disabled",
+		LastTransitionTime: metav1.Now(),
+	}
+	raIdx = getClusterOperatorConditionIndexByType(status.RemoteConfigurationValid, insightsCo.Status.Conditions)
+	insightsCo.Status.Conditions[raIdx] = v1.ClusterOperatorStatusCondition{
+		Type:               status.RemoteConfigurationValid,
+		Status:             v1.ConditionUnknown,
+		Reason:             status.NoValidationYet,
+		LastTransitionTime: metav1.Now(),
+	}
+	_, err = c.openshiftConfCli.ClusterOperators().UpdateStatus(ctx, insightsCo, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -391,6 +391,14 @@ func (c *Controller) updateControllerConditions(cs *conditions, isInitializing b
 	// we set the following Remote Configuration conditions only in non-techpreview clusters
 	// In tech preview clusters, it's not handy to use this status controller, because there are
 	// two status conditions related to the single source of status (condition gatherer in this case)
+	if c.ctrlStatus.isDisabled() {
+		status := c.ctrlStatus.getStatus(DisabledStatus)
+		cs.setCondition(RemoteConfigurationAvailable, configv1.ConditionFalse, status.reason, status.message)
+		// if the remote configuration is not available then we can't say it's valid or not
+		cs.setCondition(RemoteConfigurationValid, configv1.ConditionUnknown, NoValidationYet, "")
+		return
+	}
+
 	if rs := c.ctrlStatus.getStatus(RemoteConfigAvailableStatus); rs != nil {
 		cs.setCondition(RemoteConfigurationAvailable, configv1.ConditionFalse, rs.reason, rs.message)
 		// if the remote configuration is not available then we can't say it's valid or not


### PR DESCRIPTION
…rationValid clusteroperator conditions in disabled cluster

<!-- Short description of the PR. What does it do? -->


## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-41932
https://access.redhat.com/solutions/???
