### PR TITLE
CCXDEV-15070: move HTTP status code from condition.Reason to condition.Message

### DIFF
--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -248,13 +248,17 @@ func (g *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 
 	// upload data
 	insightsRequestID, statusCode, err := uploader.Upload(ctx, lastArchive)
-	reason := fmt.Sprintf("HttpStatus%d", statusCode)
-	dataUploadedCon := status.DataUploadedCondition(metav1.ConditionTrue, reason, "")
+	dataUploadedCon := status.DataUploadedCondition(
+		metav1.ConditionTrue,
+		status.SucceededReason,
+		fmt.Sprintf("Succeeded with http status code: %d", statusCode),
+	)
+
 	if err != nil {
 		klog.Errorf("Failed to upload data archive: %v", err)
 		dataUploadedCon.Status = metav1.ConditionFalse
-		dataUploadedCon.Reason = reason
-		dataUploadedCon.Message = fmt.Sprintf("Failed to upload data: %v", err)
+		dataUploadedCon.Reason = status.FailedReason
+		dataUploadedCon.Message = fmt.Sprintf("Failed to upload data err: %v with http status code: %d", err, statusCode)
 		updateDataGatherStatus(ctx, insightsV1alphaCli, dataGatherCR, &dataUploadedCon, insightsv1alpha1.Failed)
 		return err
 	}

--- a/pkg/controller/status/datagather_status.go
+++ b/pkg/controller/status/datagather_status.go
@@ -13,6 +13,8 @@ const (
 	DataRecorded  = "DataRecorded"
 	DataProcessed = "DataProcessed"
 
+	SucceededReason           = "Succeeded"
+	FailedReason              = "Failed"
 	NoUploadYetReason         = "NoUploadYet"
 	NoDataGatheringYetReason  = "NoDataGatheringYet"
 	NothingToProcessYetReason = "NothingToProcessYet"
@@ -83,7 +85,8 @@ func RemoteConfigurationInvalidCondition(status metav1.ConditionStatus, reason, 
 func UpdateDataGatherState(ctx context.Context,
 	insightsClient insightsv1alpha1cli.InsightsV1alpha1Interface,
 	dataGatherCR *insightsv1alpha1.DataGather,
-	newState insightsv1alpha1.DataGatherState) (*insightsv1alpha1.DataGather, error) {
+	newState insightsv1alpha1.DataGatherState,
+) (*insightsv1alpha1.DataGather, error) {
 	switch newState {
 	case insightsv1alpha1.Completed:
 		dataGatherCR.Status.FinishTime = metav1.Now()
@@ -128,7 +131,8 @@ func getConditionIndexByType(conType string, conditions []metav1.Condition) int 
 // condition
 func UpdateDataGatherConditions(ctx context.Context,
 	insightsClient insightsv1alpha1cli.InsightsV1alpha1Interface,
-	dataGather *insightsv1alpha1.DataGather, condition *metav1.Condition) (*insightsv1alpha1.DataGather, error) {
+	dataGather *insightsv1alpha1.DataGather, condition *metav1.Condition,
+) (*insightsv1alpha1.DataGather, error) {
 	newConditions := make([]metav1.Condition, len(dataGather.Status.Conditions))
 	_ = copy(newConditions, dataGather.Status.Conditions)
 	idx := getConditionIndexByType(condition.Type, newConditions)


### PR DESCRIPTION
This PR updates the UploadData condition to store the HTTP status code in the condition.Message instead of condition.Reason.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

None

## Documentation
<!-- Are these changes reflected in documentation? -->

None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

None

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/CCXDEV-15070