### PR TITLE
CCXDEV-14934: fix: allow running enabled functions from disabled gatherer

### DIFF
--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -95,6 +95,29 @@ func TestGetEnabledGatheringFunctions(t *testing.T) {
 			expected: map[string]gatherers.GatheringClosure{},
 		},
 		{
+			testName:     "disable complete top-level gatherer and enabled one function",
+			gathererName: "clusterconfig",
+			all: map[string]gatherers.GatheringClosure{
+				"container_images": {},
+				"nodes":            {},
+				"authentication":   {},
+				"some_function":    {},
+			},
+			gathererConfigs: []v1alpha1.GathererConfig{
+				{
+					Name:  "clusterconfig",
+					State: v1alpha1.Disabled,
+				},
+				{
+					Name:  "clusterconfig/nodes",
+					State: v1alpha1.Enabled,
+				},
+			},
+			expected: map[string]gatherers.GatheringClosure{
+				"nodes": {},
+			},
+		},
+		{
 			testName:     "no functions disabled",
 			gathererName: "clusterconfig",
 			all: map[string]gatherers.GatheringClosure{
@@ -402,7 +425,8 @@ func TestCollectAndRecordGathererError(t *testing.T) {
 		{
 			Name:  "mock_gatherer/some_field",
 			State: v1alpha1.Disabled,
-		}, {
+		},
+		{
 			Name:  "mock_gatherer/name",
 			State: v1alpha1.Disabled,
 		},
@@ -460,7 +484,8 @@ func TestCollectAndRecordGathererPanic(t *testing.T) {
 		{
 			Name:  "mock_gatherer/some_field",
 			State: v1alpha1.Disabled,
-		}, {
+		},
+		{
 			Name:  "mock_gatherer/name",
 			State: v1alpha1.Disabled,
 		},


### PR DESCRIPTION
This PR ensures that when a gatherer is disabled, users can still explicitly enable specific functions within that gatherer.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

None

## Documentation
<!-- Are these changes reflected in documentation? -->

None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- pkg/gather/gather_test.go

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog

No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-14934
