### PR TITLE
[release-4.15] OCPBUGS-39395: collect some nmstate customresources 

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1392,6 +1392,56 @@ None
 None
 
 
+## NodeNetworkConfigurationPolicy
+
+Collects cluster scope "nodenetworkconfigurationpolicy.nmstate.io/v1"
+resources
+
+### API Reference
+- https://github.com/nmstate/kubernetes-nmstate/blob/main/api/v1/nodenetworkconfigurationpolicy_types.go
+
+### Sample data
+- [docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/etcd-quorum-guard.json](./insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/etcd-quorum-guard.json)
+
+### Location in archive
+- `cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/{name}.json`
+
+### Config ID
+`clusterconfig/nodenetworkconfigurationpolicies`
+
+### Released version
+- 4.18.0
+
+### Backported versions
+
+### Changes
+
+
+## NodeNetworkState
+
+Collects cluster scope "nodenetworkstate.nmstate.io/v1beta1"
+resources
+
+### API Reference
+- https://github.com/nmstate/kubernetes-nmstate/blob/main/api/v1beta1/nodenetworkstate_types.go
+
+### Sample data
+- [docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/etcd-quorum-guard.json](./insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/etcd-quorum-guard.json)
+
+### Location in archive
+- `cluster-scoped-resources/nmstate.io/nodenetworkstates/{name}.json`
+
+### Config ID
+`clusterconfig/nodenetworkstates`
+
+### Released version
+- 4.18.0
+
+### Backported versions
+
+### Changes
+
+
 ## Nodes
 
 Collects all node resources.

--- a/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/policy-name.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/policy-name.json
@@ -1,0 +1,52 @@
+{
+    "apiVersion": "nmstate.io/v1",
+    "kind": "NodeNetworkConfigurationPolicy",
+    "metadata": {
+        "annotations": {
+            "nmstate.io/webhook-mutating-timestamp": "1724753787619122019"
+        },
+        "creationTimestamp": "2024-08-27T10:16:27Z",
+        "generation": 1,
+        "name": "policy-name",
+        "resourceVersion": "140132",
+        "uid": "d5e205ba-b034-42d1-bd93-a1dde9738aeb"
+    },
+    "spec": {
+        "desiredState": {
+            "interfaces": [
+                {
+                    "name": "br0",
+                    "state": "up",
+                    "type": "linux-bridge"
+                }
+            ]
+        }
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastHeartbeatTime": "2024-08-27T11:52:07Z",
+                "lastTransitionTime": "2024-08-27T11:52:07Z",
+                "message": "5/5 nodes successfully configured",
+                "reason": "SuccessfullyConfigured",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-27T11:52:07Z",
+                "lastTransitionTime": "2024-08-27T11:52:07Z",
+                "reason": "SuccessfullyConfigured",
+                "status": "False",
+                "type": "Degraded"
+            },
+            {
+                "lastHeartbeatTime": "2024-08-27T11:52:07Z",
+                "lastTransitionTime": "2024-08-27T11:52:07Z",
+                "reason": "ConfigurationProgressing",
+                "status": "False",
+                "type": "Progressing"
+            }
+        ],
+        "lastUnavailableNodeCountUpdate": "2024-08-27T10:16:37Z"
+    }
+}

