### PR TITLE
OCPBUGS-43651: gather selected clusterroles

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -605,6 +605,31 @@ None
 None
 
 
+## ClusterRoles
+
+Collects definition of the "admin" and "edit" cluster roles.
+
+### API Reference
+- https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/rbac/types.go
+
+### Sample data
+- [docs/insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles](./insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles)
+
+### Location in archive
+- `cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/`
+
+### Config ID
+`clusterconfig/clusterroles`
+
+### Released version
+- 4.18.0
+
+### Backported versions
+
+### Changes
+None
+
+
 ## ClusterVersion
 
 Collects the `ClusterVersion` (including the cluster ID) with the name

--- a/docs/insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/admin.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/admin.json
@@ -1,0 +1,1249 @@
+{
+    "metadata": {
+        "name": "admin",
+        "uid": "0d96e235-cb02-4caf-9261-d231fcb187b3",
+        "resourceVersion": "20714",
+        "creationTimestamp": "2024-10-18T06:09:08Z",
+        "labels": {
+            "kubernetes.io/bootstrapping": "rbac-defaults"
+        },
+        "annotations": {
+            "rbac.authorization.kubernetes.io/autoupdate": "true"
+        }
+    },
+    "rules": [
+        {
+            "verbs": [
+                "create",
+                "update",
+                "patch",
+                "delete"
+            ],
+            "apiGroups": [
+                "operators.coreos.com"
+            ],
+            "resources": [
+                "subscriptions"
+            ]
+        },
+        {
+            "verbs": [
+                "delete"
+            ],
+            "apiGroups": [
+                "operators.coreos.com"
+            ],
+            "resources": [
+                "clusterserviceversions",
+                "catalogsources",
+                "installplans",
+                "subscriptions"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "operators.coreos.com"
+            ],
+            "resources": [
+                "clusterserviceversions",
+                "catalogsources",
+                "installplans",
+                "subscriptions",
+                "operatorgroups"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "packages.operators.coreos.com"
+            ],
+            "resources": [
+                "packagemanifests",
+                "packagemanifests/icon"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "update",
+                "patch",
+                "delete"
+            ],
+            "apiGroups": [
+                "packages.operators.coreos.com"
+            ],
+            "resources": [
+                "packagemanifests"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "update",
+                "create",
+                "watch",
+                "patch",
+                "delete"
+            ],
+            "apiGroups": [
+                "helm.openshift.io"
+            ],
+            "resources": [
+                "projecthelmchartrepositories"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "secrets",
+                "serviceaccounts"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreamimages",
+                "imagestreammappings",
+                "imagestreams",
+                "imagestreams/secrets",
+                "imagestreamtags",
+                "imagetags"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreamimports"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "update"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreams/layers"
+            ]
+        },
+        {
+            "verbs": [
+                "get"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "namespaces"
+            ]
+        },
+        {
+            "verbs": [
+                "get"
+            ],
+            "apiGroups": [
+                "",
+                "project.openshift.io"
+            ],
+            "resources": [
+                "projects"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods/attach",
+                "pods/exec",
+                "pods/portforward",
+                "pods/proxy",
+                "secrets",
+                "services/proxy"
+            ]
+        },
+        {
+            "verbs": [
+                "impersonate"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "serviceaccounts"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods",
+                "pods/attach",
+                "pods/exec",
+                "pods/portforward",
+                "pods/proxy"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods/eviction"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "configmaps",
+                "endpoints",
+                "events",
+                "persistentvolumeclaims",
+                "replicationcontrollers",
+                "replicationcontrollers/scale",
+                "secrets",
+                "serviceaccounts",
+                "services",
+                "services/proxy"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "serviceaccounts/token"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "apps"
+            ],
+            "resources": [
+                "daemonsets",
+                "deployments",
+                "deployments/rollback",
+                "deployments/scale",
+                "replicasets",
+                "replicasets/scale",
+                "statefulsets",
+                "statefulsets/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "autoscaling"
+            ],
+            "resources": [
+                "horizontalpodautoscalers"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "batch"
+            ],
+            "resources": [
+                "cronjobs",
+                "jobs"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "extensions"
+            ],
+            "resources": [
+                "daemonsets",
+                "deployments",
+                "deployments/rollback",
+                "deployments/scale",
+                "ingresses",
+                "networkpolicies",
+                "replicasets",
+                "replicasets/scale",
+                "replicationcontrollers/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "policy"
+            ],
+            "resources": [
+                "poddisruptionbudgets"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "networking.k8s.io"
+            ],
+            "resources": [
+                "ingresses",
+                "networkpolicies"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "coordination.k8s.io"
+            ],
+            "resources": [
+                "leases"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "metrics.k8s.io"
+            ],
+            "resources": [
+                "pods",
+                "nodes"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreams"
+            ]
+        },
+        {
+            "verbs": [
+                "update"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "builds/details"
+            ]
+        },
+        {
+            "verbs": [
+                "get"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "builds"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch",
+                "create",
+                "update",
+                "patch",
+                "delete",
+                "deletecollection"
+            ],
+            "apiGroups": [
+                "snapshot.storage.k8s.io"
+            ],
+            "resources": [
+                "volumesnapshots"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildconfigs",
+                "buildconfigs/webhooks",
+                "builds"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "builds/log"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildconfigs/instantiate",
+                "buildconfigs/instantiatebinary",
+                "builds/clone"
+            ]
+        },
+        {
+            "verbs": [
+                "edit",
+                "view"
+            ],
+            "apiGroups": [
+                "build.openshift.io"
+            ],
+            "resources": [
+                "jenkins"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "apps.openshift.io"
+            ],
+            "resources": [
+                "deploymentconfigs",
+                "deploymentconfigs/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "apps.openshift.io"
+            ],
+            "resources": [
+                "deploymentconfigrollbacks",
+                "deploymentconfigs/instantiate",
+                "deploymentconfigs/rollback"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "apps.openshift.io"
+            ],
+            "resources": [
+                "deploymentconfigs/log",
+                "deploymentconfigs/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreams/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "quota.openshift.io"
+            ],
+            "resources": [
+                "appliedclusterresourcequotas"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes/custom-host"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes/status"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "template.openshift.io"
+            ],
+            "resources": [
+                "processedtemplates",
+                "templateconfigs",
+                "templateinstances",
+                "templates"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "networking.k8s.io"
+            ],
+            "resources": [
+                "networkpolicies"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildlogs"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "resourcequotausages"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "packages.operators.coreos.com"
+            ],
+            "resources": [
+                "packagemanifests"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreamimages",
+                "imagestreammappings",
+                "imagestreams",
+                "imagestreamtags",
+                "imagetags"
+            ]
+        },
+        {
+            "verbs": [
+                "get"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreams/layers"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "configmaps",
+                "endpoints",
+                "persistentvolumeclaims",
+                "persistentvolumeclaims/status",
+                "pods",
+                "replicationcontrollers",
+                "replicationcontrollers/scale",
+                "serviceaccounts",
+                "services",
+                "services/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "bindings",
+                "events",
+                "limitranges",
+                "namespaces/status",
+                "pods/log",
+                "pods/status",
+                "replicationcontrollers/status",
+                "resourcequotas",
+                "resourcequotas/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "namespaces"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "discovery.k8s.io"
+            ],
+            "resources": [
+                "endpointslices"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "apps"
+            ],
+            "resources": [
+                "controllerrevisions",
+                "daemonsets",
+                "daemonsets/status",
+                "deployments",
+                "deployments/scale",
+                "deployments/status",
+                "replicasets",
+                "replicasets/scale",
+                "replicasets/status",
+                "statefulsets",
+                "statefulsets/scale",
+                "statefulsets/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "autoscaling"
+            ],
+            "resources": [
+                "horizontalpodautoscalers",
+                "horizontalpodautoscalers/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "batch"
+            ],
+            "resources": [
+                "cronjobs",
+                "cronjobs/status",
+                "jobs",
+                "jobs/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "extensions"
+            ],
+            "resources": [
+                "daemonsets",
+                "daemonsets/status",
+                "deployments",
+                "deployments/scale",
+                "deployments/status",
+                "ingresses",
+                "ingresses/status",
+                "networkpolicies",
+                "replicasets",
+                "replicasets/scale",
+                "replicasets/status",
+                "replicationcontrollers/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "policy"
+            ],
+            "resources": [
+                "poddisruptionbudgets",
+                "poddisruptionbudgets/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "networking.k8s.io"
+            ],
+            "resources": [
+                "ingresses",
+                "ingresses/status",
+                "networkpolicies"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "snapshot.storage.k8s.io"
+            ],
+            "resources": [
+                "volumesnapshots"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildconfigs",
+                "buildconfigs/webhooks",
+                "builds"
+            ]
+        },
+        {
+            "verbs": [
+                "view"
+            ],
+            "apiGroups": [
+                "build.openshift.io"
+            ],
+            "resources": [
+                "jenkins"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "apps.openshift.io"
+            ],
+            "resources": [
+                "deploymentconfigs",
+                "deploymentconfigs/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "template.openshift.io"
+            ],
+            "resources": [
+                "processedtemplates",
+                "templateconfigs",
+                "templateinstances",
+                "templates"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildlogs"
+            ]
+        },
+        {
+            "verbs": [
+                "watch",
+                "list",
+                "get"
+            ],
+            "apiGroups": [
+                "k8s.cni.cncf.io"
+            ],
+            "resources": [
+                "network-attachment-definitions"
+            ]
+        },
+        {
+            "verbs": [
+                "*"
+            ],
+            "apiGroups": [
+                "packages.operators.coreos.com"
+            ],
+            "resources": [
+                "packagemanifests"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "authorization.openshift.io"
+            ],
+            "resources": [
+                "rolebindings",
+                "roles"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "rbac.authorization.k8s.io"
+            ],
+            "resources": [
+                "rolebindings",
+                "roles"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "authorization.openshift.io"
+            ],
+            "resources": [
+                "localresourceaccessreviews",
+                "localsubjectaccessreviews",
+                "subjectrulesreviews"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "authorization.k8s.io"
+            ],
+            "resources": [
+                "localsubjectaccessreviews"
+            ]
+        },
+        {
+            "verbs": [
+                "delete",
+                "get"
+            ],
+            "apiGroups": [
+                "",
+                "project.openshift.io"
+            ],
+            "resources": [
+                "projects"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "authorization.openshift.io"
+            ],
+            "resources": [
+                "resourceaccessreviews",
+                "subjectaccessreviews"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "security.openshift.io"
+            ],
+            "resources": [
+                "podsecuritypolicyreviews",
+                "podsecuritypolicyselfsubjectreviews",
+                "podsecuritypolicysubjectreviews"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "authorization.openshift.io"
+            ],
+            "resources": [
+                "rolebindingrestrictions"
+            ]
+        },
+        {
+            "verbs": [
+                "admin",
+                "edit",
+                "view"
+            ],
+            "apiGroups": [
+                "build.openshift.io"
+            ],
+            "resources": [
+                "jenkins"
+            ]
+        },
+        {
+            "verbs": [
+                "delete",
+                "get",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "",
+                "project.openshift.io"
+            ],
+            "resources": [
+                "projects"
+            ]
+        },
+        {
+            "verbs": [
+                "update"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes/status"
+            ]
+        }
+    ],
+    "aggregationRule": {
+        "clusterRoleSelectors": [
+            {
+                "matchLabels": {
+                    "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+                }
+            }
+        ]
+    }
+}

--- a/docs/insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/edit.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/edit.json
@@ -1,0 +1,1068 @@
+{
+    "metadata": {
+        "name": "edit",
+        "uid": "efcd24e1-a9bb-4731-9485-999ad6f35580",
+        "resourceVersion": "20701",
+        "creationTimestamp": "2024-10-18T06:09:08Z",
+        "labels": {
+            "kubernetes.io/bootstrapping": "rbac-defaults",
+            "rbac.authorization.k8s.io/aggregate-to-admin": "true"
+        },
+        "annotations": {
+            "rbac.authorization.kubernetes.io/autoupdate": "true"
+        }
+    },
+    "rules": [
+        {
+            "verbs": [
+                "create",
+                "update",
+                "patch",
+                "delete"
+            ],
+            "apiGroups": [
+                "operators.coreos.com"
+            ],
+            "resources": [
+                "subscriptions"
+            ]
+        },
+        {
+            "verbs": [
+                "delete"
+            ],
+            "apiGroups": [
+                "operators.coreos.com"
+            ],
+            "resources": [
+                "clusterserviceversions",
+                "catalogsources",
+                "installplans",
+                "subscriptions"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "operators.coreos.com"
+            ],
+            "resources": [
+                "clusterserviceversions",
+                "catalogsources",
+                "installplans",
+                "subscriptions",
+                "operatorgroups"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "packages.operators.coreos.com"
+            ],
+            "resources": [
+                "packagemanifests",
+                "packagemanifests/icon"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "update",
+                "patch",
+                "delete"
+            ],
+            "apiGroups": [
+                "packages.operators.coreos.com"
+            ],
+            "resources": [
+                "packagemanifests"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "update",
+                "create",
+                "watch",
+                "patch",
+                "delete"
+            ],
+            "apiGroups": [
+                "helm.openshift.io"
+            ],
+            "resources": [
+                "projecthelmchartrepositories"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "secrets",
+                "serviceaccounts"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreamimages",
+                "imagestreammappings",
+                "imagestreams",
+                "imagestreams/secrets",
+                "imagestreamtags",
+                "imagetags"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreamimports"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "update"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreams/layers"
+            ]
+        },
+        {
+            "verbs": [
+                "get"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "namespaces"
+            ]
+        },
+        {
+            "verbs": [
+                "get"
+            ],
+            "apiGroups": [
+                "",
+                "project.openshift.io"
+            ],
+            "resources": [
+                "projects"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods/attach",
+                "pods/exec",
+                "pods/portforward",
+                "pods/proxy",
+                "secrets",
+                "services/proxy"
+            ]
+        },
+        {
+            "verbs": [
+                "impersonate"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "serviceaccounts"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods",
+                "pods/attach",
+                "pods/exec",
+                "pods/portforward",
+                "pods/proxy"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods/eviction"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "configmaps",
+                "endpoints",
+                "events",
+                "persistentvolumeclaims",
+                "replicationcontrollers",
+                "replicationcontrollers/scale",
+                "secrets",
+                "serviceaccounts",
+                "services",
+                "services/proxy"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "serviceaccounts/token"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "apps"
+            ],
+            "resources": [
+                "daemonsets",
+                "deployments",
+                "deployments/rollback",
+                "deployments/scale",
+                "replicasets",
+                "replicasets/scale",
+                "statefulsets",
+                "statefulsets/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "autoscaling"
+            ],
+            "resources": [
+                "horizontalpodautoscalers"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "batch"
+            ],
+            "resources": [
+                "cronjobs",
+                "jobs"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "extensions"
+            ],
+            "resources": [
+                "daemonsets",
+                "deployments",
+                "deployments/rollback",
+                "deployments/scale",
+                "ingresses",
+                "networkpolicies",
+                "replicasets",
+                "replicasets/scale",
+                "replicationcontrollers/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "policy"
+            ],
+            "resources": [
+                "poddisruptionbudgets"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "patch",
+                "update"
+            ],
+            "apiGroups": [
+                "networking.k8s.io"
+            ],
+            "resources": [
+                "ingresses",
+                "networkpolicies"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "coordination.k8s.io"
+            ],
+            "resources": [
+                "leases"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "metrics.k8s.io"
+            ],
+            "resources": [
+                "pods",
+                "nodes"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreams"
+            ]
+        },
+        {
+            "verbs": [
+                "update"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "builds/details"
+            ]
+        },
+        {
+            "verbs": [
+                "get"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "builds"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch",
+                "create",
+                "update",
+                "patch",
+                "delete",
+                "deletecollection"
+            ],
+            "apiGroups": [
+                "snapshot.storage.k8s.io"
+            ],
+            "resources": [
+                "volumesnapshots"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildconfigs",
+                "buildconfigs/webhooks",
+                "builds"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "builds/log"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildconfigs/instantiate",
+                "buildconfigs/instantiatebinary",
+                "builds/clone"
+            ]
+        },
+        {
+            "verbs": [
+                "edit",
+                "view"
+            ],
+            "apiGroups": [
+                "build.openshift.io"
+            ],
+            "resources": [
+                "jenkins"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "apps.openshift.io"
+            ],
+            "resources": [
+                "deploymentconfigs",
+                "deploymentconfigs/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "apps.openshift.io"
+            ],
+            "resources": [
+                "deploymentconfigrollbacks",
+                "deploymentconfigs/instantiate",
+                "deploymentconfigs/rollback"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "apps.openshift.io"
+            ],
+            "resources": [
+                "deploymentconfigs/log",
+                "deploymentconfigs/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreams/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "quota.openshift.io"
+            ],
+            "resources": [
+                "appliedclusterresourcequotas"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes"
+            ]
+        },
+        {
+            "verbs": [
+                "create"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes/custom-host"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes/status"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "template.openshift.io"
+            ],
+            "resources": [
+                "processedtemplates",
+                "templateconfigs",
+                "templateinstances",
+                "templates"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "networking.k8s.io"
+            ],
+            "resources": [
+                "networkpolicies"
+            ]
+        },
+        {
+            "verbs": [
+                "create",
+                "delete",
+                "deletecollection",
+                "get",
+                "list",
+                "patch",
+                "update",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildlogs"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "resourcequotausages"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "packages.operators.coreos.com"
+            ],
+            "resources": [
+                "packagemanifests"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreamimages",
+                "imagestreammappings",
+                "imagestreams",
+                "imagestreamtags",
+                "imagetags"
+            ]
+        },
+        {
+            "verbs": [
+                "get"
+            ],
+            "apiGroups": [
+                "",
+                "image.openshift.io"
+            ],
+            "resources": [
+                "imagestreams/layers"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "configmaps",
+                "endpoints",
+                "persistentvolumeclaims",
+                "persistentvolumeclaims/status",
+                "pods",
+                "replicationcontrollers",
+                "replicationcontrollers/scale",
+                "serviceaccounts",
+                "services",
+                "services/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "bindings",
+                "events",
+                "limitranges",
+                "namespaces/status",
+                "pods/log",
+                "pods/status",
+                "replicationcontrollers/status",
+                "resourcequotas",
+                "resourcequotas/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "namespaces"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "discovery.k8s.io"
+            ],
+            "resources": [
+                "endpointslices"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "apps"
+            ],
+            "resources": [
+                "controllerrevisions",
+                "daemonsets",
+                "daemonsets/status",
+                "deployments",
+                "deployments/scale",
+                "deployments/status",
+                "replicasets",
+                "replicasets/scale",
+                "replicasets/status",
+                "statefulsets",
+                "statefulsets/scale",
+                "statefulsets/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "autoscaling"
+            ],
+            "resources": [
+                "horizontalpodautoscalers",
+                "horizontalpodautoscalers/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "batch"
+            ],
+            "resources": [
+                "cronjobs",
+                "cronjobs/status",
+                "jobs",
+                "jobs/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "extensions"
+            ],
+            "resources": [
+                "daemonsets",
+                "daemonsets/status",
+                "deployments",
+                "deployments/scale",
+                "deployments/status",
+                "ingresses",
+                "ingresses/status",
+                "networkpolicies",
+                "replicasets",
+                "replicasets/scale",
+                "replicasets/status",
+                "replicationcontrollers/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "policy"
+            ],
+            "resources": [
+                "poddisruptionbudgets",
+                "poddisruptionbudgets/status"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "networking.k8s.io"
+            ],
+            "resources": [
+                "ingresses",
+                "ingresses/status",
+                "networkpolicies"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "snapshot.storage.k8s.io"
+            ],
+            "resources": [
+                "volumesnapshots"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildconfigs",
+                "buildconfigs/webhooks",
+                "builds"
+            ]
+        },
+        {
+            "verbs": [
+                "view"
+            ],
+            "apiGroups": [
+                "build.openshift.io"
+            ],
+            "resources": [
+                "jenkins"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "apps.openshift.io"
+            ],
+            "resources": [
+                "deploymentconfigs",
+                "deploymentconfigs/scale"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "route.openshift.io"
+            ],
+            "resources": [
+                "routes"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "template.openshift.io"
+            ],
+            "resources": [
+                "processedtemplates",
+                "templateconfigs",
+                "templateinstances",
+                "templates"
+            ]
+        },
+        {
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ],
+            "apiGroups": [
+                "",
+                "build.openshift.io"
+            ],
+            "resources": [
+                "buildlogs"
+            ]
+        }
+    ],
+    "aggregationRule": {
+        "clusterRoleSelectors": [
+            {
+                "matchLabels": {
+                    "rbac.authorization.k8s.io/aggregate-to-edit": "true"
+                }
+            }
+        ]
+    }
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -32,6 +32,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"certificate_signing_requests":      (*Gatherer).GatherCertificateSigningRequests,
 	"ceph_cluster":                      (*Gatherer).GatherCephCluster,
 	"cluster_apiserver":                 (*Gatherer).GatherClusterAPIServer,
+	"clusterroles":                      (*Gatherer).GatherClusterRoles,
 	"config_maps":                       (*Gatherer).GatherConfigMaps,
 	"container_images":                  (*Gatherer).GatherContainerImages,
 	"container_runtime_configs":         (*Gatherer).GatherContainerRuntimeConfig,

--- a/pkg/gatherers/clusterconfig/gather_cluster_roles.go
+++ b/pkg/gatherers/clusterconfig/gather_cluster_roles.go
@@ -1,0 +1,66 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
+)
+
+// GatherClusterRoles Collects definition of the "admin" and "edit" cluster roles.
+//
+// ### API Reference
+// - https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/rbac/types.go
+//
+// ### Sample data
+// - docs/insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles
+//
+// ### Location in archive
+// - `cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/`
+//
+// ### Config ID
+// `clusterconfig/clusterroles`
+//
+// ### Released version
+// - 4.18.0
+//
+// ### Backported versions
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherClusterRoles(ctx context.Context) ([]record.Record, []error) {
+	kubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherClusterRoles(ctx, kubeClient.RbacV1(), []string{"admin", "edit"})
+}
+
+func gatherClusterRoles(ctx context.Context, rbacV1Cli v1.RbacV1Interface, names []string) ([]record.Record, []error) {
+	var errs []error
+	var records []record.Record
+	for _, name := range names {
+		clusterRoleRec, err := gatherClusterRole(ctx, name, rbacV1Cli)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			records = append(records, *clusterRoleRec)
+		}
+	}
+	return records, errs
+}
+
+func gatherClusterRole(ctx context.Context, name string, rbacV1Cli v1.RbacV1Interface) (*record.Record, error) {
+	clusterRole, err := rbacV1Cli.ClusterRoles().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &record.Record{
+		Name: fmt.Sprintf("cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/%s", clusterRole.Name),
+		Item: record.ResourceMarshaller{Resource: clusterRole},
+	}, nil
+}

