### PR TITLE
OCPBUGS-55805: Enhance insights-runtime-extractor errors

### DIFF
--- a/pkg/gatherers/workloads/gather_workloads_runtime_infos.go
+++ b/pkg/gatherers/workloads/gather_workloads_runtime_infos.go
@@ -184,7 +184,7 @@ func getNodeWorkloadRuntimeInfos(
 		return workloadRuntimesResult{
 			Error: insightsclient.HttpError{
 				StatusCode: resp.StatusCode,
-				Err:        fmt.Errorf("%s", resp.Status),
+				Err:        fmt.Errorf("received unexpected status code %s from %s", resp.Status, url),
 			},
 		}
 	}
@@ -193,14 +193,14 @@ func getNodeWorkloadRuntimeInfos(
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return workloadRuntimesResult{
-			Error: err,
+			Error: fmt.Errorf("unable to read response from %s: %s", url, err),
 		}
 	}
 	var nodeOutput nodeRuntimeInfo
 	err = json.Unmarshal(body, &nodeOutput)
 	if err != nil {
 		return workloadRuntimesResult{
-			Error: err,
+			Error: fmt.Errorf("unable to read parse JSON content from %s: %s", url, err),
 		}
 	}
 
@@ -227,6 +227,5 @@ func getNodeWorkloadRuntimeInfos(
 	}
 	return workloadRuntimesResult{
 		WorkloadRuntimes: result,
-		Error:            err,
 	}
 }

--- a/pkg/gatherers/workloads/gather_workloads_runtime_infos_test.go
+++ b/pkg/gatherers/workloads/gather_workloads_runtime_infos_test.go
@@ -194,7 +194,8 @@ func TestGetNodeWorkloadRuntimeInfos(t *testing.T) {
 			result := getNodeWorkloadRuntimeInfos(ctx, httpServer.URL, "", http.DefaultClient)
 			assert.Equal(t, tt.expectedData, result.WorkloadRuntimes)
 			if tt.expectedErr != nil {
-				assert.Equal(t, tt.expectedErr.Error(), result.Error.Error())
+				assert.Contains(t, result.Error.Error(), tt.expectedErr.Error())
+				assert.Nil(t, result.WorkloadRuntimes)
 			}
 		})
 	}


### PR DESCRIPTION
Provide meaningful error message with the URL of the insights-runtime-extractor URLs when the extraction of runtime data fails.

This fixes https://issues.redhat.com/browse/OCPBUGS-55805.

## Categories

- [X] Bugfix

## Breaking Changes

No

## References

https://issues.redhat.com/browse/OCPBUGS-55805.