### PR TITLE
OCPBUGS-51109: Fix bad IPv6 address

### DIFF
--- a/manifests/10-insights-runtime-extractor.yaml
+++ b/manifests/10-insights-runtime-extractor.yaml
@@ -39,7 +39,7 @@ spec:
         - name: kube-rbac-proxy
           image: quay.io/openshift/origin-kube-rbac-proxy:latest
           args:
-            - '--secure-listen-address=$(IP):8000'
+            - '--secure-listen-address=:8443'
             - '--upstream=http://127.0.0.1:8000'
             - '--config-file=/etc/kube-rbac-proxy/config.yaml'
             - '--tls-cert-file=/etc/tls/private/tls.crt'
@@ -57,15 +57,9 @@ spec:
               drop:
               - ALL
             runAsNonRoot: true
-          env:
-            - name: IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
           ports:
             - name: https
-              containerPort: 8000
+              containerPort: 8443
               protocol: TCP
           resources:
             requests:

--- a/pkg/gatherers/workloads/gather_workloads_runtime_infos.go
+++ b/pkg/gatherers/workloads/gather_workloads_runtime_infos.go
@@ -61,7 +61,7 @@ func gatherWorkloadRuntimeInfos(
 		go func(podInfo podWithNodeName) {
 			defer wg.Done()
 			klog.Infof("Gathering workload runtime info for node %s...\n", podInfo.nodeName)
-			hostPort := net.JoinHostPort(podInfo.podIP, "8000")
+			hostPort := net.JoinHostPort(podInfo.podIP, "8443")
 			extractorURL := fmt.Sprintf("https://%s/gather_runtime_info", hostPort)
 			httpCli, err := createHTTPClient()
 			if err != nil {


### PR DESCRIPTION
Let the kube-rbac-proxy listens on `8443` (without specifying the IP address)

In the insights-operator, connect to this port to go through the kube-rbac-proxy

This fixes https://issues.redhat.com/browse/OCPBUGS-51109

## Categories

- [X] Bugfix