--- a/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-21-41.us-east-2.compute.internal.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-21-41.us-east-2.compute.internal.json
@@ -1,0 +1,620 @@
+{
+    "apiVersion": "nmstate.io/v1beta1",
+    "kind": "NodeNetworkState",
+    "metadata": {
+        "creationTimestamp": "2024-08-27T12:51:52Z",
+        "generation": 1,
+        "labels": {
+            "nmstate.io/force-nns-refresh": "1724763113550238006"
+        },
+        "name": "ip-10-0-21-41.us-east-2.compute.internal",
+        "ownerReferences": [
+            {
+                "apiVersion": "v1",
+                "kind": "Node",
+                "name": "ip-10-0-21-41.us-east-2.compute.internal",
+                "uid": "bedd754f-77db-4f22-950c-40f5a5a6062f"
+            }
+        ],
+        "resourceVersion": "179624",
+        "uid": "1e0d4b3e-7db6-451d-9bb0-f4cf3036559b"
+    },
+    "status": {
+        "currentState": {
+            "dns-resolver": {
+                "config": {
+                    "search": null,
+                    "server": null
+                },
+                "running": {
+                    "search": [
+                        "us-east-2.compute.internal"
+                    ],
+                    "server": [
+                        "10.0.0.2"
+                    ]
+                }
+            },
+            "interfaces": [
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.0.21.41",
+                                "preferred-life-time": "2913sec",
+                                "prefix-length": 19,
+                                "valid-life-time": "2913sec"
+                            },
+                            {
+                                "ip": "169.254.0.2",
+                                "prefix-length": 17
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "address": [
+                            {
+                                "ip": "fe80::c175:5d6d:4d1c:4f7",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 9001,
+                    "name": "br-ex",
+                    "profile-name": "ovs-if-br-ex",
+                    "state": "up",
+                    "type": "ovs-interface",
+                    "wait-ip": "ipv4"
+                },
+                {
+                    "bridge": {
+                        "options": {
+                            "datapath": "",
+                            "fail-mode": "",
+                            "mcast-snooping-enable": false,
+                            "rstp": false,
+                            "stp": {
+                                "enabled": false
+                            }
+                        },
+                        "port": [
+                            {
+                                "name": "br-ex"
+                            },
+                            {
+                                "name": "ens5"
+                            },
+                            {
+                                "name": "patch-br-ex_ip-10-0-21-41.us-east-2.compute.internal-to-br-int"
+                            }
+                        ]
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "name": "br-ex",
+                    "ovs-db": {
+                        "external_ids": {},
+                        "other_config": {
+                            "hwaddr": "02:21:B0:76:D3:47"
+                        }
+                    },
+                    "state": "up",
+                    "type": "ovs-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 8901,
+                    "name": "br-int",
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "bridge": {
+                        "options": {
+                            "group-addr": "01:80:C2:00:00:00",
+                            "group-forward-mask": 0,
+                            "group-fwd-mask": 0,
+                            "hash-max": 4096,
+                            "mac-ageing-time": 300,
+                            "multicast-last-member-count": 2,
+                            "multicast-last-member-interval": 100,
+                            "multicast-membership-interval": 26000,
+                            "multicast-querier": false,
+                            "multicast-querier-interval": 25500,
+                            "multicast-query-interval": 12500,
+                            "multicast-query-response-interval": 1000,
+                            "multicast-query-use-ifaddr": false,
+                            "multicast-router": "auto",
+                            "multicast-snooping": true,
+                            "multicast-startup-query-count": 2,
+                            "multicast-startup-query-interval": 3125,
+                            "stp": {
+                                "enabled": true,
+                                "forward-delay": 15,
+                                "hello-time": 2,
+                                "max-age": 20,
+                                "priority": 32768
+                            },
+                            "vlan-default-pvid": 1,
+                            "vlan-protocol": "802.1q"
+                        },
+                        "port": []
+                    },
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-esp-segmentation": true,
+                            "tx-fcoe-segmentation": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-gso-partial": true,
+                            "tx-gso-robust": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-tunnel-remcsum-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "autoconf": false,
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 1500,
+                    "name": "br0",
+                    "state": "up",
+                    "type": "linux-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "driver": "ena",
+                    "ethernet": {},
+                    "ethtool": {
+                        "coalesce": {
+                            "adaptive-rx": false,
+                            "rx-usecs": 0,
+                            "tx-usecs": 64
+                        },
+                        "feature": {
+                            "highdma": true,
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-hashing": true,
+                            "rx-udp-gro-forwarding": true,
+                            "tx-checksum-ipv4": true,
+                            "tx-generic-segmentation": true,
+                            "tx-nocache-copy": false
+                        },
+                        "ring": {
+                            "rx": 1024,
+                            "rx-max": 16384,
+                            "tx": 1024,
+                            "tx-max": 1024
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 9216,
+                    "min-mtu": 128,
+                    "mtu": 9001,
+                    "name": "ens5",
+                    "permanent-mac-address": "02:21:B0:76:D3:47",
+                    "profile-name": "ovs-if-phys0",
+                    "state": "up",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "ovs-system",
+                    "ethernet": {},
+                    "ethtool": {
+                        "feature": {
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::a0bd:14ff:fe54:8a6b",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65465,
+                    "min-mtu": 68,
+                    "mtu": 65000,
+                    "name": "genev_sys_6081",
+                    "state": "ignore",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "ethtool": {
+                        "feature": {
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "127.0.0.1",
+                                "prefix-length": 8
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "::1",
+                                "prefix-length": 128
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "mtu": 65536,
+                    "name": "lo",
+                    "state": "up",
+                    "type": "loopback"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.130.8.2",
+                                "prefix-length": 23
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::4cb3:8bff:fe7a:68d4",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 8901,
+                    "name": "ovn-k8s-mp0",
+                    "ovs-db": {
+                        "external_ids": {
+                            "iface-id": "k8s-ip-10-0-21-41.us-east-2.compute.internal",
+                            "ovn-installed": "true",
+                            "ovn-installed-ts": "1724763108703"
+                        },
+                        "other_config": {}
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-ex",
+                    "name": "patch-br-ex_ip-10-0-21-41.us-east-2.compute.internal-to-br-int",
+                    "patch": {
+                        "peer": "patch-br-int-to-br-ex_ip-10-0-21-41.us-east-2.compute.internal"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-int",
+                    "name": "patch-br-int-to-br-ex_ip-10-0-21-41.us-east-2.compute.internal",
+                    "patch": {
+                        "peer": "patch-br-ex_ip-10-0-21-41.us-east-2.compute.internal-to-br-int"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                }
+            ],
+            "ovn": {
+                "bridge-mappings": [
+                    {
+                        "bridge": "br-ex",
+                        "localnet": "physnet"
+                    }
+                ]
+            },
+            "routes": {
+                "config": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.130.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.130.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.130.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ],
+                "running": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.130.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.130.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.130.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "0.0.0.0/0",
+                        "metric": 48,
+                        "next-hop-address": "10.0.0.1",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ]
+            }
+        },
+        "handlerNmstateVersion": "nmstatectl 2.2.33",
+        "hostNetworkManagerVersion": "1.46.0",
+        "lastSuccessfulUpdateTime": "2024-08-27T13:32:11Z"
+    }
+}

--- a/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-24-83.us-east-2.compute.internal.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-24-83.us-east-2.compute.internal.json
@@ -1,0 +1,620 @@
+{
+    "apiVersion": "nmstate.io/v1beta1",
+    "kind": "NodeNetworkState",
+    "metadata": {
+        "creationTimestamp": "2024-08-27T10:11:12Z",
+        "generation": 1,
+        "labels": {
+            "nmstate.io/force-nns-refresh": "1724753797149402587"
+        },
+        "name": "ip-10-0-24-83.us-east-2.compute.internal",
+        "ownerReferences": [
+            {
+                "apiVersion": "v1",
+                "kind": "Node",
+                "name": "ip-10-0-24-83.us-east-2.compute.internal",
+                "uid": "3c93e257-6acb-40b5-b4a8-66c3b7d8e39d"
+            }
+        ],
+        "resourceVersion": "179799",
+        "uid": "c09ccd60-1063-41cd-8275-9b34d8efed2d"
+    },
+    "status": {
+        "currentState": {
+            "dns-resolver": {
+                "config": {
+                    "search": null,
+                    "server": null
+                },
+                "running": {
+                    "search": [
+                        "us-east-2.compute.internal"
+                    ],
+                    "server": [
+                        "10.0.0.2"
+                    ]
+                }
+            },
+            "interfaces": [
+                {
+                    "bridge": {
+                        "options": {
+                            "datapath": "",
+                            "fail-mode": "",
+                            "mcast-snooping-enable": false,
+                            "rstp": false,
+                            "stp": {
+                                "enabled": false
+                            }
+                        },
+                        "port": [
+                            {
+                                "name": "br-ex"
+                            },
+                            {
+                                "name": "ens5"
+                            },
+                            {
+                                "name": "patch-br-ex_ip-10-0-24-83.us-east-2.compute.internal-to-br-int"
+                            }
+                        ]
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "name": "br-ex",
+                    "ovs-db": {
+                        "external_ids": {},
+                        "other_config": {
+                            "hwaddr": "02:66:96:A4:24:C1"
+                        }
+                    },
+                    "state": "up",
+                    "type": "ovs-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.0.24.83",
+                                "preferred-life-time": "3274sec",
+                                "prefix-length": 19,
+                                "valid-life-time": "3274sec"
+                            },
+                            {
+                                "ip": "169.254.0.2",
+                                "prefix-length": 17
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "address": [
+                            {
+                                "ip": "fe80::cad6:203f:d81e:d8c1",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 9001,
+                    "name": "br-ex",
+                    "profile-name": "ovs-if-br-ex",
+                    "state": "up",
+                    "type": "ovs-interface",
+                    "wait-ip": "ipv4"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 8901,
+                    "name": "br-int",
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "bridge": {
+                        "options": {
+                            "group-addr": "01:80:C2:00:00:00",
+                            "group-forward-mask": 0,
+                            "group-fwd-mask": 0,
+                            "hash-max": 4096,
+                            "mac-ageing-time": 300,
+                            "multicast-last-member-count": 2,
+                            "multicast-last-member-interval": 100,
+                            "multicast-membership-interval": 26000,
+                            "multicast-querier": false,
+                            "multicast-querier-interval": 25500,
+                            "multicast-query-interval": 12500,
+                            "multicast-query-response-interval": 1000,
+                            "multicast-query-use-ifaddr": false,
+                            "multicast-router": "auto",
+                            "multicast-snooping": true,
+                            "multicast-startup-query-count": 2,
+                            "multicast-startup-query-interval": 3125,
+                            "stp": {
+                                "enabled": true,
+                                "forward-delay": 15,
+                                "hello-time": 2,
+                                "max-age": 20,
+                                "priority": 32768
+                            },
+                            "vlan-default-pvid": 1,
+                            "vlan-protocol": "802.1q"
+                        },
+                        "port": []
+                    },
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-esp-segmentation": true,
+                            "tx-fcoe-segmentation": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-gso-partial": true,
+                            "tx-gso-robust": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-tunnel-remcsum-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "autoconf": false,
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 1500,
+                    "name": "br0",
+                    "state": "up",
+                    "type": "linux-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "driver": "ena",
+                    "ethernet": {},
+                    "ethtool": {
+                        "coalesce": {
+                            "adaptive-rx": false,
+                            "rx-usecs": 0,
+                            "tx-usecs": 64
+                        },
+                        "feature": {
+                            "highdma": true,
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-hashing": true,
+                            "rx-udp-gro-forwarding": true,
+                            "tx-checksum-ipv4": true,
+                            "tx-generic-segmentation": true,
+                            "tx-nocache-copy": false
+                        },
+                        "ring": {
+                            "rx": 1024,
+                            "rx-max": 16384,
+                            "tx": 1024,
+                            "tx-max": 1024
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 9216,
+                    "min-mtu": 128,
+                    "mtu": 9001,
+                    "name": "ens5",
+                    "permanent-mac-address": "02:66:96:A4:24:C1",
+                    "profile-name": "ovs-if-phys0",
+                    "state": "up",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "ovs-system",
+                    "ethernet": {},
+                    "ethtool": {
+                        "feature": {
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::5c3d:beff:fe24:e9fd",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65465,
+                    "min-mtu": 68,
+                    "mtu": 65000,
+                    "name": "genev_sys_6081",
+                    "state": "ignore",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "ethtool": {
+                        "feature": {
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "127.0.0.1",
+                                "prefix-length": 8
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "::1",
+                                "prefix-length": 128
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "mtu": 65536,
+                    "name": "lo",
+                    "state": "up",
+                    "type": "loopback"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.128.0.2",
+                                "prefix-length": 23
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::8850:2cff:fe63:6660",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 8901,
+                    "name": "ovn-k8s-mp0",
+                    "ovs-db": {
+                        "external_ids": {
+                            "iface-id": "k8s-ip-10-0-24-83.us-east-2.compute.internal",
+                            "ovn-installed": "true",
+                            "ovn-installed-ts": "1724740191009"
+                        },
+                        "other_config": {}
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-ex",
+                    "name": "patch-br-ex_ip-10-0-24-83.us-east-2.compute.internal-to-br-int",
+                    "patch": {
+                        "peer": "patch-br-int-to-br-ex_ip-10-0-24-83.us-east-2.compute.internal"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-int",
+                    "name": "patch-br-int-to-br-ex_ip-10-0-24-83.us-east-2.compute.internal",
+                    "patch": {
+                        "peer": "patch-br-ex_ip-10-0-24-83.us-east-2.compute.internal-to-br-int"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                }
+            ],
+            "ovn": {
+                "bridge-mappings": [
+                    {
+                        "bridge": "br-ex",
+                        "localnet": "physnet"
+                    }
+                ]
+            },
+            "routes": {
+                "config": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.128.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.128.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.128.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ],
+                "running": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.128.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.128.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.128.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "0.0.0.0/0",
+                        "metric": 48,
+                        "next-hop-address": "10.0.0.1",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ]
+            }
+        },
+        "handlerNmstateVersion": "nmstatectl 2.2.33",
+        "hostNetworkManagerVersion": "1.46.0",
+        "lastSuccessfulUpdateTime": "2024-08-27T13:32:42Z"
+    }
+}

--- a/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-42-30.us-east-2.compute.internal.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-42-30.us-east-2.compute.internal.json
@@ -1,0 +1,620 @@
+{
+    "apiVersion": "nmstate.io/v1beta1",
+    "kind": "NodeNetworkState",
+    "metadata": {
+        "creationTimestamp": "2024-08-27T12:50:37Z",
+        "generation": 1,
+        "labels": {
+            "nmstate.io/force-nns-refresh": "1724763038818557189"
+        },
+        "name": "ip-10-0-42-30.us-east-2.compute.internal",
+        "ownerReferences": [
+            {
+                "apiVersion": "v1",
+                "kind": "Node",
+                "name": "ip-10-0-42-30.us-east-2.compute.internal",
+                "uid": "0ca81670-5779-4945-b03a-a784ee3e0d4b"
+            }
+        ],
+        "resourceVersion": "179811",
+        "uid": "89dcfaae-ed36-468c-bb6a-cbf70ece3fc5"
+    },
+    "status": {
+        "currentState": {
+            "dns-resolver": {
+                "config": {
+                    "search": null,
+                    "server": null
+                },
+                "running": {
+                    "search": [
+                        "us-east-2.compute.internal"
+                    ],
+                    "server": [
+                        "10.0.0.2"
+                    ]
+                }
+            },
+            "interfaces": [
+                {
+                    "bridge": {
+                        "options": {
+                            "datapath": "",
+                            "fail-mode": "",
+                            "mcast-snooping-enable": false,
+                            "rstp": false,
+                            "stp": {
+                                "enabled": false
+                            }
+                        },
+                        "port": [
+                            {
+                                "name": "br-ex"
+                            },
+                            {
+                                "name": "ens5"
+                            },
+                            {
+                                "name": "patch-br-ex_ip-10-0-42-30.us-east-2.compute.internal-to-br-int"
+                            }
+                        ]
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "name": "br-ex",
+                    "ovs-db": {
+                        "external_ids": {},
+                        "other_config": {
+                            "hwaddr": "06:6E:1A:65:90:AF"
+                        }
+                    },
+                    "state": "up",
+                    "type": "ovs-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.0.42.30",
+                                "preferred-life-time": "2803sec",
+                                "prefix-length": 19,
+                                "valid-life-time": "2803sec"
+                            },
+                            {
+                                "ip": "169.254.0.2",
+                                "prefix-length": 17
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "address": [
+                            {
+                                "ip": "fe80::ffa0:1a6c:baf0:aeba",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 9001,
+                    "name": "br-ex",
+                    "profile-name": "ovs-if-br-ex",
+                    "state": "up",
+                    "type": "ovs-interface",
+                    "wait-ip": "ipv4"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 8901,
+                    "name": "br-int",
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "bridge": {
+                        "options": {
+                            "group-addr": "01:80:C2:00:00:00",
+                            "group-forward-mask": 0,
+                            "group-fwd-mask": 0,
+                            "hash-max": 4096,
+                            "mac-ageing-time": 300,
+                            "multicast-last-member-count": 2,
+                            "multicast-last-member-interval": 100,
+                            "multicast-membership-interval": 26000,
+                            "multicast-querier": false,
+                            "multicast-querier-interval": 25500,
+                            "multicast-query-interval": 12500,
+                            "multicast-query-response-interval": 1000,
+                            "multicast-query-use-ifaddr": false,
+                            "multicast-router": "auto",
+                            "multicast-snooping": true,
+                            "multicast-startup-query-count": 2,
+                            "multicast-startup-query-interval": 3125,
+                            "stp": {
+                                "enabled": true,
+                                "forward-delay": 15,
+                                "hello-time": 2,
+                                "max-age": 20,
+                                "priority": 32768
+                            },
+                            "vlan-default-pvid": 1,
+                            "vlan-protocol": "802.1q"
+                        },
+                        "port": []
+                    },
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-esp-segmentation": true,
+                            "tx-fcoe-segmentation": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-gso-partial": true,
+                            "tx-gso-robust": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-tunnel-remcsum-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "autoconf": false,
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 1500,
+                    "name": "br0",
+                    "state": "up",
+                    "type": "linux-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "driver": "ena",
+                    "ethernet": {},
+                    "ethtool": {
+                        "coalesce": {
+                            "adaptive-rx": false,
+                            "rx-usecs": 0,
+                            "tx-usecs": 64
+                        },
+                        "feature": {
+                            "highdma": true,
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-hashing": true,
+                            "rx-udp-gro-forwarding": true,
+                            "tx-checksum-ipv4": true,
+                            "tx-generic-segmentation": true,
+                            "tx-nocache-copy": false
+                        },
+                        "ring": {
+                            "rx": 1024,
+                            "rx-max": 16384,
+                            "tx": 1024,
+                            "tx-max": 1024
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 9216,
+                    "min-mtu": 128,
+                    "mtu": 9001,
+                    "name": "ens5",
+                    "permanent-mac-address": "06:6E:1A:65:90:AF",
+                    "profile-name": "ovs-if-phys0",
+                    "state": "up",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "ovs-system",
+                    "ethernet": {},
+                    "ethtool": {
+                        "feature": {
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::9c02:67ff:fe1b:85a9",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65465,
+                    "min-mtu": 68,
+                    "mtu": 65000,
+                    "name": "genev_sys_6081",
+                    "state": "ignore",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "ethtool": {
+                        "feature": {
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "127.0.0.1",
+                                "prefix-length": 8
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "::1",
+                                "prefix-length": 128
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "mtu": 65536,
+                    "name": "lo",
+                    "state": "up",
+                    "type": "loopback"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.128.8.2",
+                                "prefix-length": 23
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::d467:b7ff:fea4:ef90",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 8901,
+                    "name": "ovn-k8s-mp0",
+                    "ovs-db": {
+                        "external_ids": {
+                            "iface-id": "k8s-ip-10-0-42-30.us-east-2.compute.internal",
+                            "ovn-installed": "true",
+                            "ovn-installed-ts": "1724763030075"
+                        },
+                        "other_config": {}
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-ex",
+                    "name": "patch-br-ex_ip-10-0-42-30.us-east-2.compute.internal-to-br-int",
+                    "patch": {
+                        "peer": "patch-br-int-to-br-ex_ip-10-0-42-30.us-east-2.compute.internal"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-int",
+                    "name": "patch-br-int-to-br-ex_ip-10-0-42-30.us-east-2.compute.internal",
+                    "patch": {
+                        "peer": "patch-br-ex_ip-10-0-42-30.us-east-2.compute.internal-to-br-int"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                }
+            ],
+            "ovn": {
+                "bridge-mappings": [
+                    {
+                        "bridge": "br-ex",
+                        "localnet": "physnet"
+                    }
+                ]
+            },
+            "routes": {
+                "config": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.128.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.128.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.128.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ],
+                "running": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.128.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.128.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.128.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "0.0.0.0/0",
+                        "metric": 48,
+                        "next-hop-address": "10.0.32.1",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ]
+            }
+        },
+        "handlerNmstateVersion": "nmstatectl 2.2.33",
+        "hostNetworkManagerVersion": "1.46.0",
+        "lastSuccessfulUpdateTime": "2024-08-27T13:32:43Z"
+    }
+}

--- a/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-61-249.us-east-2.compute.internal.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-61-249.us-east-2.compute.internal.json
@@ -1,0 +1,620 @@
+{
+    "apiVersion": "nmstate.io/v1beta1",
+    "kind": "NodeNetworkState",
+    "metadata": {
+        "creationTimestamp": "2024-08-27T10:11:07Z",
+        "generation": 1,
+        "labels": {
+            "nmstate.io/force-nns-refresh": "1724753796108669355"
+        },
+        "name": "ip-10-0-61-249.us-east-2.compute.internal",
+        "ownerReferences": [
+            {
+                "apiVersion": "v1",
+                "kind": "Node",
+                "name": "ip-10-0-61-249.us-east-2.compute.internal",
+                "uid": "a2ce0a92-b32c-4485-b78a-68cacfd83834"
+            }
+        ],
+        "resourceVersion": "179719",
+        "uid": "f3670ca8-e573-4f57-ad1e-781638d7168a"
+    },
+    "status": {
+        "currentState": {
+            "dns-resolver": {
+                "config": {
+                    "search": null,
+                    "server": null
+                },
+                "running": {
+                    "search": [
+                        "us-east-2.compute.internal"
+                    ],
+                    "server": [
+                        "10.0.0.2"
+                    ]
+                }
+            },
+            "interfaces": [
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.0.61.249",
+                                "preferred-life-time": "3288sec",
+                                "prefix-length": 19,
+                                "valid-life-time": "3288sec"
+                            },
+                            {
+                                "ip": "169.254.0.2",
+                                "prefix-length": 17
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "address": [
+                            {
+                                "ip": "fe80::8af3:2c05:8c18:27af",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 9001,
+                    "name": "br-ex",
+                    "profile-name": "ovs-if-br-ex",
+                    "state": "up",
+                    "type": "ovs-interface",
+                    "wait-ip": "ipv4"
+                },
+                {
+                    "bridge": {
+                        "options": {
+                            "datapath": "",
+                            "fail-mode": "",
+                            "mcast-snooping-enable": false,
+                            "rstp": false,
+                            "stp": {
+                                "enabled": false
+                            }
+                        },
+                        "port": [
+                            {
+                                "name": "br-ex"
+                            },
+                            {
+                                "name": "ens5"
+                            },
+                            {
+                                "name": "patch-br-ex_ip-10-0-61-249.us-east-2.compute.internal-to-br-int"
+                            }
+                        ]
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "name": "br-ex",
+                    "ovs-db": {
+                        "external_ids": {},
+                        "other_config": {
+                            "hwaddr": "06:B4:BC:C1:FA:5D"
+                        }
+                    },
+                    "state": "up",
+                    "type": "ovs-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 8901,
+                    "name": "br-int",
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "bridge": {
+                        "options": {
+                            "group-addr": "01:80:C2:00:00:00",
+                            "group-forward-mask": 0,
+                            "group-fwd-mask": 0,
+                            "hash-max": 4096,
+                            "mac-ageing-time": 300,
+                            "multicast-last-member-count": 2,
+                            "multicast-last-member-interval": 100,
+                            "multicast-membership-interval": 26000,
+                            "multicast-querier": false,
+                            "multicast-querier-interval": 25500,
+                            "multicast-query-interval": 12500,
+                            "multicast-query-response-interval": 1000,
+                            "multicast-query-use-ifaddr": false,
+                            "multicast-router": "auto",
+                            "multicast-snooping": true,
+                            "multicast-startup-query-count": 2,
+                            "multicast-startup-query-interval": 3125,
+                            "stp": {
+                                "enabled": true,
+                                "forward-delay": 15,
+                                "hello-time": 2,
+                                "max-age": 20,
+                                "priority": 32768
+                            },
+                            "vlan-default-pvid": 1,
+                            "vlan-protocol": "802.1q"
+                        },
+                        "port": []
+                    },
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-esp-segmentation": true,
+                            "tx-fcoe-segmentation": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-gso-partial": true,
+                            "tx-gso-robust": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-tunnel-remcsum-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "autoconf": false,
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 1500,
+                    "name": "br0",
+                    "state": "up",
+                    "type": "linux-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "driver": "ena",
+                    "ethernet": {},
+                    "ethtool": {
+                        "coalesce": {
+                            "adaptive-rx": false,
+                            "rx-usecs": 0,
+                            "tx-usecs": 64
+                        },
+                        "feature": {
+                            "highdma": true,
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-hashing": true,
+                            "rx-udp-gro-forwarding": true,
+                            "tx-checksum-ipv4": true,
+                            "tx-generic-segmentation": true,
+                            "tx-nocache-copy": false
+                        },
+                        "ring": {
+                            "rx": 1024,
+                            "rx-max": 16384,
+                            "tx": 1024,
+                            "tx-max": 1024
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 9216,
+                    "min-mtu": 128,
+                    "mtu": 9001,
+                    "name": "ens5",
+                    "permanent-mac-address": "06:B4:BC:C1:FA:5D",
+                    "profile-name": "ovs-if-phys0",
+                    "state": "up",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "ovs-system",
+                    "ethernet": {},
+                    "ethtool": {
+                        "feature": {
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::3889:9bff:fe63:4ae2",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65465,
+                    "min-mtu": 68,
+                    "mtu": 65000,
+                    "name": "genev_sys_6081",
+                    "state": "ignore",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "ethtool": {
+                        "feature": {
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "127.0.0.1",
+                                "prefix-length": 8
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "::1",
+                                "prefix-length": 128
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "mtu": 65536,
+                    "name": "lo",
+                    "state": "up",
+                    "type": "loopback"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.129.0.2",
+                                "prefix-length": 23
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::7403:76ff:feed:af93",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 8901,
+                    "name": "ovn-k8s-mp0",
+                    "ovs-db": {
+                        "external_ids": {
+                            "iface-id": "k8s-ip-10-0-61-249.us-east-2.compute.internal",
+                            "ovn-installed": "true",
+                            "ovn-installed-ts": "1724740211834"
+                        },
+                        "other_config": {}
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-ex",
+                    "name": "patch-br-ex_ip-10-0-61-249.us-east-2.compute.internal-to-br-int",
+                    "patch": {
+                        "peer": "patch-br-int-to-br-ex_ip-10-0-61-249.us-east-2.compute.internal"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-int",
+                    "name": "patch-br-int-to-br-ex_ip-10-0-61-249.us-east-2.compute.internal",
+                    "patch": {
+                        "peer": "patch-br-ex_ip-10-0-61-249.us-east-2.compute.internal-to-br-int"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                }
+            ],
+            "ovn": {
+                "bridge-mappings": [
+                    {
+                        "bridge": "br-ex",
+                        "localnet": "physnet"
+                    }
+                ]
+            },
+            "routes": {
+                "config": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.129.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.129.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.129.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ],
+                "running": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.129.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.129.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.129.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "0.0.0.0/0",
+                        "metric": 48,
+                        "next-hop-address": "10.0.32.1",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ]
+            }
+        },
+        "handlerNmstateVersion": "nmstatectl 2.2.33",
+        "hostNetworkManagerVersion": "1.46.0",
+        "lastSuccessfulUpdateTime": "2024-08-27T13:32:28Z"
+    }
+}

--- a/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-78-199.us-east-2.compute.internal.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-78-199.us-east-2.compute.internal.json
@@ -1,0 +1,620 @@
+{
+    "apiVersion": "nmstate.io/v1beta1",
+    "kind": "NodeNetworkState",
+    "metadata": {
+        "creationTimestamp": "2024-08-27T12:50:37Z",
+        "generation": 1,
+        "labels": {
+            "nmstate.io/force-nns-refresh": "1724763038856286533"
+        },
+        "name": "ip-10-0-78-199.us-east-2.compute.internal",
+        "ownerReferences": [
+            {
+                "apiVersion": "v1",
+                "kind": "Node",
+                "name": "ip-10-0-78-199.us-east-2.compute.internal",
+                "uid": "1d528fcf-9b79-44a2-b6fd-914b4914c62e"
+            }
+        ],
+        "resourceVersion": "179491",
+        "uid": "8f47d4ed-ac7e-41a0-be59-78fedbd9f435"
+    },
+    "status": {
+        "currentState": {
+            "dns-resolver": {
+                "config": {
+                    "search": null,
+                    "server": null
+                },
+                "running": {
+                    "search": [
+                        "us-east-2.compute.internal"
+                    ],
+                    "server": [
+                        "10.0.0.2"
+                    ]
+                }
+            },
+            "interfaces": [
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.0.78.199",
+                                "preferred-life-time": "2862sec",
+                                "prefix-length": 19,
+                                "valid-life-time": "2862sec"
+                            },
+                            {
+                                "ip": "169.254.0.2",
+                                "prefix-length": 17
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "address": [
+                            {
+                                "ip": "fe80::f9c9:da27:3087:ee31",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 9001,
+                    "name": "br-ex",
+                    "profile-name": "ovs-if-br-ex",
+                    "state": "up",
+                    "type": "ovs-interface",
+                    "wait-ip": "ipv4"
+                },
+                {
+                    "bridge": {
+                        "options": {
+                            "datapath": "",
+                            "fail-mode": "",
+                            "mcast-snooping-enable": false,
+                            "rstp": false,
+                            "stp": {
+                                "enabled": false
+                            }
+                        },
+                        "port": [
+                            {
+                                "name": "br-ex"
+                            },
+                            {
+                                "name": "ens5"
+                            },
+                            {
+                                "name": "patch-br-ex_ip-10-0-78-199.us-east-2.compute.internal-to-br-int"
+                            }
+                        ]
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "name": "br-ex",
+                    "ovs-db": {
+                        "external_ids": {},
+                        "other_config": {
+                            "hwaddr": "0A:87:EC:E3:14:A5"
+                        }
+                    },
+                    "state": "up",
+                    "type": "ovs-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 8901,
+                    "name": "br-int",
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "bridge": {
+                        "options": {
+                            "group-addr": "01:80:C2:00:00:00",
+                            "group-forward-mask": 0,
+                            "group-fwd-mask": 0,
+                            "hash-max": 4096,
+                            "mac-ageing-time": 300,
+                            "multicast-last-member-count": 2,
+                            "multicast-last-member-interval": 100,
+                            "multicast-membership-interval": 26000,
+                            "multicast-querier": false,
+                            "multicast-querier-interval": 25500,
+                            "multicast-query-interval": 12500,
+                            "multicast-query-response-interval": 1000,
+                            "multicast-query-use-ifaddr": false,
+                            "multicast-router": "auto",
+                            "multicast-snooping": true,
+                            "multicast-startup-query-count": 2,
+                            "multicast-startup-query-interval": 3125,
+                            "stp": {
+                                "enabled": true,
+                                "forward-delay": 15,
+                                "hello-time": 2,
+                                "max-age": 20,
+                                "priority": 32768
+                            },
+                            "vlan-default-pvid": 1,
+                            "vlan-protocol": "802.1q"
+                        },
+                        "port": []
+                    },
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-esp-segmentation": true,
+                            "tx-fcoe-segmentation": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-gso-partial": true,
+                            "tx-gso-robust": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-tunnel-remcsum-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "autoconf": false,
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 1500,
+                    "name": "br0",
+                    "state": "up",
+                    "type": "linux-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "driver": "ena",
+                    "ethernet": {},
+                    "ethtool": {
+                        "coalesce": {
+                            "adaptive-rx": false,
+                            "rx-usecs": 0,
+                            "tx-usecs": 64
+                        },
+                        "feature": {
+                            "highdma": true,
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-hashing": true,
+                            "rx-udp-gro-forwarding": true,
+                            "tx-checksum-ipv4": true,
+                            "tx-generic-segmentation": true,
+                            "tx-nocache-copy": false
+                        },
+                        "ring": {
+                            "rx": 1024,
+                            "rx-max": 16384,
+                            "tx": 1024,
+                            "tx-max": 1024
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 9216,
+                    "min-mtu": 128,
+                    "mtu": 9001,
+                    "name": "ens5",
+                    "permanent-mac-address": "0A:87:EC:E3:14:A5",
+                    "profile-name": "ovs-if-phys0",
+                    "state": "up",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "ovs-system",
+                    "ethernet": {},
+                    "ethtool": {
+                        "feature": {
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::b057:2dff:fed7:d02b",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65465,
+                    "min-mtu": 68,
+                    "mtu": 65000,
+                    "name": "genev_sys_6081",
+                    "state": "ignore",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "ethtool": {
+                        "feature": {
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "127.0.0.1",
+                                "prefix-length": 8
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "::1",
+                                "prefix-length": 128
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "mtu": 65536,
+                    "name": "lo",
+                    "state": "up",
+                    "type": "loopback"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.129.8.2",
+                                "prefix-length": 23
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::bcd6:a1ff:fe92:64de",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 8901,
+                    "name": "ovn-k8s-mp0",
+                    "ovs-db": {
+                        "external_ids": {
+                            "iface-id": "k8s-ip-10-0-78-199.us-east-2.compute.internal",
+                            "ovn-installed": "true",
+                            "ovn-installed-ts": "1724763031952"
+                        },
+                        "other_config": {}
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-ex",
+                    "name": "patch-br-ex_ip-10-0-78-199.us-east-2.compute.internal-to-br-int",
+                    "patch": {
+                        "peer": "patch-br-int-to-br-ex_ip-10-0-78-199.us-east-2.compute.internal"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-int",
+                    "name": "patch-br-int-to-br-ex_ip-10-0-78-199.us-east-2.compute.internal",
+                    "patch": {
+                        "peer": "patch-br-ex_ip-10-0-78-199.us-east-2.compute.internal-to-br-int"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                }
+            ],
+            "ovn": {
+                "bridge-mappings": [
+                    {
+                        "bridge": "br-ex",
+                        "localnet": "physnet"
+                    }
+                ]
+            },
+            "routes": {
+                "config": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.129.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.129.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.129.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ],
+                "running": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.129.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.129.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.129.8.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "0.0.0.0/0",
+                        "metric": 48,
+                        "next-hop-address": "10.0.64.1",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ]
+            }
+        },
+        "handlerNmstateVersion": "nmstatectl 2.2.33",
+        "hostNetworkManagerVersion": "1.46.0",
+        "lastSuccessfulUpdateTime": "2024-08-27T13:31:45Z"
+    }
+}

--- a/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-85-177.us-east-2.compute.internal.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/ip-10-0-85-177.us-east-2.compute.internal.json
@@ -1,0 +1,620 @@
+{
+    "apiVersion": "nmstate.io/v1beta1",
+    "kind": "NodeNetworkState",
+    "metadata": {
+        "creationTimestamp": "2024-08-27T10:11:09Z",
+        "generation": 1,
+        "labels": {
+            "nmstate.io/force-nns-refresh": "1724753795786001810"
+        },
+        "name": "ip-10-0-85-177.us-east-2.compute.internal",
+        "ownerReferences": [
+            {
+                "apiVersion": "v1",
+                "kind": "Node",
+                "name": "ip-10-0-85-177.us-east-2.compute.internal",
+                "uid": "6e73a2bd-9af3-440a-9bf6-ed8bf9464669"
+            }
+        ],
+        "resourceVersion": "179639",
+        "uid": "5f08283c-175d-414d-9063-4bba7ac1ea98"
+    },
+    "status": {
+        "currentState": {
+            "dns-resolver": {
+                "config": {
+                    "search": null,
+                    "server": null
+                },
+                "running": {
+                    "search": [
+                        "us-east-2.compute.internal"
+                    ],
+                    "server": [
+                        "10.0.0.2"
+                    ]
+                }
+            },
+            "interfaces": [
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.0.85.177",
+                                "preferred-life-time": "3303sec",
+                                "prefix-length": 19,
+                                "valid-life-time": "3303sec"
+                            },
+                            {
+                                "ip": "169.254.0.2",
+                                "prefix-length": 17
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "address": [
+                            {
+                                "ip": "fe80::b32b:b7b3:d868:6a7",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-metric": 48,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 9001,
+                    "name": "br-ex",
+                    "profile-name": "ovs-if-br-ex",
+                    "state": "up",
+                    "type": "ovs-interface",
+                    "wait-ip": "ipv4"
+                },
+                {
+                    "bridge": {
+                        "options": {
+                            "datapath": "",
+                            "fail-mode": "",
+                            "mcast-snooping-enable": false,
+                            "rstp": false,
+                            "stp": {
+                                "enabled": false
+                            }
+                        },
+                        "port": [
+                            {
+                                "name": "br-ex"
+                            },
+                            {
+                                "name": "ens5"
+                            },
+                            {
+                                "name": "patch-br-ex_ip-10-0-85-177.us-east-2.compute.internal-to-br-int"
+                            }
+                        ]
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "addr-gen-mode": "stable-privacy",
+                        "auto-dns": true,
+                        "auto-gateway": true,
+                        "auto-route-table-id": 0,
+                        "auto-routes": true,
+                        "autoconf": true,
+                        "dhcp": true,
+                        "dhcp-send-hostname": true,
+                        "enabled": true
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "name": "br-ex",
+                    "ovs-db": {
+                        "external_ids": {},
+                        "other_config": {
+                            "hwaddr": "0A:E9:55:A5:41:01"
+                        }
+                    },
+                    "state": "up",
+                    "type": "ovs-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 8901,
+                    "name": "br-int",
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "bridge": {
+                        "options": {
+                            "group-addr": "01:80:C2:00:00:00",
+                            "group-forward-mask": 0,
+                            "group-fwd-mask": 0,
+                            "hash-max": 4096,
+                            "mac-ageing-time": 300,
+                            "multicast-last-member-count": 2,
+                            "multicast-last-member-interval": 100,
+                            "multicast-membership-interval": 26000,
+                            "multicast-querier": false,
+                            "multicast-querier-interval": 25500,
+                            "multicast-query-interval": 12500,
+                            "multicast-query-response-interval": 1000,
+                            "multicast-query-use-ifaddr": false,
+                            "multicast-router": "auto",
+                            "multicast-snooping": true,
+                            "multicast-startup-query-count": 2,
+                            "multicast-startup-query-interval": 3125,
+                            "stp": {
+                                "enabled": true,
+                                "forward-delay": 15,
+                                "hello-time": 2,
+                                "max-age": 20,
+                                "priority": 32768
+                            },
+                            "vlan-default-pvid": 1,
+                            "vlan-protocol": "802.1q"
+                        },
+                        "port": []
+                    },
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-esp-segmentation": true,
+                            "tx-fcoe-segmentation": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-gso-partial": true,
+                            "tx-gso-robust": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-tunnel-remcsum-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "autoconf": false,
+                        "dhcp": false,
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mtu": 1500,
+                    "name": "br0",
+                    "state": "up",
+                    "type": "linux-bridge",
+                    "wait-ip": "any"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-ex",
+                    "driver": "ena",
+                    "ethernet": {},
+                    "ethtool": {
+                        "coalesce": {
+                            "adaptive-rx": false,
+                            "rx-usecs": 0,
+                            "tx-usecs": 64
+                        },
+                        "feature": {
+                            "highdma": true,
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-hashing": true,
+                            "rx-udp-gro-forwarding": true,
+                            "tx-checksum-ipv4": true,
+                            "tx-generic-segmentation": true,
+                            "tx-nocache-copy": false
+                        },
+                        "ring": {
+                            "rx": 1024,
+                            "rx-max": 16384,
+                            "tx": 1024,
+                            "tx-max": 1024
+                        }
+                    },
+                    "identifier": "name",
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "enabled": false
+                    },
+                    "lldp": {
+                        "enabled": false
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 9216,
+                    "min-mtu": 128,
+                    "mtu": 9001,
+                    "name": "ens5",
+                    "permanent-mac-address": "0A:E9:55:A5:41:01",
+                    "profile-name": "ovs-if-phys0",
+                    "state": "up",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "ovs-system",
+                    "ethernet": {},
+                    "ethtool": {
+                        "feature": {
+                            "rx-checksum": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "enabled": false
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::4:19ff:fe55:ab9e",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65465,
+                    "min-mtu": 68,
+                    "mtu": 65000,
+                    "name": "genev_sys_6081",
+                    "state": "ignore",
+                    "type": "ethernet"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "ethtool": {
+                        "feature": {
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-generic-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "127.0.0.1",
+                                "prefix-length": 8
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "::1",
+                                "prefix-length": 128
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "mtu": 65536,
+                    "name": "lo",
+                    "state": "up",
+                    "type": "loopback"
+                },
+                {
+                    "accept-all-mac-addresses": false,
+                    "controller": "br-int",
+                    "ethtool": {
+                        "feature": {
+                            "highdma": true,
+                            "rx-gro": true,
+                            "rx-gro-list": false,
+                            "rx-udp-gro-forwarding": false,
+                            "tx-checksum-ip-generic": true,
+                            "tx-generic-segmentation": true,
+                            "tx-gre-csum-segmentation": true,
+                            "tx-gre-segmentation": true,
+                            "tx-gso-list": true,
+                            "tx-ipxip4-segmentation": true,
+                            "tx-ipxip6-segmentation": true,
+                            "tx-nocache-copy": false,
+                            "tx-scatter-gather-fraglist": true,
+                            "tx-sctp-segmentation": true,
+                            "tx-tcp-ecn-segmentation": true,
+                            "tx-tcp-mangleid-segmentation": true,
+                            "tx-tcp-segmentation": true,
+                            "tx-tcp6-segmentation": true,
+                            "tx-udp-segmentation": true,
+                            "tx-udp_tnl-csum-segmentation": true,
+                            "tx-udp_tnl-segmentation": true,
+                            "tx-vlan-hw-insert": true,
+                            "tx-vlan-stag-hw-insert": true
+                        }
+                    },
+                    "ipv4": {
+                        "address": [
+                            {
+                                "ip": "10.130.0.2",
+                                "prefix-length": 23
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "ipv6": {
+                        "address": [
+                            {
+                                "ip": "fe80::b85f:f1ff:fedb:b0f8",
+                                "prefix-length": 64
+                            }
+                        ],
+                        "enabled": true
+                    },
+                    "mac-address": "xxxxxxxxxxxxxxxxx",
+                    "max-mtu": 65535,
+                    "min-mtu": 68,
+                    "mptcp": {
+                        "address-flags": []
+                    },
+                    "mtu": 8901,
+                    "name": "ovn-k8s-mp0",
+                    "ovs-db": {
+                        "external_ids": {
+                            "iface-id": "k8s-ip-10-0-85-177.us-east-2.compute.internal",
+                            "ovn-installed": "true",
+                            "ovn-installed-ts": "1724740211475"
+                        },
+                        "other_config": {}
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-ex",
+                    "name": "patch-br-ex_ip-10-0-85-177.us-east-2.compute.internal-to-br-int",
+                    "patch": {
+                        "peer": "patch-br-int-to-br-ex_ip-10-0-85-177.us-east-2.compute.internal"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                },
+                {
+                    "controller": "br-int",
+                    "name": "patch-br-int-to-br-ex_ip-10-0-85-177.us-east-2.compute.internal",
+                    "patch": {
+                        "peer": "patch-br-ex_ip-10-0-85-177.us-east-2.compute.internal-to-br-int"
+                    },
+                    "state": "ignore",
+                    "type": "ovs-interface"
+                }
+            ],
+            "ovn": {
+                "bridge-mappings": [
+                    {
+                        "bridge": "br-ex",
+                        "localnet": "physnet"
+                    }
+                ]
+            },
+            "routes": {
+                "config": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.130.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.130.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.130.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ],
+                "running": [
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "10.130.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 7
+                    },
+                    {
+                        "destination": "10.128.0.0/14",
+                        "next-hop-address": "10.130.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.1/32",
+                        "next-hop-address": "0.0.0.0",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "169.254.0.3/32",
+                        "next-hop-address": "10.130.0.1",
+                        "next-hop-interface": "ovn-k8s-mp0",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "172.30.0.0/16",
+                        "next-hop-address": "169.254.0.4",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    },
+                    {
+                        "destination": "0.0.0.0/0",
+                        "metric": 48,
+                        "next-hop-address": "10.0.64.1",
+                        "next-hop-interface": "br-ex",
+                        "table-id": 254
+                    }
+                ]
+            }
+        },
+        "handlerNmstateVersion": "nmstatectl 2.2.33",
+        "hostNetworkManagerVersion": "1.46.0",
+        "lastSuccessfulUpdateTime": "2024-08-27T13:32:14Z"
+    }
+}

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -322,6 +322,14 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - nmstate.io
+    resources:
+      - nodenetworkconfigurationpolicies
+      - nodenetworkstates
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -62,6 +62,8 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"networks":                          (*Gatherer).GatherClusterNetwork,
 	"node_logs":                         (*Gatherer).GatherNodeLogs,
 	"nodes":                             (*Gatherer).GatherNodes,
+	"nodenetworkconfigurationpolicies":  (*Gatherer).GatherNodeNetworkConfigurationPolicy,
+	"nodenetworkstates":                 (*Gatherer).GatherNodeNetworkState,
 	"oauths":                            (*Gatherer).GatherClusterOAuth,
 	"olm_operators":                     (*Gatherer).GatherOLMOperators,
 	"openshift_apiserver_operator_logs": (*Gatherer).GatherOpenShiftAPIServerOperatorLogs,

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -74,6 +74,9 @@ var (
 		Version:  "v1alpha1",
 		Resource: "clusterserviceversions",
 	}
+
+	nodeNetConfPoliciesV1GVR = schema.GroupVersionResource{Group: "nmstate.io", Version: "v1", Resource: "nodenetworkconfigurationpolicies"}
+	nodeNetStatesV1Beta1GVR  = schema.GroupVersionResource{Group: "nmstate.io", Version: "v1beta1", Resource: "nodenetworkstates"}
 )
 
 func init() { //nolint: gochecknoinits

--- a/pkg/gatherers/clusterconfig/gather_nmstate_node_network_configuration_policy.go
+++ b/pkg/gatherers/clusterconfig/gather_nmstate_node_network_configuration_policy.go
@@ -1,0 +1,61 @@
+// nolint: dupl
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// GatherNodeNetworkConfigurationPolicy Collects cluster scope "nodenetworkconfigurationpolicy.nmstate.io/v1"
+// resources
+//
+// ### API Reference
+// - https://github.com/nmstate/kubernetes-nmstate/blob/main/api/v1/nodenetworkconfigurationpolicy_types.go
+//
+// ### Sample data
+// - docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/etcd-quorum-guard.json
+//
+// ### Location in archive
+// - `cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/{name}.json`
+//
+// ### Config ID
+// `clusterconfig/nodenetworkconfigurationpolicies`
+//
+// ### Released version
+// - 4.18.0
+//
+// ### Backported versions
+//
+// ### Changes
+func (g *Gatherer) GatherNodeNetworkConfigurationPolicy(ctx context.Context) ([]record.Record, []error) {
+	dynCli, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherNodeNetworkConfigurationPolicy(ctx, dynCli)
+}
+
+func gatherNodeNetworkConfigurationPolicy(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	nodeNetConfPoliciesList, err := dynamicClient.Resource(nodeNetConfPoliciesV1GVR).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	records := []record.Record{}
+	for i := range nodeNetConfPoliciesList.Items {
+		nodeNetworkConfigurationPolicy := nodeNetConfPoliciesList.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/%s", nodeNetworkConfigurationPolicy.GetName()),
+			Item: record.ResourceMarshaller{Resource: &nodeNetworkConfigurationPolicy},
+		})
+	}
+	return records, nil
+}

--- a/pkg/gatherers/clusterconfig/gather_nmstate_node_network_configuration_policy_test.go
+++ b/pkg/gatherers/clusterconfig/gather_nmstate_node_network_configuration_policy_test.go
@@ -1,0 +1,61 @@
+// nolint: dupl
+package clusterconfig
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGatherNodeNetworkConfigurationPolicy(t *testing.T) {
+	tests := []struct {
+		name                    string
+		filePath                string
+		expectedErrors          []error
+		expectedNumberOfRecords int
+	}{
+		{
+			name:                    "no NodeNetworkConfigurationPolicy exists",
+			filePath:                "",
+			expectedErrors:          nil,
+			expectedNumberOfRecords: 0,
+		},
+		{
+			name:                    "NodeNetworkConfigurationPolicy exists",
+			filePath:                "testdata/node_network_configuration_policy.yaml",
+			expectedErrors:          nil,
+			expectedNumberOfRecords: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			cli := createDynamicClient(nodeNetConfPoliciesV1GVR, "NodeNetworkConfigurationPoliciesList")
+			var resourceData []byte
+			if tt.filePath != "" {
+				var err error
+				resourceData, err = os.ReadFile(tt.filePath)
+				assert.NoError(t, err)
+			}
+
+			unstructuredResource, err := createResource(ctx, cli, resourceData, nodeNetConfPoliciesV1GVR)
+			assert.NoError(t, err)
+			records, errs := gatherNodeNetworkConfigurationPolicy(ctx, cli)
+			assert.Equal(t, tt.expectedErrors, errs)
+			assert.Len(t, records, tt.expectedNumberOfRecords)
+			if tt.expectedNumberOfRecords > 0 {
+				marshaledRecord, err := records[0].Item.Marshal()
+				assert.NoError(t, err)
+				unstructuredRec := unstructured.Unstructured{}
+				err = json.Unmarshal(marshaledRecord, &unstructuredRec)
+				assert.NoError(t, err)
+				assert.Equal(t, unstructuredResource, unstructuredRec)
+			}
+		})
+	}
+}

--- a/pkg/gatherers/clusterconfig/gather_nmstate_nodenetworkstate.go
+++ b/pkg/gatherers/clusterconfig/gather_nmstate_nodenetworkstate.go
@@ -1,0 +1,102 @@
+// nolint: dupl
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils"
+	"github.com/openshift/insights-operator/pkg/utils/anonymize"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+)
+
+// GatherNodeNetworkState Collects cluster scope "nodenetworkstate.nmstate.io/v1beta1"
+// resources
+//
+// ### API Reference
+// - https://github.com/nmstate/kubernetes-nmstate/blob/main/api/v1beta1/nodenetworkstate_types.go
+//
+// ### Sample data
+// - docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkstates/etcd-quorum-guard.json
+//
+// ### Location in archive
+// - `cluster-scoped-resources/nmstate.io/nodenetworkstates/{name}.json`
+//
+// ### Config ID
+// `clusterconfig/nodenetworkstates`
+//
+// ### Released version
+// - 4.18.0
+//
+// ### Backported versions
+//
+// ### Changes
+func (g *Gatherer) GatherNodeNetworkState(ctx context.Context) ([]record.Record, []error) {
+	dynCli, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherNodeNetworkState(ctx, dynCli)
+}
+
+func gatherNodeNetworkState(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	nodeNetStateList, err := dynamicClient.Resource(nodeNetStatesV1Beta1GVR).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	records := []record.Record{}
+	errs := []error{}
+
+	for i := range nodeNetStateList.Items {
+		nodeNetworkState := nodeNetStateList.Items[i]
+		err := anonymizeNodeNetworkState(nodeNetworkState.Object)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("cluster-scoped-resources/nmstate.io/nodenetworkstates/%s", nodeNetworkState.GetName()),
+			Item: record.ResourceMarshaller{Resource: &nodeNetworkState},
+		})
+	}
+
+	return records, errs
+}
+
+func anonymizeNodeNetworkState(nodeNetworkState map[string]interface{}) error {
+	networInterfaces, err := utils.NestedSliceWrapper(nodeNetworkState, "status", "currentState", "interfaces")
+	if err != nil {
+		klog.Warning(err)
+		return nil
+	}
+	anonymizedInterfaces := []interface{}{}
+	for _, networInterface := range networInterfaces {
+		networInterfaceMap, ok := networInterface.(map[string]interface{})
+		if !ok {
+			klog.Errorf("cannot cast the interface type: %v", err)
+			continue
+		}
+		macAddress, err := utils.NestedStringWrapper(networInterfaceMap, "mac-address")
+		if err != nil {
+			// if there's no "mac-address" attribute, we still want to keep the interface
+			anonymizedInterfaces = append(anonymizedInterfaces, networInterfaceMap)
+			continue
+		}
+		err = unstructured.SetNestedField(networInterfaceMap, anonymize.String(macAddress), "mac-address")
+		if err != nil {
+			klog.Errorf("cannot anonymize the nodenetworkstate attribute: %v", err)
+			continue
+		}
+		anonymizedInterfaces = append(anonymizedInterfaces, networInterfaceMap)
+	}
+	return unstructured.SetNestedSlice(nodeNetworkState, anonymizedInterfaces, "status", "currentState", "interfaces")
+}

--- a/pkg/gatherers/clusterconfig/gather_nmstate_nodenetworkstate_test.go
+++ b/pkg/gatherers/clusterconfig/gather_nmstate_nodenetworkstate_test.go
@@ -1,0 +1,113 @@
+// nolint: dupl
+package clusterconfig
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestGatherNodeNetworkState(t *testing.T) {
+	tests := []struct {
+		name                    string
+		filePath                string
+		expectedErrors          []error
+		expectedNumberOfRecords int
+		obfuscated              bool
+	}{
+		{
+			name:                    "no NodeNetworkState resource exists",
+			filePath:                "",
+			expectedErrors:          []error{},
+			expectedNumberOfRecords: 0,
+		},
+		{
+			name:                    "NodeNetworkState resource with no interfaces",
+			filePath:                "testdata/node_network_state_no_interfaces.yaml",
+			expectedErrors:          []error{},
+			expectedNumberOfRecords: 1,
+		},
+		{
+			name:                    "NodeNetworkState resource with interfaces",
+			filePath:                "testdata/node_network_state_with_interfaces.yaml",
+			expectedErrors:          []error{},
+			expectedNumberOfRecords: 1,
+		},
+		{
+			name:                    "NodeNetworkState resource with interfaces with some mac addresses",
+			filePath:                "testdata/node_network_state_with_interfaces_and_mac_addresses.yaml",
+			expectedErrors:          []error{},
+			expectedNumberOfRecords: 1,
+			obfuscated:              true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			client := createDynamicClient(nodeNetStatesV1Beta1GVR, "NodeNetworkStatesList")
+			var resourceData []byte
+			if tt.filePath != "" {
+				var err error
+				resourceData, err = os.ReadFile(tt.filePath)
+				assert.NoError(t, err)
+			}
+
+			unstructuredResource, err := createResource(ctx, client, resourceData, nodeNetStatesV1Beta1GVR)
+			assert.NoError(t, err)
+			records, errs := gatherNodeNetworkState(ctx, client)
+			assert.Equal(t, tt.expectedErrors, errs)
+			assert.Len(t, records, tt.expectedNumberOfRecords)
+
+			if tt.expectedNumberOfRecords > 0 {
+				marshaledRecord, err := records[0].Item.Marshal()
+				assert.NoError(t, err)
+				unstructuredRec := unstructured.Unstructured{}
+				err = json.Unmarshal(marshaledRecord, &unstructuredRec)
+				assert.NoError(t, err)
+				if tt.obfuscated {
+					err := anonymizeNodeNetworkState(unstructuredResource.Object)
+					assert.NoError(t, err)
+					assert.Equal(t, unstructuredResource, unstructuredRec)
+				} else {
+					assert.Equal(t, unstructuredResource, unstructuredRec)
+				}
+			}
+		})
+	}
+}
+
+func createDynamicClient(gvr schema.GroupVersionResource, gvrList string) dynamic.Interface {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		gvr: gvrList,
+	})
+}
+
+func createResource(ctx context.Context, client dynamic.Interface, resourceDefinition []byte,
+	gvr schema.GroupVersionResource) (unstructured.Unstructured, error) {
+	if len(resourceDefinition) == 0 {
+		return unstructured.Unstructured{}, nil
+	}
+
+	decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	resource := unstructured.Unstructured{}
+	_, _, err := decUnstructured.Decode(resourceDefinition, nil, &resource)
+	if err != nil {
+		return unstructured.Unstructured{}, err
+	}
+	_, err = client.Resource(gvr).Create(ctx, &resource, metav1.CreateOptions{})
+	if err != nil {
+		return unstructured.Unstructured{}, err
+	}
+	return resource, nil
+}

--- a/pkg/gatherers/clusterconfig/testdata/node_network_configuration_policy.yaml
+++ b/pkg/gatherers/clusterconfig/testdata/node_network_configuration_policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+    name: node-network-config-policy-test
+spec:
+  desiredStates:
+    interfaces:
+      - name: test-interface
+        state: test-state
+        type: test-type
+status:
+    currentState:
+       dnsResolver: {}

--- a/pkg/gatherers/clusterconfig/testdata/node_network_state_no_interfaces.yaml
+++ b/pkg/gatherers/clusterconfig/testdata/node_network_state_no_interfaces.yaml
@@ -1,0 +1,7 @@
+apiVersion: nmstate.io/v1beta1
+kind: NodeNetworkState
+metadata:
+    name: node-network-state-1
+status:
+    currentState:
+       dnsResolver: {}

--- a/pkg/gatherers/clusterconfig/testdata/node_network_state_with_interfaces.yaml
+++ b/pkg/gatherers/clusterconfig/testdata/node_network_state_with_interfaces.yaml
@@ -1,0 +1,14 @@
+apiVersion: nmstate.io/v1beta1
+kind: NodeNetworkState
+metadata:
+    name: node-network-state-1
+status:
+    currentState:
+      dnsResolver: {}
+      interfaces: 
+        - identifier: first
+          ipv4: ""
+          controller: br-ex
+        - identifier: second
+          ipv4: ""
+          controller: br-ex

--- a/pkg/gatherers/clusterconfig/testdata/node_network_state_with_interfaces_and_mac_addresses.yaml
+++ b/pkg/gatherers/clusterconfig/testdata/node_network_state_with_interfaces_and_mac_addresses.yaml
@@ -1,0 +1,15 @@
+apiVersion: nmstate.io/v1beta1
+kind: NodeNetworkState
+metadata:
+    name: node-network-state-1
+status:
+    currentState:
+      dnsResolver: {}
+      interfaces: 
+        - identifier: first
+          ipv4: ""
+          controller: br-ex
+        - identifier: second
+          ipv4: ""
+          mac-address: some-macaddress
+          controller: br-ex


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [X] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/cluster-scoped-resources/nmstate.io/nodenetworkconfigurationpolicies/policy-name.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_nmstate_node_network_configuration_policy_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-39395
https://access.redhat.com/solutions/???
