### PR TITLE
OCPBUGS-32233: Not able to enable repositories during entitled build in OCP Cluster on IBM-Z

### DIFF
--- a/pkg/ocm/sca/sca.go
+++ b/pkg/ocm/sca/sca.go
@@ -211,6 +211,8 @@ func getArch() string {
 	validArchs := map[string]string{
 		"amd64": "x86_64",
 		"i386":  "x86",
+		"386":   "x86",
+		"arm64": "aarch64",
 	}
 
 	if translation, ok := validArchs[runtime.GOARCH]; ok {


### PR DESCRIPTION
Small bugfix over the previous PR #988

## Categories
- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
N/A

## Documentation
N/A

## Unit Tests
N/A

## Privacy
Yes. There are no sensitive data in the newly collected information.

## Changelog
No

## Breaking Changes
No

## References
https://issues.redhat.com/browse/OCPBUGS-32233
