### PR TITLE
CCXDEV-14462: [IO Enhancement] collect how many unused MachineConfigs in the cluster

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1088,9 +1088,11 @@ Following data is intentionally removed from the definitions:
 - https://docs.openshift.com/container-platform/4.7/rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.html
 
 ### Sample data
+- [docs/insights-archive-sample/aggregated/unused_machine_configs_count.json](./insights-archive-sample/aggregated/unused_machine_configs_count.json)
 - [docs/insights-archive-sample/config/machineconfigs/75-worker-sap-data-intelligence.json](./insights-archive-sample/config/machineconfigs/75-worker-sap-data-intelligence.json)
 
 ### Location in archive
+- `aggregated/unused_machine_configs_count.json`
 - `config/machineconfigs/{resource}.json`
 
 ### Config ID

--- a/pkg/gatherers/clusterconfig/gather_machine_configs.go
+++ b/pkg/gatherers/clusterconfig/gather_machine_configs.go
@@ -33,9 +33,11 @@ type UnusedMachineConfigsCount struct {
 // - https://docs.openshift.com/container-platform/4.7/rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.html
 //
 // ### Sample data
+// - docs/insights-archive-sample/aggregated/unused_machine_configs_count.json
 // - docs/insights-archive-sample/config/machineconfigs/75-worker-sap-data-intelligence.json
 //
 // ### Location in archive
+// - `aggregated/unused_machine_configs_count.json`
 // - `config/machineconfigs/{resource}.json`
 //
 // ### Config ID

--- a/pkg/gatherers/clusterconfig/gather_machine_configs.go
+++ b/pkg/gatherers/clusterconfig/gather_machine_configs.go
@@ -92,7 +92,7 @@ func gatherMachineConfigs(ctx context.Context, dynamicClient dynamic.Interface,
 		mc := items[i]
 		// skip machine configs which are not in use
 		if len(inUseMachineConfigs) != 0 && !inUseMachineConfigs.Has(mc.GetName()) {
-			count.UnusedCount += 1
+			count.UnusedCount++
 			continue
 		}
 		// remove the sensitive content by overwriting the values

--- a/pkg/gatherers/clusterconfig/gather_machine_configs.go
+++ b/pkg/gatherers/clusterconfig/gather_machine_configs.go
@@ -17,6 +17,11 @@ import (
 	"github.com/openshift/insights-operator/pkg/record"
 )
 
+// UnusedMachineConfigsCount represents the count of unused MachineConfig in the cluster
+type UnusedMachineConfigsCount struct {
+	UnusedCount uint `json:"unused_machineconfigs_count"`
+}
+
 // GatherMachineConfigs Collects definitions of in-use 'MachineConfigs'. MachineConfig is used when it's referenced in
 // a MachineConfigPool or in Node `machineconfiguration.openshift.io/desiredConfig` and `machineconfiguration.openshift.io/currentConfig`
 // annotations
@@ -59,22 +64,35 @@ func (g *Gatherer) GatherMachineConfigs(ctx context.Context) ([]record.Record, [
 	return records, errs
 }
 
-func gatherMachineConfigs(ctx context.Context, dynamicClient dynamic.Interface,
-	inUseMachineConfigs sets.Set[string]) ([]record.Record, []error) {
+func gatherAllMachineConfigs(ctx context.Context, dynamicClient dynamic.Interface) ([]unstructured.Unstructured, error) {
 	mcList, err := dynamicClient.Resource(machineConfigGroupVersionResource).List(ctx, metav1.ListOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	return mcList.Items, nil
+}
+
+func gatherMachineConfigs(ctx context.Context, dynamicClient dynamic.Interface,
+	inUseMachineConfigs sets.Set[string]) ([]record.Record, []error) {
+	const unusedCountFilename string = "aggregated/unused_machine_configs_count"
+	count := UnusedMachineConfigsCount{UnusedCount: 0}
+
+	items, err := gatherAllMachineConfigs(ctx, dynamicClient)
 	if err != nil {
 		return nil, []error{err}
 	}
 
 	records := []record.Record{}
 	var errs []error
-	for i := range mcList.Items {
-		mc := mcList.Items[i]
+	for i := range items {
+		mc := items[i]
 		// skip machine configs which are not in use
 		if len(inUseMachineConfigs) != 0 && !inUseMachineConfigs.Has(mc.GetName()) {
+			count.UnusedCount += 1
 			continue
 		}
 		// remove the sensitive content by overwriting the values
@@ -96,6 +114,11 @@ func gatherMachineConfigs(ctx context.Context, dynamicClient dynamic.Interface,
 	if len(errs) > 0 {
 		return records, errs
 	}
+
+	records = append(records, record.Record{
+		Name: unusedCountFilename,
+		Item: record.JSONMarshaller{Object: count},
+	})
 	return records, nil
 }
 

--- a/pkg/gatherers/clusterconfig/gather_machine_configs_test.go
+++ b/pkg/gatherers/clusterconfig/gather_machine_configs_test.go
@@ -43,7 +43,7 @@ func TestGatherMachineConfigs(t *testing.T) {
 			name:                    "no machine configs exists",
 			machineConfigYAMLs:      []string{},
 			inUseMachineConfigs:     sets.Set[string]{},
-			expectedNumberOfRecords: 0,
+			expectedNumberOfRecords: 1,
 		},
 		{
 			name: "one machine config which is in use",
@@ -53,11 +53,11 @@ kind: MachineConfig
 metadata: 
   name: 75-worker-sap-data-intelligence`},
 			inUseMachineConfigs:     sets.Set[string]{"75-worker-sap-data-intelligence": {}},
-			expectedNumberOfRecords: 1,
+			expectedNumberOfRecords: 2,
 		},
 		{
 			name:                    "two machine configs but only one in use",
-			expectedNumberOfRecords: 1,
+			expectedNumberOfRecords: 2,
 			machineConfigYAMLs: []string{
 				`apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
@@ -72,7 +72,7 @@ metadata:
 		},
 		{
 			name:                    "no machine config in use",
-			expectedNumberOfRecords: 0,
+			expectedNumberOfRecords: 1,
 			machineConfigYAMLs: []string{
 				`apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
@@ -87,7 +87,7 @@ metadata:
 		},
 		{
 			name:                    "two machine configs in use",
-			expectedNumberOfRecords: 2,
+			expectedNumberOfRecords: 3,
 			machineConfigYAMLs: []string{
 				`apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig


### PR DESCRIPTION
This PR implements a new data enhancement to the MachineConfig gatherer. It will generate the number of unused MachineConfig detected on the cluster.

## Categories
- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
- `aggregated/unused_machine_configs_count.json`

## Documentation
N/A

## Unit Tests
N/A

## Privacy
Yes. There are no sensitive data in the newly collected information.

## Changelog
No

## Breaking Changes
No

## References
https://issues.redhat.com/browse/CCXDEV-14462