### PR TITLE
OCPBUGS-42675: do not propagate the remote configuration status as an

### DIFF
--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -1597,7 +1597,7 @@ func TestSetRemoteConfigConditionsWhenDisabled(t *testing.T) {
 	expectedRemoteConfigurationValid := configv1.ClusterOperatorStatusCondition{
 		Type:   status.RemoteConfigurationValid,
 		Status: configv1.ConditionUnknown,
-		Reason: status.NoValidationYet,
+		Reason: status.RemoteConfNotValidatedYet,
 	}
 
 	tests := []struct {

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -395,14 +395,14 @@ func (c *Controller) updateControllerConditions(cs *conditions, isInitializing b
 		status := c.ctrlStatus.getStatus(DisabledStatus)
 		cs.setCondition(RemoteConfigurationAvailable, configv1.ConditionFalse, status.reason, status.message)
 		// if the remote configuration is not available then we can't say it's valid or not
-		cs.setCondition(RemoteConfigurationValid, configv1.ConditionUnknown, NoValidationYet, "")
+		cs.setCondition(RemoteConfigurationValid, configv1.ConditionUnknown, RemoteConfNotValidatedYet, "")
 		return
 	}
 
 	if rs := c.ctrlStatus.getStatus(RemoteConfigAvailableStatus); rs != nil {
 		cs.setCondition(RemoteConfigurationAvailable, configv1.ConditionFalse, rs.reason, rs.message)
 		// if the remote configuration is not available then we can't say it's valid or not
-		cs.setCondition(RemoteConfigurationValid, configv1.ConditionUnknown, NoValidationYet, "")
+		cs.setCondition(RemoteConfigurationValid, configv1.ConditionUnknown, RemoteConfNotValidatedYet, "")
 		return
 	}
 

--- a/pkg/controller/status/datagather_status.go
+++ b/pkg/controller/status/datagather_status.go
@@ -16,7 +16,8 @@ const (
 	NoUploadYetReason         = "NoUploadYet"
 	NoDataGatheringYetReason  = "NoDataGatheringYet"
 	NothingToProcessYetReason = "NothingToProcessYet"
-	NoValidationYet           = "NoValidationYet"
+	RemoteConfNotValidatedYet = "NoValidationYet"
+	RemoteConfNotRequestedYet = "RemoteConfigNotRequestedYet"
 	UnknownReason             = "Unknown"
 )
 

--- a/pkg/controllerstatus/controllerstatus.go
+++ b/pkg/controllerstatus/controllerstatus.go
@@ -31,11 +31,9 @@ var (
 	PullingSCACerts = Operation{Name: "PullingSCACerts"}
 	// PullingClusterTransfer is an operator for pulling ClusterTransfer object from the OCM API endpoint
 	PullingClusterTransfer = Operation{Name: "PullingClusterTransfer"}
-	// ReadingRemoteConfiguration is an operation of reading the remote configuration (provided by the conditional
+	// RemoteConfigurationStatus is an operation of reading the remote configuration (provided by the conditional
 	// gatherer endpoint)
-	ReadingRemoteConfiguration = Operation{Name: "ReadingRemoteConfiguration"}
-	// ValidatingRemoteConfiguration
-	ValidatingRemoteConfiguration = Operation{Name: "ValidatingRemoteConfiguration"}
+	RemoteConfigurationStatus = Operation{Name: "RemoteConfigurationStatus"}
 )
 
 // Summary represents the status summary of an Operation

--- a/pkg/gatherers/conditional/conditional_gatherer.go
+++ b/pkg/gatherers/conditional/conditional_gatherer.go
@@ -151,6 +151,7 @@ func (g *Gatherer) GetGatheringFunctions(ctx context.Context) (map[string]gather
 
 	g.remoteConfigStatus.ConfigValid = true
 	g.remoteConfigStatus.ValidReason = AsExpectedReason
+	g.remoteConfigStatus.ConfigData = remoteConfigData
 	return g.createAllGatheringFunctions(ctx, remoteConfig)
 }
 

--- a/pkg/gatherers/conditional/conditional_gatherer.go
+++ b/pkg/gatherers/conditional/conditional_gatherer.go
@@ -138,11 +138,11 @@ func (g *Gatherer) GetGatheringFunctions(ctx context.Context) (map[string]gather
 	if len(errs) > 0 {
 		validationErr := utils.UniqueErrors(errs)
 		klog.Infof("Failed to validate the remote configuration data: %v", validationErr)
-		remoteConfigData, err := json.Marshal(remoteConfig)
+		configData, err := json.Marshal(remoteConfig)
 		if err != nil {
 			klog.Errorf("Failed to marshal the invalid remote configuration: %v", err)
 		}
-		g.remoteConfigStatus.ConfigData = remoteConfigData
+		g.remoteConfigStatus.ConfigData = configData
 		g.remoteConfigStatus.ConfigValid = false
 		g.remoteConfigStatus.Err = validationErr
 		g.remoteConfigStatus.ValidReason = InvalidReason

--- a/pkg/gatherers/conditional/conditional_gatherer_test.go
+++ b/pkg/gatherers/conditional/conditional_gatherer_test.go
@@ -82,41 +82,6 @@ func Test_Gatherer_GetGatheringFunctions_BuiltInConfigIsUsed(t *testing.T) {
 	assert.True(t, found)
 }
 
-func Test_Gatherer_GetGatheringFunctions_InvalidConfig(t *testing.T) {
-	t.Setenv("RELEASE_VERSION", "1.2.3")
-	gathererConfig := `{
-		"version": "1.0.0",
-		"conditional_gathering_rules": [{
-			"conditions": [{
-				"type": "alert_is_firing",
-				"alert": {
-					"name": "SamplesImagestreamImportFailing"
-				}
-			}],
-			"gathering_functions": {
-				"logs_of_namespace": {
-					"namespace": "not-openshift-cluster-samples-operator",
-					"tail_lines": 100
-				}
-			}
-		}]
-	}` // invalid namespace (doesn't start with openshift-)
-
-	gatherer := newEmptyGatherer(gathererConfig, "")
-
-	err := gatherer.updateAlertsCache(context.TODO(), newFakeClientWithAlerts("SamplesImagestreamImportFailing"))
-	assert.NoError(t, err)
-
-	gatheringFunctions, err := gatherer.GetGatheringFunctions(context.TODO())
-	assert.EqualError(
-		t,
-		err,
-		"got invalid config for conditional gatherer: 0.gathering_functions.logs_of_namespace.namespace: "+
-			"Does not match pattern '^openshift-[a-zA-Z0-9_.-]{1,128}$'",
-	)
-	assert.Empty(t, gatheringFunctions)
-}
-
 func Test_Gatherer_GetGatheringFunctions_NoConditionsAreSatisfied(t *testing.T) {
 	t.Setenv("RELEASE_VERSION", "1.2.3")
 	gatherer := newEmptyGatherer("", "")

--- a/pkg/gatherers/conditional/conditional_gatherer_test.go
+++ b/pkg/gatherers/conditional/conditional_gatherer_test.go
@@ -16,6 +16,28 @@ import (
 	"github.com/openshift/insights-operator/pkg/gatherers"
 )
 
+var testRemoteConfig = `{
+			"version": "1.0.0",
+			"conditional_gathering_rules": [{
+				"conditions": [
+					{
+						"type": "` + string(AlertIsFiring) + `",
+						"alert": { "name": "SamplesImagestreamImportFailing" }
+					}
+				],
+				"gathering_functions": {
+					"logs_of_namespace": {
+						"namespace": "openshift-cluster-samples-operator",
+						"tail_lines": 100
+					},
+					"image_streams_of_namespace": {
+						"namespace": "openshift-cluster-samples-operator"
+					}
+				}
+			}],
+			"container_logs":[]
+		}`
+
 func Test_Gatherer_Basic(t *testing.T) {
 	t.Setenv("RELEASE_VERSION", "1.2.3")
 	gatherer := newEmptyGatherer("", "")
@@ -273,6 +295,7 @@ func TestGetGatheringFunctions(t *testing.T) {
 				AvailableReason: AsExpectedReason,
 				ValidReason:     AsExpectedReason,
 				Err:             nil,
+				ConfigData:      []byte(testRemoteConfig),
 			},
 		},
 		{
@@ -374,27 +397,7 @@ func TestBuiltInConfigIsUsed(t *testing.T) {
 
 func newEmptyGatherer(remoteConfig string, conditionalGathererEndpoint string) *Gatherer { // nolint:gocritic
 	if len(remoteConfig) == 0 {
-		remoteConfig = `{
-			"version": "1.0.0",
-			"conditional_gathering_rules": [{
-				"conditions": [
-					{
-						"type": "` + string(AlertIsFiring) + `",
-						"alert": { "name": "SamplesImagestreamImportFailing" }
-					}
-				],
-				"gathering_functions": {
-					"logs_of_namespace": {
-						"namespace": "openshift-cluster-samples-operator",
-						"tail_lines": 100
-					},
-					"image_streams_of_namespace": {
-						"namespace": "openshift-cluster-samples-operator"
-					}
-				}
-			}],
-			"container_logs":[]
-		}`
+		remoteConfig = testRemoteConfig
 	}
 	if conditionalGathererEndpoint == "" {
 		conditionalGathererEndpoint = "/gathering_rules"

--- a/pkg/gatherers/conditional/types.go
+++ b/pkg/gatherers/conditional/types.go
@@ -7,8 +7,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-var Invalid = "Invalid"
-var Unavailable = "Unavailable"
+var (
+	InvalidReason      = "Invalid"
+	AsExpectedReason   = "AsExpected"
+	NotAvailableReason = "NotAvailable"
+)
 
 // RemoteConfiguration is a structure to hold gathering rules with their version
 type RemoteConfiguration struct {
@@ -87,16 +90,4 @@ type ContainerLogRequest struct {
 	ContainerName string
 	Previous      bool
 	MessageRegex  *regexp.Regexp
-}
-
-// RemoteConfigError is a custom error type used
-// when reading of the remote configuration fails
-type RemoteConfigError struct {
-	Err        error
-	Reason     string
-	ConfigData []byte
-}
-
-func (u RemoteConfigError) Error() string {
-	return u.Err.Error()
 }

--- a/pkg/gatherers/conditional/validation.go
+++ b/pkg/gatherers/conditional/validation.go
@@ -19,6 +19,17 @@ var containerLogJSONSchema string
 //go:embed container_logs.schema.json
 var containerLogsJSONSchema string
 
+// validateRemoteConfig validates the both main parts of the remote configuration.
+// the original conditional gathering rules as well as the container logs
+func validateRemoteConfig(remoteConfig RemoteConfiguration) []error {
+	var errs []error
+	gatheringRulesErrs := validateGatheringRules(remoteConfig.ConditionalGatheringRules)
+	errs = append(errs, gatheringRulesErrs...)
+	containerLogErrs := validateContainerLogRequests(remoteConfig.ContainerLogRequests)
+	errs = append(errs, containerLogErrs...)
+	return errs
+}
+
 // validateGatheringRules validates provided gathering rules, will return nil on success, or a list of errors
 func validateGatheringRules(gatheringRules []GatheringRule) []error {
 	if len(gatheringRules) == 0 {

--- a/pkg/gatherers/interface.go
+++ b/pkg/gatherers/interface.go
@@ -28,7 +28,26 @@ type CustomPeriodGatherer interface {
 	UpdateLastProcessingTime()
 }
 
+type GathererUsingRemoteConfig interface {
+	Interface
+
+	// RemoteConfigStatus provides information about the availability and validity of the remote configuration
+	// used as source of the data gathering
+	RemoteConfigStatus() RemoteConfigStatus
+}
+
 // GatheringClosure is a struct containing a closure each gatherer returns
 type GatheringClosure struct {
 	Run func(context.Context) ([]record.Record, []error)
+}
+
+// RemoteConfigStatus is a struct providing information about the availability
+// and validity of the remote configuration
+type RemoteConfigStatus struct {
+	Err             error
+	AvailableReason string
+	ValidReason     string
+	ConfigData      []byte
+	ConfigAvailable bool
+	ConfigValid     bool
 }


### PR DESCRIPTION
error

<!-- Short description of the PR. What does it do? -->
  We can't propagate the remote configuration status as an error, because then the gathering won't take place (when the remote config is not available) and we still want to run it based on the built-in configuration (even though it's empty now). 

This introduces a new "gatherer type" providing the acess to the remote configuration status.   

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- no new data

## Documentation
<!-- Are these changes reflected in documentation? -->


## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

-

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-42675
https://access.redhat.com/solutions/???
