### PR TITLE
OCPBUGS-55804: Report an error when the insights-runtime-extractor is …

### DIFF
--- a/pkg/gatherers/workloads/gather_workloads_runtime_infos.go
+++ b/pkg/gatherers/workloads/gather_workloads_runtime_infos.go
@@ -102,7 +102,7 @@ func getInsightsOperatorRuntimePodIPs(
 		return nil, err
 	}
 
-	var runtimePods []podWithNodeName
+	runtimePods := []podWithNodeName{}
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		running := pod.Status.Phase == corev1.PodRunning
@@ -113,6 +113,11 @@ func getInsightsOperatorRuntimePodIPs(
 			})
 		}
 	}
+
+	if len(runtimePods) == 0 {
+		return nil, fmt.Errorf("no running pods found for the insights-runtime-extractor statefulset")
+	}
+
 	return runtimePods, nil
 }
 

--- a/pkg/gatherers/workloads/gather_workloads_runtime_infos_test.go
+++ b/pkg/gatherers/workloads/gather_workloads_runtime_infos_test.go
@@ -210,8 +210,8 @@ func TestGetInsightsOperatorRuntimePodIPs(t *testing.T) {
 		{
 			name:           "empty Pod list",
 			pods:           []*v1.Pod{},
-			expectedErr:    nil,
-			expectedResult: []podWithNodeName(nil),
+			expectedErr:    fmt.Errorf("no running pods found for the insights-runtime-extractor statefulset"),
+			expectedResult: nil,
 		},
 		{
 			name: "Pod doesn't have the required label",
@@ -223,8 +223,8 @@ func TestGetInsightsOperatorRuntimePodIPs(t *testing.T) {
 					},
 				},
 			},
-			expectedErr:    nil,
-			expectedResult: []podWithNodeName(nil),
+			expectedErr:    fmt.Errorf("no running pods found for the insights-runtime-extractor statefulset"),
+			expectedResult: nil,
 		},
 		{
 			name: "Pod has the required label, but it is not running",
@@ -239,8 +239,8 @@ func TestGetInsightsOperatorRuntimePodIPs(t *testing.T) {
 					},
 				},
 			},
-			expectedErr:    nil,
-			expectedResult: []podWithNodeName(nil),
+			expectedErr:    fmt.Errorf("no running pods found for the insights-runtime-extractor statefulset"),
+			expectedResult: nil,
 		},
 		{
 			name: "some Pods found",
@@ -325,7 +325,11 @@ func TestGetInsightsOperatorRuntimePodIPs(t *testing.T) {
 			err = os.Setenv("POD_NAMESPACE", "openshift-insights")
 			assert.NoError(t, err)
 			result, err := getInsightsOperatorRuntimePodIPs(context.Background(), cli.CoreV1())
-			assert.Equal(t, tt.expectedErr, err)
+			if tt.expectedErr == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.Contains(t, err.Error(), tt.expectedErr.Error())
+			}
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}


### PR DESCRIPTION
…not running

If there are no running pods for the insights-runtime-extractor, report it as an error. There should be 1 running pods on every cluster's worker node. The number can differ based on the cluster size but the absence of any running pods is an error to report to the user.

This fixes https://issues.redhat.com/browse/OCPBUGS-55804

## Categories

- [X] Bugfix

## Breaking Changes

No

## References

https://issues.redhat.com/browse/OCPBUGS-55804
