### PR TITLE
CCXDEV-12875: Enable Insight Operator entitlements for multi arch clusters

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -15,8 +15,7 @@ pull_report:
 processingStatusEndpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/status
 reportEndpointTechPreview: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/report
 ocm:
-  scaEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/certificates
+  scaEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/entitlement_certificates
   scaInterval: "8h"
   clusterTransferEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/cluster_transfers/
   clusterTransferInterval: "12h"
-

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -117,7 +117,13 @@ rules:
       - get
       - list
       - watch
-
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -137,7 +143,6 @@ subjects:
   - kind: ServiceAccount
     namespace: openshift-insights
     name: operator
----
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -516,7 +521,7 @@ metadata:
     capability.openshift.io/name: Insights
 rules:
   - apiGroups:
-      - ''
+      - ""
     resources:
       - secrets
     verbs:
@@ -559,7 +564,7 @@ metadata:
     capability.openshift.io/name: Insights
 rules:
   - apiGroups:
-      - ''
+      - ""
     resources:
       - secrets
     verbs:
@@ -606,26 +611,26 @@ metadata:
     release.openshift.io/feature-set: TechPreviewNoUpgrade
     capability.openshift.io/name: Insights
 rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - insights-runtime-extractor-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - insights-runtime-extractor-scc
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -664,11 +669,12 @@ allowHostDirVolumePlugin: true
 allowHostPID: true
 allowPrivilegedContainer: true
 allowedCapabilities:
-- CAP_SYS_ADMIN
+  - CAP_SYS_ADMIN
 runAsUser:
   type: RunAsAny
 seLinuxContext:
   type: RunAsAny
 seccompProfiles:
-- runtime/default
+  - runtime/default
 ---
+

