### PR TITLE
CCXDEV-15026: ensure the etc-entitlement-pki secret exists

### DIFF
--- a/pkg/ocm/sca/architectures_gather_test.go
+++ b/pkg/ocm/sca/architectures_gather_test.go
@@ -14,6 +14,10 @@ var testNodes = []v1.Node{
 	{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node-x86_64",
+			Labels: map[string]string{
+				// Node marked as control plane
+				"node-role.kubernetes.io/control-plane": "",
+			},
 		},
 		Status: v1.NodeStatus{
 			NodeInfo: v1.NodeSystemInfo{
@@ -49,9 +53,12 @@ func Test_SCAController_GatherMultipleArchitectures(t *testing.T) {
 	}
 
 	scaController := New(coreClient, nil, nil)
-	gatheredArch, err := scaController.gatherArchitectures(context.Background())
+	clusterArchitectures, err := scaController.gatherArchitectures(context.Background())
 	assert.NoError(t, err, "failed to gather architectures")
 
-	assert.Len(t, gatheredArch, len(testNodes), "unexpected number of architectures")
-	assert.Equal(t, gatheredArch, expectedArchitectures, "unexpected architectures")
+	// check the correct control plane arch was found
+	assert.Equal(t, "x86_64", clusterArchitectures.ControlPlaneArch, "incorrect control plane architecture")
+
+	assert.Len(t, clusterArchitectures.NodeArchitectures, len(testNodes), "unexpected number of architectures")
+	assert.Equal(t, expectedArchitectures, clusterArchitectures.NodeArchitectures, "unexpected architectures")
 }


### PR DESCRIPTION
This PR ensures that default etc-entitlement-pki secret is created and updated, including multi-architecture clusters where the architecture specific secrets are created as well.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- None

## Documentation
<!-- Are these changes reflected in documentation? -->

- None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- pkg/ocm/sca/architectures_gather_test.go
- pkg/ocm/sca/sca_test.go

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog

None

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References

https://issues.redhat.com/browse/CCXDEV-15026

