### PR TITLE
OCPBUGS-44211: Ignore previous status when disabling alerts

### DIFF
--- a/pkg/insights/prometheus_rules.go
+++ b/pkg/insights/prometheus_rules.go
@@ -65,7 +65,7 @@ func (p *PrometheusRulesController) Start(ctx context.Context) {
 func (p *PrometheusRulesController) checkAlertsDisabled(ctx context.Context) {
 	disableInsightsAlerts := p.configurator.Config().Alerting.Disabled
 
-	if disableInsightsAlerts && p.promRulesExist {
+	if disableInsightsAlerts {
 		err := p.removeInsightsAlerts(ctx)
 		if err != nil {
 			klog.Errorf("Failed to remove Insights Prometheus rules definition: %v", err)


### PR DESCRIPTION
This is bug fix for [OCPBUGS-44211](https://issues.redhat.com/browse/OCPBUGS-44211).

Ignoring the previous status, that can be unknown when starting the Insights Operator, as creating or removing a `PrometheusRule` is an idempotent operation.

The described problem is caused because when the Insights Operator starts it doesn't know if the `PrometheusRule` to enable the alert triggering is already existing or not, and it assumes by default that it doesn't exist, so it doesn't try to remove it.

With the new approach, the `PrometheusRule` will be removed in any case.

## Categories
- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
N/A

## Documentation
N/A

## Unit Tests
N/A

## Privacy
Yes. There is no new collected information.

## Changelog
No

## Breaking Changes
No

## References
https://issues.redhat.com/browse/OCPBUGS-44211
