### PR TITLE
OCPBUGS-45479: avoid possible Go panic when searching existing conditions

### DIFF
--- a/pkg/controller/status/datagather_status.go
+++ b/pkg/controller/status/datagather_status.go
@@ -111,8 +111,10 @@ func GetConditionByType(dataGather *insightsv1alpha1.DataGather, conType string)
 	return c
 }
 
+// getConditionIndexByType tries to find an index of the condition with the provided type.
+// If no match is found, it returns -1.
 func getConditionIndexByType(conType string, conditions []metav1.Condition) int {
-	var idx int
+	idx := -1
 	for i := range conditions {
 		con := conditions[i]
 		if con.Type == conType {
@@ -130,7 +132,11 @@ func UpdateDataGatherConditions(ctx context.Context,
 	newConditions := make([]metav1.Condition, len(dataGather.Status.Conditions))
 	_ = copy(newConditions, dataGather.Status.Conditions)
 	idx := getConditionIndexByType(condition.Type, newConditions)
-	newConditions[idx] = *condition
+	if idx != -1 {
+		newConditions[idx] = *condition
+	} else {
+		newConditions = append(newConditions, *condition)
+	}
 	dataGather.Status.Conditions = newConditions
 	return insightsClient.DataGathers().UpdateStatus(ctx, dataGather, metav1.UpdateOptions{})
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- no new data

## Documentation
<!-- Are these changes reflected in documentation? -->

- 

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/status/datagather_status_test.go` - extended to cover the problematic case

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->
No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-45479
https://access.redhat.com/solutions/???
