### PR TITLE
OCPBUGS-45047: Avoid to send the same error repeated N times

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1002,15 +1002,15 @@ None
 
 Collects `lokistacks.loki.grafana.com` resources.
 
-The gatherer will collect up to 20 resources from `openshift-logging` namespace
+The gatherer will collect up to 20 resources from `openshift-*` namespaces
 and it will report errors if it finds a `LokiStack` resource in a different namespace
-or if there are more than 20 `LokiStacks` in the `openshift-logging` namespace.
+or if there are more than 20 `LokiStacks` in the `openshift-*` namespaces.
 
 ### API Reference
 None
 
 ### Sample data
-- [docs/insights-archive-sample/namespaces/openshift-logging/.json](./insights-archive-sample/namespaces/openshift-logging/.json)
+- [docs/insights-archive-sample/namespaces/openshift-logging/lokistack-sample.json](./insights-archive-sample/namespaces/openshift-logging/lokistack-sample.json)
 
 ### Location in archive
 - `namespace/{namespace}/loki.grafana.com/lokistacks/{name}.json`
@@ -1019,7 +1019,7 @@ None
 `clusterconfig/lokistacks
 
 ### Released version
-- 4.18.0
+- 4.19.0
 
 ### Backported versions
 None
@@ -1631,7 +1631,7 @@ resources from all namespaces
 None
 
 ### Sample data
-- [docs/insights-archive-sample/namespaces/openstack/dataplane.openstack.org/openstackdataplanenodesets/openstack-edpm-ipam.json](./insights-archive-sample/namespaces/openstack/dataplane.openstack.org/openstackdataplanenodesets/openstack-edpm-ipam.json)
+- [docs/insights-archive-sample/namespaces/openstack/dataplane.openstack.org/openstackdataplanenodesets/openstack-edpm.json](./insights-archive-sample/namespaces/openstack/dataplane.openstack.org/openstackdataplanenodesets/openstack-edpm.json)
 
 ### Location in archive
 - `namespaces/{namespace}/dataplane.openstack.org/openstackdataplanes/{name}.json`
@@ -1655,7 +1655,7 @@ resources from all namespaces
 None
 
 ### Sample data
-- [docs/insights-archive-sample/namespaces/openstack/core.openstack.org/openstackversions/openstack-galera-network-isolation.json](./insights-archive-sample/namespaces/openstack/core.openstack.org/openstackversions/openstack-galera-network-isolation.json)
+- [docs/insights-archive-sample/namespaces/openstack/core.openstack.org/openstackversion/openstack-galera-network-isolation.json](./insights-archive-sample/namespaces/openstack/core.openstack.org/openstackversion/openstack-galera-network-isolation.json)
 
 ### Location in archive
 - `namespaces/{namespace}/core.openstack.org/openstackversion/{name}.json`
@@ -2094,5 +2094,6 @@ None
 
 ### Changes
 - Image repository is now collected if it comes from outside the Red Hat domain
+- [Tech Preview] runtime info for workloads are collected (since 4.18.0)
 
 

--- a/pkg/gatherers/clusterconfig/gather_lokistack.go
+++ b/pkg/gatherers/clusterconfig/gather_lokistack.go
@@ -21,24 +21,24 @@ const lokiStackResourceLimit = 20
 
 // GatherLokiStack Collects `lokistacks.loki.grafana.com` resources.
 //
-// The gatherer will collect up to 20 resources from `openshift-logging` namespace
+// The gatherer will collect up to 20 resources from `openshift-*` namespaces
 // and it will report errors if it finds a `LokiStack` resource in a different namespace
-// or if there are more than 20 `LokiStacks` in the `openshift-logging` namespace.
+// or if there are more than 20 `LokiStacks` in the `openshift-*` namespaces.
 //
 // ### API Reference
 // None
 //
 // ### Sample data
-// - docs/insights-archive-sample/namespaces/openshift-logging/.json
+// - docs/insights-archive-sample/namespaces/openshift-logging/lokistack-sample.json
 //
 // ### Location in archive
-// - `namespace/openshift-logging/loki.grafana.com/lokistacks/{name}.json`
+// - `namespace/{namespace}/loki.grafana.com/lokistacks/{name}.json`
 //
 // ### Config ID
 // `clusterconfig/lokistacks
 //
 // ### Released version
-// - 4.18.0
+// - 4.19.0
 //
 // ### Backported versions
 // None

--- a/pkg/gatherers/clusterconfig/gather_lokistack.go
+++ b/pkg/gatherers/clusterconfig/gather_lokistack.go
@@ -87,6 +87,7 @@ func gatherLokiStack(ctx context.Context, dynamicClient dynamic.Interface) ([]re
 
 		if len(records) >= lokiStackResourceLimit {
 			if !tooManyResourcesError {
+				tooManyResourcesError = true
 				errs = append(errs, fmt.Errorf(
 					"found %d resources, limit (%d) reached",
 					len(loggingResourceList.Items), lokiStackResourceLimit),


### PR DESCRIPTION
The current implementation includes the same error several times. This improvement makes to only include one time the error, making it more clear

## Categories
- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [x] Others (CI, Infrastructure, Documentation)

## Sample Archive
N/A

## Documentation
N/A

## Unit Tests
N/A

## Privacy
No

## Changelog
No

## Breaking Changes
No

## References
#1022 
[OCPBUGS-45047
](https://issues.redhat.com/browse/OCPBUGS-45047)