### PR TITLE
NO-JIRA: Fix links to the OpenStack related CRs in the gathered-data doc

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1601,7 +1601,7 @@ resources from all namespaces
 None
 
 ### Sample data
-- [docs/insights-archive-sample/namespaces/openstack/dataplane.openstack.org/openstackdataplanenodesets/openstack-edpm.json](./insights-archive-sample/namespaces/openstack/dataplane.openstack.org/openstackdataplanenodesets/openstack-edpm.json)
+- [docs/insights-archive-sample/namespaces/openstack/dataplane.openstack.org/openstackdataplanenodesets/openstack-edpm-ipam.json](./insights-archive-sample/namespaces/openstack/dataplane.openstack.org/openstackdataplanenodesets/openstack-edpm-ipam.json)
 
 ### Location in archive
 - `namespaces/{namespace}/dataplane.openstack.org/openstackdataplanes/{name}.json`
@@ -1625,7 +1625,7 @@ resources from all namespaces
 None
 
 ### Sample data
-- [docs/insights-archive-sample/namespaces/openstack/core.openstack.org/openstackversion/openstack-galera-network-isolation.json](./insights-archive-sample/namespaces/openstack/core.openstack.org/openstackversion/openstack-galera-network-isolation.json)
+- [docs/insights-archive-sample/namespaces/openstack/core.openstack.org/openstackversions/openstack-galera-network-isolation.json](./insights-archive-sample/namespaces/openstack/core.openstack.org/openstackversions/openstack-galera-network-isolation.json)
 
 ### Location in archive
 - `namespaces/{namespace}/core.openstack.org/openstackversion/{name}.json`


### PR DESCRIPTION
This PR is just fix of the documentation bug and fixes links to the OpenStackDataPlaneNodeSet and OpenStackDataPlaneVersion example CRs

## Categories
<!-- Select the categories that your PR better fits on -->

- [x] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No
