### PR TITLE
CCXDEV-14944: remove the upgradeable condition

### DIFF
--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -39,7 +39,6 @@ const (
 	insightsAvailableMessage = "Insights works as expected"
 	reportingDisabledMsg     = "Health reporting is disabled"
 	monitoringMsg            = "Monitoring the cluster"
-	canBeUpgradedMsg         = "Insights operator can be upgraded"
 )
 
 type Reported struct {
@@ -73,7 +72,8 @@ func NewController(client configv1client.ConfigV1Interface,
 	configurator configobserver.Interface,
 	apiConfigurator configobserver.InsightsDataGatherObserver,
 	namespace string,
-	isTechPreview bool) *Controller {
+	isTechPreview bool,
+) *Controller {
 	c := &Controller{
 		name:            "insights",
 		statusCh:        make(chan struct{}, 1),
@@ -417,7 +417,8 @@ func (c *Controller) updateControllerConditions(cs *conditions, isInitializing b
 func (c *Controller) updateControllerConditionByReason(cs *conditions,
 	condition configv1.ClusterStatusConditionType,
 	controllerName, reason string,
-	isInitializing bool) {
+	isInitializing bool,
+) {
 	controller := c.Source(controllerName)
 	if controller == nil {
 		return
@@ -466,7 +467,6 @@ func (c *Controller) updateControllerConditionsByStatus(cs *conditions, isInitia
 		klog.Infof("The operator has some internal errors: %s", es.message)
 		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, degradedReason, "An error has occurred")
 		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionFalse, es.reason, es.message)
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, degradedReason, es.message)
 	}
 
 	// when the operator is already healthy then it doesn't make sense to set those, but when it's degraded and then
@@ -475,14 +475,12 @@ func (c *Controller) updateControllerConditionsByStatus(cs *conditions, isInitia
 		klog.Infof("The operator is marked as disabled")
 		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, AsExpectedReason, monitoringMsg)
 		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, AsExpectedReason, insightsAvailableMessage)
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, upgradeableReason, canBeUpgradedMsg)
 	}
 
 	if c.ctrlStatus.isHealthy() {
 		klog.Infof("The operator is healthy")
 		cs.setCondition(configv1.OperatorProgressing, configv1.ConditionFalse, AsExpectedReason, monitoringMsg)
 		cs.setCondition(configv1.OperatorAvailable, configv1.ConditionTrue, AsExpectedReason, insightsAvailableMessage)
-		cs.setCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, upgradeableReason, canBeUpgradedMsg)
 	}
 }
 

--- a/pkg/controller/status/controller_test.go
+++ b/pkg/controller/status/controller_test.go
@@ -111,13 +111,6 @@ func Test_updatingConditionsInDisabledState(t *testing.T) {
 		Message:            insightsAvailableMessage,
 		LastTransitionTime: lastTransitionTime,
 	}
-	upgradeableCondition := configv1.ClusterOperatorStatusCondition{
-		Type:               configv1.OperatorUpgradeable,
-		Status:             configv1.ConditionTrue,
-		Reason:             upgradeableReason,
-		Message:            canBeUpgradedMsg,
-		LastTransitionTime: lastTransitionTime,
-	}
 
 	testCO := configv1.ClusterOperator{
 		Status: configv1.ClusterOperatorStatus{
@@ -125,7 +118,6 @@ func Test_updatingConditionsInDisabledState(t *testing.T) {
 				availableCondition,
 				progressingCondition,
 				degradedCondition,
-				upgradeableCondition,
 				{
 					Type:               OperatorDisabled,
 					Status:             configv1.ConditionFalse,
@@ -150,7 +142,8 @@ func Test_updatingConditionsInDisabledState(t *testing.T) {
 	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
 	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
 	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
-	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+	// Upgradeable should not  be set
+	assert.Nil(t, getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
 
 	disabledCondition := getConditionByType(updatedCO.Status.Conditions, OperatorDisabled)
 	assert.Equal(t, configv1.ConditionTrue, disabledCondition.Status)
@@ -164,7 +157,8 @@ func Test_updatingConditionsInDisabledState(t *testing.T) {
 	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
 	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
 	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
-	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
+	// Upgradeable should not  be set
+	assert.Nil(t, getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
 	assert.Equal(t, disabledCondition, getConditionByType(updatedCO.Status.Conditions, OperatorDisabled))
 }
 
@@ -191,12 +185,6 @@ func Test_updatingConditionsFromDegradedToDisabled(t *testing.T) {
 					Type:               configv1.OperatorDegraded,
 					Status:             configv1.ConditionTrue,
 					Reason:             "UploadFailed",
-					LastTransitionTime: lastTransitionTime,
-				},
-				{
-					Type:               configv1.OperatorUpgradeable,
-					Status:             configv1.ConditionFalse,
-					Reason:             degradedReason,
 					LastTransitionTime: lastTransitionTime,
 				},
 				{
@@ -228,9 +216,8 @@ func Test_updatingConditionsFromDegradedToDisabled(t *testing.T) {
 	assert.Equal(t, degradedCondition.Status, configv1.ConditionFalse)
 	assert.True(t, degradedCondition.LastTransitionTime.After(lastTransitionTime.Time))
 
-	upgradeableCondition := *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable)
-	assert.Equal(t, upgradeableCondition.Status, configv1.ConditionTrue)
-	assert.True(t, upgradeableCondition.LastTransitionTime.After(lastTransitionTime.Time))
+	// Upgradeable should not be set
+	assert.Nil(t, getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
 
 	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
 
@@ -246,12 +233,12 @@ func Test_updatingConditionsFromDegradedToDisabled(t *testing.T) {
 	assert.Equal(t, availableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorAvailable))
 	assert.Equal(t, progressingCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorProgressing))
 	assert.Equal(t, degradedCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorDegraded))
-	assert.Equal(t, upgradeableCondition, *getConditionByType(updatedCO.Status.Conditions, configv1.OperatorUpgradeable))
 	assert.Equal(t, disabledCondition, getConditionByType(updatedCO.Status.Conditions, OperatorDisabled))
 }
 
 func getConditionByType(conditions []configv1.ClusterOperatorStatusCondition,
-	ctype configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	ctype configv1.ClusterStatusConditionType,
+) *configv1.ClusterOperatorStatusCondition {
 	for _, c := range conditions {
 		if c.Type == ctype {
 			return &c


### PR DESCRIPTION
This PR removes the Upgradeable condition from the Insights Operator so that it does not block cluster-version operator updates.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

None

## Documentation
<!-- Are these changes reflected in documentation? -->

None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

None

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

None

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-14944
