### PR TITLE
[WIP]: AUTH-482: set required-scc for openshift workloads 

### DIFF
--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -719,6 +719,9 @@ func (c *Controller) createNewDataGatherCR(ctx context.Context, disabledGatherer
 	dataGatherCR := insightsv1alpha1.DataGather{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: periodicGatheringPrefix,
+			Annotations: map[string]string{
+				"openshift.io/required-scc": "restricted-v2",
+			},
 		},
 		Spec: insightsv1alpha1.DataGatherSpec{
 			DataPolicy: dataPolicy,

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -242,6 +242,9 @@ func TestCreateNewDataGatherCR(t *testing.T) {
 			expected: &v1alpha1.DataGather{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "periodic-gathering-",
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "restricted-v2",
+					},
 				},
 				Spec: v1alpha1.DataGatherSpec{
 					DataPolicy: "",
@@ -255,6 +258,9 @@ func TestCreateNewDataGatherCR(t *testing.T) {
 			expected: &v1alpha1.DataGather{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "periodic-gathering-",
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "restricted-v2",
+					},
 				},
 				Spec: v1alpha1.DataGatherSpec{
 					DataPolicy: "ClearText",
@@ -272,6 +278,9 @@ func TestCreateNewDataGatherCR(t *testing.T) {
 			expected: &v1alpha1.DataGather{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "periodic-gathering-",
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "restricted-v2",
+					},
 				},
 				Spec: v1alpha1.DataGatherSpec{
 					DataPolicy: "ObfuscateNetworking",


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...
This PR sets the required SCC explicitly on each workload in openshift-* namespaces. The SCC chosen is the one that the pods are getting admitted with, so no change expected there. This is to protect the pods from getting admitted with a different custom SCC than the one intended.
## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