--- a/pkg/insights/insightsclient/insightsclient.go
+++ b/pkg/insights/insightsclient/insightsclient.go
@@ -33,7 +33,7 @@ import (
 const (
 	responseBodyLogLen = 1024
 	insightsReqId      = "x-rh-insights-request-id"
-	scaArchPayload     = `{"type": "sca","arch": "%s"}`
+	scaArchPayload     = `{"arch": ["%s"]}`
 )
 
 type Client struct {
@@ -247,12 +247,10 @@ func (c *Client) createAndWriteMIMEHeader(source *Source, mw *multipart.Writer, 
 	_ = pw.CloseWithError(mw.Close())
 }
 
-var (
-	counterRequestRecvReport = metrics.NewCounterVec(&metrics.CounterOpts{
-		Name: "insightsclient_request_recvreport_total",
-		Help: "Tracks the number of insights reports received/downloaded",
-	}, []string{"client", "status_code"})
-)
+var counterRequestRecvReport = metrics.NewCounterVec(&metrics.CounterOpts{
+	Name: "insightsclient_request_recvreport_total",
+	Help: "Tracks the number of insights reports received/downloaded",
+}, []string{"client", "status_code"})
 
 func init() {
 	insights.MustRegisterMetrics(counterRequestRecvReport)

--- a/pkg/insights/insightsclient/requests_test.go
+++ b/pkg/insights/insightsclient/requests_test.go
@@ -165,13 +165,13 @@ func TestClient_RecvSCACerts(t *testing.T) {
 		"aarch64": {},
 	}
 
-	expectedResponse := sca.SCAResponse{
-		Items: []sca.SCACertData{
+	expectedResponse := sca.Response{
+		Items: []sca.CertData{
 			{
 				Cert: "testing-cert",
 				Key:  "testing-key",
 				ID:   "testing-id",
-				Metadata: sca.SCACertMetadata{
+				Metadata: sca.CertMetadata{
 					Arch: "aarch64",
 				},
 				OrgID: "testing-org-id",
@@ -180,7 +180,7 @@ func TestClient_RecvSCACerts(t *testing.T) {
 				Cert: "testing-cert",
 				Key:  "testing-key",
 				ID:   "testing-id",
-				Metadata: sca.SCACertMetadata{
+				Metadata: sca.CertMetadata{
 					Arch: "x86_64",
 				},
 				OrgID: "testing-org-id",
@@ -193,7 +193,7 @@ func TestClient_RecvSCACerts(t *testing.T) {
 	certsBytes, err := insightsClient.RecvSCACerts(context.Background(), endpoint, architectures)
 	assert.NoError(t, err)
 
-	var certReponse sca.SCAResponse
+	var certReponse sca.Response
 	assert.NoError(t, json.Unmarshal(certsBytes, &certReponse))
 	assert.Equal(t, expectedResponse, certReponse)
 }

--- a/pkg/ocm/sca/architectures_gather.go
+++ b/pkg/ocm/sca/architectures_gather.go
@@ -6,6 +6,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Mapping of kubernetes architecture labels to the format used by SCA API
+var kubernetesArchMapping = map[string]string{
+	"386":     "x86",
+	"amd64":   "x86_64",
+	"ppc":     "ppc",
+	"ppc64":   "ppc64",
+	"ppc64le": "ppc64le",
+	"s390":    "s390",
+	"s390x":   "s390x",
+	"ia64":    "ia64",
+	"arm64":   "aarch64",
+}
+
 // gatherArchitectures connects to K8S API to retrieve the list of
 // nodes and create a set of the present architectures
 func (c *Controller) gatherArchitectures(ctx context.Context) (map[string]struct{}, error) {
@@ -17,7 +30,8 @@ func (c *Controller) gatherArchitectures(ctx context.Context) (map[string]struct
 	architectures := make(map[string]struct{})
 	for i := range nodes.Items {
 		nodeArch := nodes.Items[i].Status.NodeInfo.Architecture
-		architectures[nodeArch] = struct{}{}
+		architectures[kubernetesArchMapping[nodeArch]] = struct{}{}
 	}
+
 	return architectures, nil
 }

--- a/pkg/ocm/sca/architectures_gather.go
+++ b/pkg/ocm/sca/architectures_gather.go
@@ -1,0 +1,23 @@
+package sca
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// gatherArchitectures connects to K8S API to retrieve the list of
+// nodes and create a set of the present architectures
+func (c *Controller) gatherArchitectures(ctx context.Context) (map[string]struct{}, error) {
+	nodes, err := c.coreClient.Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	architectures := make(map[string]struct{})
+	for i := range nodes.Items {
+		nodeArch := nodes.Items[i].Status.NodeInfo.Architecture
+		architectures[nodeArch] = struct{}{}
+	}
+	return architectures, nil
+}

--- a/pkg/ocm/sca/architectures_gather_test.go
+++ b/pkg/ocm/sca/architectures_gather_test.go
@@ -1,0 +1,57 @@
+package sca
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+)
+
+var testNodes = []v1.Node{
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-x86_64",
+		},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{
+				Architecture: "amd64",
+			},
+		},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-ppc64le",
+		},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{
+				Architecture: "ppc64le",
+			},
+		},
+	},
+}
+
+func Test_SCAController_GatherMultipleArchitectures(t *testing.T) {
+	kube := kubefake.NewSimpleClientset()
+	coreClient := kube.CoreV1()
+
+	// Create test nodes
+	for _, node := range testNodes {
+		_, err := coreClient.Nodes().Create(context.Background(), &node, metav1.CreateOptions{})
+		assert.NoError(t, err)
+	}
+
+	expectedArchitectures := map[string]struct{}{
+		"x86_64":  {},
+		"ppc64le": {},
+	}
+
+	scaController := New(coreClient, nil, nil)
+	gatheredArch, err := scaController.gatherArchitectures(context.Background())
+	assert.NoError(t, err, "failed to gather architectures")
+
+	assert.Len(t, gatheredArch, len(testNodes), "unexpected number of architectures")
+	assert.Equal(t, gatheredArch, expectedArchitectures, "unexpected architectures")
+}

--- a/pkg/ocm/sca/sca.go
+++ b/pkg/ocm/sca/sca.go
@@ -98,7 +98,11 @@ func (c *Controller) requestDataAndCheckSecret(ctx context.Context, endpoint str
 	klog.Infof("Pulling SCA certificates from %s. Next check is in %s", c.configurator.Config().SCA.Endpoint,
 		c.configurator.Config().SCA.Interval)
 
-	data, err := c.requestSCAWithExpBackoff(ctx, endpoint)
+	architectures, err := c.gatherArchitectures(ctx)
+	if err != nil {
+		klog.Warningf("Gathering nodes architectures failed: %s", err.Error())
+	}
+	responses, err := c.requestSCAWithExpBackoff(ctx, endpoint, architectures)
 	if err != nil {
 		httpErr, ok := err.(insightsclient.HttpError)
 		errMsg := fmt.Sprintf("Failed to pull SCA certs from %s: %v", endpoint, err)
@@ -125,17 +129,19 @@ func (c *Controller) requestDataAndCheckSecret(ctx context.Context, endpoint str
 		return
 	}
 
-	var ocmRes Response
-	err = json.Unmarshal(data, &ocmRes)
-	if err != nil {
-		klog.Errorf("Unable to decode response: %v", err)
-		return
-	}
-	// check & update the secret here
-	err = c.checkSecret(ctx, &ocmRes)
-	if err != nil {
-		klog.Errorf("Error when checking the %s secret: %v", secretName, err)
-		return
+	for idx := range responses {
+		var ocmRes Response
+		err = json.Unmarshal(responses[idx], &ocmRes)
+		if err != nil {
+			klog.Errorf("Unable to decode response: %v", err)
+			return
+		}
+		// check & update the secret here
+		err = c.checkSecret(ctx, &ocmRes)
+		if err != nil {
+			klog.Errorf("Error when checking the %s secret: %v", secretName, err)
+			return
+		}
 	}
 
 	klog.Infof("%s secret successfully updated", secretName)
@@ -224,7 +230,7 @@ func getArch() string {
 // requestSCAWithExpBackoff queries OCM API with exponential backoff.
 // Returns HttpError (see insightsclient.go) in case of any HTTP error response from OCM API.
 // The exponential backoff is applied only for HTTP errors >= 500.
-func (c *Controller) requestSCAWithExpBackoff(ctx context.Context, endpoint string) ([]byte, error) {
+func (c *Controller) requestSCAWithExpBackoff(ctx context.Context, endpoint string, architectures map[string]struct{}) ([][]byte, error) {
 	bo := wait.Backoff{
 		Duration: c.configurator.Config().SCA.Interval / 32, // 15 min by default
 		Factor:   2,
@@ -233,30 +239,35 @@ func (c *Controller) requestSCAWithExpBackoff(ctx context.Context, endpoint stri
 		Cap:      c.configurator.Config().SCA.Interval,
 	}
 
-	var data []byte
+	klog.Infof("Nodes architectures: %s", architectures)
+	var responses [][]byte
+	responses = make([][]byte, len(architectures))
 	err := wait.ExponentialBackoff(bo, func() (bool, error) {
-		var err error
-		data, err = c.client.RecvSCACerts(ctx, endpoint, getArch())
-		if err != nil {
-			// don't try again in case it's not an HTTP error - it could mean we're in disconnected env
-			if !insightsclient.IsHttpError(err) {
-				return true, err
-			}
-			httpErr := err.(insightsclient.HttpError)
-			// try again only in case of 500 or higher
-			if httpErr.StatusCode >= http.StatusInternalServerError {
-				// check the number of steps to prevent "timeout waiting for condition" error - we want to propagate the HTTP error
-				if bo.Steps > 1 {
-					klog.Errorf("%v. Trying again in %s", httpErr, bo.Step())
-					return false, nil
+		for arch := range architectures {
+			data, err := c.client.RecvSCACerts(ctx, endpoint, arch)
+			if err != nil {
+				// don't try again in case it's not an HTTP error - it could mean we're in disconnected env
+				if !insightsclient.IsHttpError(err) {
+					return true, err
 				}
+				httpErr := err.(insightsclient.HttpError)
+				// try again only in case of 500 or higher
+				if httpErr.StatusCode >= http.StatusInternalServerError {
+					// check the number of steps to prevent "timeout waiting for condition" error - we want to propagate the HTTP error
+					if bo.Steps > 1 {
+						klog.Errorf("%v. Trying again in %s", httpErr, bo.Step())
+						return false, nil
+					}
+				}
+				return true, httpErr
 			}
-			return true, httpErr
+
+			responses = append(responses, data)
 		}
 		return true, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return data, nil
+	return responses, nil
 }

--- a/pkg/ocm/sca/sca.go
+++ b/pkg/ocm/sca/sca.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"runtime"
 	"strings"
 	"time"
 
@@ -25,11 +24,25 @@ import (
 const (
 	targetNamespaceName    = "openshift-config-managed" //nolint: gosec
 	secretName             = "etc-pki-entitlement"      //nolint: gosec
+	secretArchName         = "etc-pki-entitlement-%s"
 	entitlementAttrName    = "entitlement.pem"
 	entitlementKeyAttrName = "entitlement-key.pem"
 	ControllerName         = "scaController"
 	AvailableReason        = "Updated"
 )
+
+// Mapping of architecture format used by SCA API to the format used by kubernetes
+var archMapping map[string]string = map[string]string{
+	"x86":     "386",
+	"x86_64":  "amd64",
+	"ppc":     "ppc",
+	"ppc64":   "ppc64",
+	"ppc64le": "ppc64le",
+	"s390":    "s390",
+	"s390x":   "s390x",
+	"ia64":    "ia64",
+	"aarch64": "arm64",
+}
 
 // Controller holds all the required resources to be able to communicate with OCM API
 type Controller struct {
@@ -39,17 +52,31 @@ type Controller struct {
 	client       *insightsclient.Client
 }
 
-// Response structure is used to unmarshall the OCM SCA response. It holds the SCA certificate
-type Response struct {
-	ID    string `json:"id"`
-	OrgID string `json:"organization_id"`
-	Key   string `json:"key"`
-	Cert  string `json:"cert"`
+// SCAResponse structure is used to unmarshall the OCM SCA response.
+type SCAResponse struct {
+	Items []SCACertData `json:"items"`
+	Kind  string        `json:"kind"`
+	Total int           `json:"total"`
+}
+
+// SCACertData holds the SCA certificate
+type SCACertData struct {
+	ID       string          `json:"id"`
+	OrgID    string          `json:"organization_id"`
+	Key      string          `json:"key"`
+	Cert     string          `json:"cert"`
+	Metadata SCACertMetadata `json:"metadata"`
+}
+
+// ResonseMetadata structure is used to unmarshall the OCM SCA response metadata.
+type SCACertMetadata struct {
+	Arch string `json:"arch"`
 }
 
 // New creates new instance
 func New(coreClient corev1client.CoreV1Interface, configurator configobserver.Interface,
-	insightsClient *insightsclient.Client) *Controller {
+	insightsClient *insightsclient.Client,
+) *Controller {
 	return &Controller{
 		StatusController: controllerstatus.New(ControllerName),
 		coreClient:       coreClient,
@@ -102,12 +129,13 @@ func (c *Controller) requestDataAndCheckSecret(ctx context.Context, endpoint str
 	if err != nil {
 		klog.Warningf("Gathering nodes architectures failed: %s", err.Error())
 	}
+
 	responses, err := c.requestSCAWithExpBackoff(ctx, endpoint, architectures)
 	if err != nil {
 		httpErr, ok := err.(insightsclient.HttpError)
 		errMsg := fmt.Sprintf("Failed to pull SCA certs from %s: %v", endpoint, err)
 		if ok {
-			c.StatusController.UpdateStatus(controllerstatus.Summary{
+			c.UpdateStatus(controllerstatus.Summary{
 				Operation: controllerstatus.Operation{
 					Name:           controllerstatus.PullingSCACerts.Name,
 					HTTPStatusCode: httpErr.StatusCode,
@@ -119,7 +147,7 @@ func (c *Controller) requestDataAndCheckSecret(ctx context.Context, endpoint str
 			return
 		}
 		klog.Warning(errMsg)
-		c.StatusController.UpdateStatus(controllerstatus.Summary{
+		c.UpdateStatus(controllerstatus.Summary{
 			Operation:          controllerstatus.PullingSCACerts,
 			Healthy:            true,
 			Reason:             "NonHTTPError",
@@ -129,23 +157,14 @@ func (c *Controller) requestDataAndCheckSecret(ctx context.Context, endpoint str
 		return
 	}
 
-	for idx := range responses {
-		var ocmRes Response
-		err = json.Unmarshal(responses[idx], &ocmRes)
-		if err != nil {
-			klog.Errorf("Unable to decode response: %v", err)
-			return
-		}
-		// check & update the secret here
-		err = c.checkSecret(ctx, &ocmRes)
-		if err != nil {
-			klog.Errorf("Error when checking the %s secret: %v", secretName, err)
-			return
-		}
+	err = c.processResponses(ctx, *responses)
+	if err != nil {
+		klog.Errorf("Error when checking the sca secret: %v", err)
+		return
 	}
 
-	klog.Infof("%s secret successfully updated", secretName)
-	c.StatusController.UpdateStatus(controllerstatus.Summary{
+	klog.Info("sca secret successfully updated")
+	c.UpdateStatus(controllerstatus.Summary{
 		Operation:          controllerstatus.PullingSCACerts,
 		Message:            fmt.Sprintf("SCA certs successfully updated in the %s secret", secretName),
 		Healthy:            true,
@@ -154,15 +173,35 @@ func (c *Controller) requestDataAndCheckSecret(ctx context.Context, endpoint str
 	})
 }
 
-// checkSecret checks "etc-pki-entitlement" secret in the "openshift-config-managed" namespace.
+func (c *Controller) processResponses(ctx context.Context, responses SCAResponse) error {
+	if responses.Total == 1 {
+		// If there is only one architecture then we will use the secret name "etc-pki-entitlement"
+		// without the arch suffix to keep the backward compatibility
+		return c.checkSecret(ctx, &responses.Items[0], secretName)
+	}
+
+	for _, response := range responses.Items {
+		secretArchName := fmt.Sprintf(secretArchName, archMapping[response.Metadata.Arch])
+
+		err := c.checkSecret(ctx, &response, secretArchName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkSecret checks "etc-pki-entitlement" or "etc-pki-entitlement-arch"
+// secret in the "openshift-config-managed" namespace.
 // If the secret doesn't exist then it will create a new one.
 // If the secret already exist then it will update the data.
-func (c *Controller) checkSecret(ctx context.Context, ocmData *Response) error {
-	scaSec, err := c.coreClient.Secrets(targetNamespaceName).Get(ctx, secretName, metav1.GetOptions{})
+func (c *Controller) checkSecret(ctx context.Context, ocmData *SCACertData, secretArchName string) error {
+	scaSec, err := c.coreClient.Secrets(targetNamespaceName).Get(ctx, secretArchName, metav1.GetOptions{})
 
 	// if the secret doesn't exist then create one
 	if errors.IsNotFound(err) {
-		_, err = c.createSecret(ctx, ocmData)
+		_, err = c.createSecret(ctx, ocmData, secretArchName)
 		if err != nil {
 			return err
 		}
@@ -179,10 +218,10 @@ func (c *Controller) checkSecret(ctx context.Context, ocmData *Response) error {
 	return nil
 }
 
-func (c *Controller) createSecret(ctx context.Context, ocmData *Response) (*v1.Secret, error) {
+func (c *Controller) createSecret(ctx context.Context, ocmData *SCACertData, secretArchName string) (*v1.Secret, error) {
 	newSCA := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
+			Name:      secretArchName,
 			Namespace: targetNamespaceName,
 		},
 		Data: map[string][]byte{
@@ -191,46 +230,34 @@ func (c *Controller) createSecret(ctx context.Context, ocmData *Response) (*v1.S
 		},
 		Type: v1.SecretTypeOpaque,
 	}
+
 	cm, err := c.coreClient.Secrets(targetNamespaceName).Create(ctx, newSCA, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
+
 	return cm, nil
 }
 
 // updateSecret updates provided secret with given data
-func (c *Controller) updateSecret(ctx context.Context, s *v1.Secret, ocmData *Response) (*v1.Secret, error) {
+func (c *Controller) updateSecret(ctx context.Context, s *v1.Secret, ocmData *SCACertData) (*v1.Secret, error) {
 	s.Data = map[string][]byte{
 		entitlementAttrName:    []byte(ocmData.Cert),
 		entitlementKeyAttrName: []byte(ocmData.Key),
 	}
+
 	s, err := c.coreClient.Secrets(s.Namespace).Update(ctx, s, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
+
 	return s, nil
-}
-
-// getArch check the value of GOARCH and return a valid representation for
-// OCM certificates API
-func getArch() string {
-	validArchs := map[string]string{
-		"amd64": "x86_64",
-		"i386":  "x86",
-		"386":   "x86",
-		"arm64": "aarch64",
-	}
-
-	if translation, ok := validArchs[runtime.GOARCH]; ok {
-		return translation
-	}
-	return runtime.GOARCH
 }
 
 // requestSCAWithExpBackoff queries OCM API with exponential backoff.
 // Returns HttpError (see insightsclient.go) in case of any HTTP error response from OCM API.
 // The exponential backoff is applied only for HTTP errors >= 500.
-func (c *Controller) requestSCAWithExpBackoff(ctx context.Context, endpoint string, architectures map[string]struct{}) ([][]byte, error) {
+func (c *Controller) requestSCAWithExpBackoff(ctx context.Context, endpoint string, architectures map[string]struct{}) (*SCAResponse, error) {
 	bo := wait.Backoff{
 		Duration: c.configurator.Config().SCA.Interval / 32, // 15 min by default
 		Factor:   2,
@@ -240,34 +267,38 @@ func (c *Controller) requestSCAWithExpBackoff(ctx context.Context, endpoint stri
 	}
 
 	klog.Infof("Nodes architectures: %s", architectures)
-	var responses [][]byte
-	responses = make([][]byte, len(architectures))
-	err := wait.ExponentialBackoff(bo, func() (bool, error) {
-		for arch := range architectures {
-			data, err := c.client.RecvSCACerts(ctx, endpoint, arch)
-			if err != nil {
-				// don't try again in case it's not an HTTP error - it could mean we're in disconnected env
-				if !insightsclient.IsHttpError(err) {
-					return true, err
-				}
-				httpErr := err.(insightsclient.HttpError)
-				// try again only in case of 500 or higher
-				if httpErr.StatusCode >= http.StatusInternalServerError {
-					// check the number of steps to prevent "timeout waiting for condition" error - we want to propagate the HTTP error
-					if bo.Steps > 1 {
-						klog.Errorf("%v. Trying again in %s", httpErr, bo.Step())
-						return false, nil
-					}
-				}
-				return true, httpErr
-			}
 
-			responses = append(responses, data)
+	var responses SCAResponse
+	err := wait.ExponentialBackoff(bo, func() (bool, error) {
+		data, err := c.client.RecvSCACerts(ctx, endpoint, architectures)
+		if err != nil {
+			// don't try again in case it's not an HTTP error - it could mean we're in disconnected env
+			if !insightsclient.IsHttpError(err) {
+				return true, err
+			}
+			httpErr := err.(insightsclient.HttpError)
+			// try again only in case of 500 or higher
+			if httpErr.StatusCode >= http.StatusInternalServerError {
+				// check the number of steps to prevent "timeout waiting for condition" error - we want to propagate the HTTP error
+				if bo.Steps > 1 {
+					klog.Errorf("%v. Trying again in %s", httpErr, bo.Step())
+					return false, nil
+				}
+			}
+			return true, httpErr
 		}
+
+		err = json.Unmarshal(data, &responses)
+		if err != nil {
+			klog.Errorf("Unable to decode response: %v", err)
+			return true, err
+		}
+
 		return true, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return responses, nil
+
+	return &responses, nil
 }

--- a/pkg/ocm/sca/sca_test.go
+++ b/pkg/ocm/sca/sca_test.go
@@ -2,6 +2,7 @@ package sca
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,30 +11,53 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 )
 
-var (
+const (
 	entitlementPem    = "entitlement.pem"
 	entitlementKeyPem = "entitlement-key.pem"
 	secTestData       = "secret testing data"
+	unexpectedDataErr = "unexpected data in %s secret"
+	notFoundDataErr   = "can't find %s in the %s secret data"
 )
+
+var testingSCACertData = []SCACertData{
+	{
+		Cert: "testing-cert",
+		Key:  "testing-key",
+		ID:   "testing-id",
+		Metadata: SCACertMetadata{
+			Arch: "aarch64",
+		},
+		OrgID: "testing-org-id",
+	},
+	{
+		Cert: "testing-cert",
+		Key:  "testing-key",
+		ID:   "testing-id",
+		Metadata: SCACertMetadata{
+			Arch: "x86_64",
+		},
+		OrgID: "testing-org-id",
+	},
+}
 
 func Test_SCAController_SecretIsCreated(t *testing.T) {
 	kube := kubefake.NewSimpleClientset()
 	coreClient := kube.CoreV1()
 	scaController := New(coreClient, nil, nil)
 
-	testRes := &Response{
+	testRes := &SCACertData{
 		Key:  "secret key",
 		Cert: "secret cert",
 	}
-	err := scaController.checkSecret(context.Background(), testRes)
+	err := scaController.checkSecret(context.Background(), testRes, secretName)
 	assert.NoError(t, err, "failed to check the secret")
 
 	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
 	assert.NoError(t, err, "can't get secret")
-	assert.Contains(t, testSecret.Data, entitlementKeyPem, "can't find %s in the %s secret data", entitlementKeyPem, secretName)
-	assert.Contains(t, testSecret.Data, entitlementPem, "can't find %s in the %s secret data", entitlementPem, secretName)
-	assert.Equal(t, "secret key", string(testSecret.Data[entitlementKeyPem]), "unexpected data in %s secret", secretName)
-	assert.Equal(t, "secret cert", string(testSecret.Data[entitlementPem]), "unexpected data in %s secret", secretName)
+	assert.Contains(t, testSecret.Data, entitlementKeyPem, notFoundDataErr, entitlementKeyPem, secretName)
+	assert.Contains(t, testSecret.Data, entitlementPem, notFoundDataErr, entitlementPem, secretName)
+	assert.Equal(t, "secret key", string(testSecret.Data[entitlementKeyPem]), unexpectedDataErr, secretName)
+	assert.Equal(t, "secret cert", string(testSecret.Data[entitlementPem]), unexpectedDataErr, secretName)
 }
 
 func Test_SCAController_SecretIsUpdated(t *testing.T) {
@@ -53,17 +77,68 @@ func Test_SCAController_SecretIsUpdated(t *testing.T) {
 	_, err := coreClient.Secrets(targetNamespaceName).Create(context.Background(), existingSec, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	scaController := New(coreClient, nil, nil)
-	testRes := &Response{
+	testRes := &SCACertData{
 		Key:  "new secret testing key",
 		Cert: "new secret testing cert",
 	}
-	err = scaController.checkSecret(context.Background(), testRes)
+	err = scaController.checkSecret(context.Background(), testRes, secretName)
 	assert.NoError(t, err, "failed to check the secret")
 
 	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
 	assert.NoError(t, err, "can't get secret")
-	assert.Contains(t, testSecret.Data, entitlementKeyPem, "can't find %s in the %s secret data", entitlementKeyPem, secretName)
-	assert.Contains(t, testSecret.Data, entitlementPem, "can't find %s in the %s secret data", entitlementPem, secretName)
-	assert.Equal(t, "new secret testing key", string(testSecret.Data[entitlementKeyPem]), "unexpected data in %s secret", secretName)
-	assert.Equal(t, "new secret testing cert", string(testSecret.Data[entitlementPem]), "unexpected data in %s secret", secretName)
+	assert.Contains(t, testSecret.Data, entitlementKeyPem, notFoundDataErr, entitlementKeyPem, secretName)
+	assert.Contains(t, testSecret.Data, entitlementPem, notFoundDataErr, entitlementPem, secretName)
+	assert.Equal(t, "new secret testing key", string(testSecret.Data[entitlementKeyPem]), unexpectedDataErr, secretName)
+	assert.Equal(t, "new secret testing cert", string(testSecret.Data[entitlementPem]), unexpectedDataErr, secretName)
+}
+
+func Test_SCAController_ProcessSingleResponse(t *testing.T) {
+	kube := kubefake.NewSimpleClientset()
+	coreClient := kube.CoreV1()
+	scaController := New(coreClient, nil, nil)
+
+	testingResponses := SCAResponse{
+		Items: testingSCACertData[:1],
+		Kind:  "EntitlementCertificatesList",
+		Total: 1,
+	}
+
+	err := scaController.processResponses(context.Background(), testingResponses)
+	assert.NoError(t, err, "failed to process the response")
+
+	// Should create one secret without the arch suffix to keep backward compatibility
+	testSecret, err := coreClient.Secrets(targetNamespaceName).Get(context.Background(), secretName, metav1.GetOptions{})
+	assert.NoError(t, err, "can't get secret")
+	assert.Contains(t, testSecret.Data, entitlementKeyPem, notFoundDataErr, entitlementKeyPem, secretName)
+	assert.Contains(t, testSecret.Data, entitlementPem, notFoundDataErr, entitlementPem, secretName)
+	assert.Equal(t, testingResponses.Items[0].Key, string(testSecret.Data[entitlementKeyPem]), unexpectedDataErr, secretName)
+	assert.Equal(t, testingResponses.Items[0].Cert, string(testSecret.Data[entitlementPem]), unexpectedDataErr, secretName)
+}
+
+func Test_SCAController_ProcessMultipleResponses(t *testing.T) {
+	kube := kubefake.NewSimpleClientset()
+	coreClient := kube.CoreV1()
+	scaController := New(coreClient, nil, nil)
+
+	testingResponses := SCAResponse{
+		Items: testingSCACertData,
+		Kind:  "EntitlementCertificatesList",
+		Total: 2,
+	}
+
+	err := scaController.processResponses(context.Background(), testingResponses)
+	assert.NoError(t, err, "failed to process the response")
+
+	for _, response := range testingResponses.Items {
+		testSecret, err := coreClient.Secrets(targetNamespaceName).Get(
+			context.Background(),
+			fmt.Sprintf(secretArchName, archMapping[response.Metadata.Arch]),
+			metav1.GetOptions{},
+		)
+		assert.NoError(t, err, "can't get secret")
+		assert.Contains(t, testSecret.Data, entitlementKeyPem, notFoundDataErr, entitlementKeyPem, testSecret.Name)
+		assert.Contains(t, testSecret.Data, entitlementPem, notFoundDataErr, entitlementPem, testSecret.Name)
+		assert.Equal(t, response.Key, string(testSecret.Data[entitlementKeyPem]), unexpectedDataErr, testSecret.Name)
+		assert.Equal(t, response.Cert, string(testSecret.Data[entitlementPem]), unexpectedDataErr, testSecret.Name)
+	}
 }

--- a/pkg/ocm/sca/sca_test.go
+++ b/pkg/ocm/sca/sca_test.go
@@ -19,12 +19,12 @@ const (
 	notFoundDataErr   = "can't find %s in the %s secret data"
 )
 
-var testingSCACertData = []SCACertData{
+var testingSCACertData = []CertData{
 	{
 		Cert: "testing-cert",
 		Key:  "testing-key",
 		ID:   "testing-id",
-		Metadata: SCACertMetadata{
+		Metadata: CertMetadata{
 			Arch: "aarch64",
 		},
 		OrgID: "testing-org-id",
@@ -33,7 +33,7 @@ var testingSCACertData = []SCACertData{
 		Cert: "testing-cert",
 		Key:  "testing-key",
 		ID:   "testing-id",
-		Metadata: SCACertMetadata{
+		Metadata: CertMetadata{
 			Arch: "x86_64",
 		},
 		OrgID: "testing-org-id",
@@ -45,7 +45,7 @@ func Test_SCAController_SecretIsCreated(t *testing.T) {
 	coreClient := kube.CoreV1()
 	scaController := New(coreClient, nil, nil)
 
-	testRes := &SCACertData{
+	testRes := &CertData{
 		Key:  "secret key",
 		Cert: "secret cert",
 	}
@@ -77,7 +77,7 @@ func Test_SCAController_SecretIsUpdated(t *testing.T) {
 	_, err := coreClient.Secrets(targetNamespaceName).Create(context.Background(), existingSec, metav1.CreateOptions{})
 	assert.NoError(t, err)
 	scaController := New(coreClient, nil, nil)
-	testRes := &SCACertData{
+	testRes := &CertData{
 		Key:  "new secret testing key",
 		Cert: "new secret testing cert",
 	}
@@ -97,7 +97,7 @@ func Test_SCAController_ProcessSingleResponse(t *testing.T) {
 	coreClient := kube.CoreV1()
 	scaController := New(coreClient, nil, nil)
 
-	testingResponses := SCAResponse{
+	testingResponses := Response{
 		Items: testingSCACertData[:1],
 		Kind:  "EntitlementCertificatesList",
 		Total: 1,
@@ -120,7 +120,7 @@ func Test_SCAController_ProcessMultipleResponses(t *testing.T) {
 	coreClient := kube.CoreV1()
 	scaController := New(coreClient, nil, nil)
 
-	testingResponses := SCAResponse{
+	testingResponses := Response{
 		Items: testingSCACertData,
 		Kind:  "EntitlementCertificatesList",
 		Total: 2,


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR implements the gathering of architectures used by nodes and the retrieval of entitlement certificates for each architecture in use. These certificates are then stored in secrets. 

If only one architecture is present, the secret is named etc-pki-entitlement. 
If multiple architectures are present, secrets are created with names like etc-pki-entitlement-ARCH, where ARCH represents the specific architecture.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive

The archive won't change with this feature

## Documentation

No documentation update

## Unit Tests

- pkg/ocm/sca/architectures_gather_test.go
- pkg/ocm/sca/sca_test.go

## Privacy

Yes. There are no sensitive data in the newly collected information.

## Changelog

No

## Breaking Changes

Yes/No

## References

https://issues.redhat.com/browse/CCXDEV-12875
