### PR TITLE
CCXDEV-9968: add disabledWithApi condition

### DIFF
--- a/pkg/controller/status/conditions.go
+++ b/pkg/controller/status/conditions.go
@@ -23,6 +23,8 @@ const (
 	RemoteConfigurationAvailable configv1.ClusterStatusConditionType = "RemoteConfigurationAvailable"
 	// RemoteConfigurationInvalid is a condition type providing info about remote configuration content validity
 	RemoteConfigurationValid configv1.ClusterStatusConditionType = "RemoteConfigurationValid"
+	// GatheringDisabled is a condition providing information about the disabling of gathering with the API.
+	GatheringDisabled configv1.ClusterStatusConditionType = "GatheringDisabled"
 )
 
 type conditionsMap map[configv1.ClusterStatusConditionType]configv1.ClusterOperatorStatusCondition
@@ -75,6 +77,12 @@ func newConditions(cos *configv1.ClusterOperatorStatus, time metav1.Time) *condi
 			LastTransitionTime: time,
 			Reason:             "",
 		},
+		GatheringDisabled: {
+			Type:               GatheringDisabled,
+			Status:             configv1.ConditionUnknown,
+			LastTransitionTime: time,
+			Reason:             "",
+		},
 	}
 
 	for _, c := range cos.Conditions {
@@ -87,7 +95,8 @@ func newConditions(cos *configv1.ClusterOperatorStatus, time metav1.Time) *condi
 }
 
 func (c *conditions) setCondition(conditionType configv1.ClusterStatusConditionType,
-	status configv1.ConditionStatus, reason, message string) {
+	status configv1.ConditionStatus, reason, message string,
+) {
 	originalCondition, ok := c.entryMap[conditionType]
 	transitionTime := metav1.Now()
 	// if condition is defined and there is no new status then don't update transition time

--- a/pkg/controller/status/conditions_test.go
+++ b/pkg/controller/status/conditions_test.go
@@ -496,6 +496,12 @@ func Test_newConditions(t *testing.T) { // nolint: funlen
 						LastTransitionTime: time,
 						Reason:             "",
 					},
+					GatheringDisabled: {
+						Type:               GatheringDisabled,
+						Status:             configv1.ConditionUnknown,
+						LastTransitionTime: time,
+						Reason:             "",
+					},
 				},
 			},
 		},
@@ -556,6 +562,12 @@ func Test_newConditions(t *testing.T) { // nolint: funlen
 					},
 					RemoteConfigurationValid: {
 						Type:               RemoteConfigurationValid,
+						Status:             configv1.ConditionUnknown,
+						LastTransitionTime: time,
+						Reason:             "",
+					},
+					GatheringDisabled: {
+						Type:               GatheringDisabled,
 						Status:             configv1.ConditionUnknown,
 						LastTransitionTime: time,
 						Reason:             "",


### PR DESCRIPTION
This PR adds a new condition to IO, which is set when gathering is disabled via the API. To disable gathering in the API, set `disabledGatherers` to `all` in the `InsightsDataGather` spec.


## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- None

## Documentation
<!-- Are these changes reflected in documentation? -->

- None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- None

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-9968
