### PR TITLE
OCPBUGS-48154: Add a liveness probe to the extractor container

### DIFF
--- a/manifests/10-insights-runtime-extractor.yaml
+++ b/manifests/10-insights-runtime-extractor.yaml
@@ -93,6 +93,13 @@ spec:
           env:
             - name: CONTAINER_RUNTIME_ENDPOINT
               value: unix:///crio.sock
+          livenessProbe:
+            exec:
+              command:
+                - crictl
+                - info
+              periodSeconds: 10
+              failureThreshold: 2
           resources: 
             requests:
               cpu: 10m


### PR DESCRIPTION
The extractor container relies on critctl to collect container information

If the crio.service is restarted on the worker nodes when the CA bundle has been updated by the proxy/cluster, the container would not be able to connect anymore on the restarted CRI-O service.

Adding a liveness probe that check that crictl works as expected ensure that the container will be killed and restarted with the correct TLS settings to connect to the CRI-O service.

This fixes https://issues.redhat.com/browse/OCPBUGS-48154.

## Categories

- [X] Bugfix

## Breaking Changes

No

## References

https://issues.redhat.com/browse/OCPBUGS-48154