--- a/pkg/gatherers/clusterconfig/gather_cluster_roles_test.go
+++ b/pkg/gatherers/clusterconfig/gather_cluster_roles_test.go
@@ -1,0 +1,103 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGatherClusterRoles(t *testing.T) {
+	tests := []struct {
+		name                    string
+		clusterRoleNames        []string
+		testClusterRoles        []v1.ClusterRole
+		expectedErrors          []error
+		expectedLenghtOfRecords int
+	}{
+		{
+			name:             "no existing clusterroles",
+			testClusterRoles: []v1.ClusterRole{},
+		},
+		{
+			name:             "no existing clusterroles but some are requested",
+			clusterRoleNames: []string{"role1", "role2"},
+			testClusterRoles: []v1.ClusterRole{},
+			expectedErrors: []error{
+				&errors.StatusError{
+					ErrStatus: metav1.Status{
+						Status: "Failure",
+						Reason: metav1.StatusReasonNotFound,
+						Details: &metav1.StatusDetails{
+							Name:  "role1",
+							Group: "rbac.authorization.k8s.io",
+							Kind:  "clusterroles",
+						},
+						Code:    404,
+						Message: "clusterroles.rbac.authorization.k8s.io \"role1\" not found",
+					},
+				},
+				&errors.StatusError{
+					ErrStatus: metav1.Status{
+						Reason: metav1.StatusReasonNotFound,
+						Status: "Failure",
+						Details: &metav1.StatusDetails{
+							Name:  "role2",
+							Group: "rbac.authorization.k8s.io",
+							Kind:  "clusterroles",
+						},
+						Code:    404,
+						Message: "clusterroles.rbac.authorization.k8s.io \"role2\" not found",
+					},
+				},
+			},
+		},
+		{
+			name:             "one existing clusterrole gathered",
+			clusterRoleNames: []string{"role1", "role2"},
+			testClusterRoles: []v1.ClusterRole{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "role1",
+					},
+					Rules: []v1.PolicyRule{
+						{Verbs: []string{"get", "list"}},
+					},
+				},
+			},
+			expectedLenghtOfRecords: 1,
+			expectedErrors: []error{
+				&errors.StatusError{
+					ErrStatus: metav1.Status{
+						Status: "Failure",
+						Reason: metav1.StatusReasonNotFound,
+						Details: &metav1.StatusDetails{
+							Name:  "role2",
+							Group: "rbac.authorization.k8s.io",
+							Kind:  "clusterroles",
+						},
+						Code:    404,
+						Message: "clusterroles.rbac.authorization.k8s.io \"role2\" not found",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := kubefake.NewSimpleClientset()
+			for _, clusterRole := range tt.testClusterRoles {
+				err := cli.Tracker().Add(&clusterRole)
+				assert.NoError(t, err)
+			}
+			records, errs := gatherClusterRoles(context.Background(), cli.RbacV1(), tt.clusterRoleNames)
+			assert.Len(t, records, tt.expectedLenghtOfRecords)
+			assert.Equal(t, tt.expectedErrors, errs)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/admin.json`
- `docs/insights-archive-sample/cluster-scoped-resources/rbac.authorization.k8s.io/clusterroles/edit.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_cluster_roles_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-43651
https://access.redhat.com/solutions/???
