### PR TITLE
CCXDEV-15190: add Progressing condition

### DIFF
--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -765,6 +765,7 @@ func (c *Controller) updateNewDataGatherCRStatus(ctx context.Context, dg *insigh
 		status.DataProcessedCondition(metav1.ConditionUnknown, status.NothingToProcessYetReason, ""),
 		status.RemoteConfigurationAvailableCondition(metav1.ConditionUnknown, status.UnknownReason, ""),
 		status.RemoteConfigurationValidCondition(metav1.ConditionUnknown, status.UnknownReason, ""),
+		status.ProgressingCondition(insightsv1alpha1.Pending),
 	}
 	dg.Status.State = insightsv1alpha1.Pending
 	if job != nil {

--- a/pkg/controller/status/datagather_status.go
+++ b/pkg/controller/status/datagather_status.go
@@ -6,6 +6,7 @@ import (
 	insightsv1alpha1 "github.com/openshift/api/insights/v1alpha1"
 	insightsv1alpha1cli "github.com/openshift/client-go/insights/clientset/versioned/typed/insights/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -27,7 +28,48 @@ const (
 	RemoteConfNotValidatedYet = "NoValidationYet"
 	RemoteConfNotRequestedYet = "RemoteConfigNotRequestedYet"
 	UnknownReason             = "Unknown"
+
+	// Progressing Condition
+	Progressing                 = "Progressing"
+	DataGatheringPendingReason  = "DataGatherPending"
+	DataGatheringPendingMessage = "The gathering has not started yet"
+	GatheringReason             = "Gathering"
+	GatheringMessage            = "The gathering is running"
+	GatheringSucceededReason    = "GatheringSucceeded"
+	GatheringSucceededMessage   = "The gathering successfully finished."
+	GatheringFailedReason       = "GatheringFailed"
+	GatheringFailedMessage      = "The gathering failed."
 )
+
+// ProgressingCondition returns new "ProgressingCondition" status condition with provided status, reason and message
+func ProgressingCondition(state insightsv1alpha1.DataGatherState) metav1.Condition {
+	progressingStatus := metav1.ConditionFalse
+
+	var progressingReason, progressingMessage string
+	switch state {
+	case insightsv1alpha1.Pending:
+		progressingReason = DataGatheringPendingReason
+		progressingMessage = DataGatheringPendingMessage
+	case insightsv1alpha1.Running:
+		progressingStatus = metav1.ConditionTrue
+		progressingReason = GatheringReason
+		progressingMessage = GatheringMessage
+	case insightsv1alpha1.Completed:
+		progressingReason = GatheringSucceededReason
+		progressingMessage = GatheringSucceededMessage
+	case insightsv1alpha1.Failed:
+		progressingReason = GatheringFailedReason
+		progressingMessage = GatheringFailedMessage
+	}
+
+	return metav1.Condition{
+		Type:               Progressing,
+		LastTransitionTime: metav1.Now(),
+		Status:             progressingStatus,
+		Reason:             progressingReason,
+		Message:            progressingMessage,
+	}
+}
 
 // DataUploadedCondition returns new "DataUploaded" status condition with provided status, reason and message
 func DataUploadedCondition(status metav1.ConditionStatus, reason, message string) metav1.Condition {
@@ -103,8 +145,16 @@ func UpdateDataGatherState(ctx context.Context,
 	case insightsv1alpha1.Pending:
 		// no op
 	}
-	dataGatherCR.Status.State = newState
-	return insightsClient.DataGathers().UpdateStatus(ctx, dataGatherCR, metav1.UpdateOptions{})
+
+	updatedDataGather, err := UpdateDataGatherConditions(
+		ctx, insightsClient, dataGatherCR, ProgressingCondition(newState),
+	)
+	if err != nil {
+		klog.Errorf("Failed to update DataGather resource %s conditions: %v", dataGatherCR.Name, err)
+	}
+
+	updatedDataGather.Status.State = newState
+	return insightsClient.DataGathers().UpdateStatus(ctx, updatedDataGather, metav1.UpdateOptions{})
 }
 
 // GetConditionByType tries to get the condition with the provided condition status
@@ -137,16 +187,20 @@ func getConditionIndexByType(conType string, conditions []metav1.Condition) int 
 // condition
 func UpdateDataGatherConditions(ctx context.Context,
 	insightsClient insightsv1alpha1cli.InsightsV1alpha1Interface,
-	dataGather *insightsv1alpha1.DataGather, condition *metav1.Condition,
+	dataGather *insightsv1alpha1.DataGather, conditions ...metav1.Condition,
 ) (*insightsv1alpha1.DataGather, error) {
 	newConditions := make([]metav1.Condition, len(dataGather.Status.Conditions))
 	_ = copy(newConditions, dataGather.Status.Conditions)
-	idx := getConditionIndexByType(condition.Type, newConditions)
-	if idx != -1 {
-		newConditions[idx] = *condition
-	} else {
-		newConditions = append(newConditions, *condition)
+
+	for _, condition := range conditions {
+		idx := getConditionIndexByType(condition.Type, newConditions)
+		if idx != -1 {
+			newConditions[idx] = condition
+		} else {
+			newConditions = append(newConditions, condition)
+		}
 	}
+
 	dataGather.Status.Conditions = newConditions
 	return insightsClient.DataGathers().UpdateStatus(ctx, dataGather, metav1.UpdateOptions{})
 }


### PR DESCRIPTION
This PR introduces the Progressing condition, which will replace the deprecated status.State field in the next version of the DataGather API.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- None

## Documentation
<!-- Are these changes reflected in documentation? -->

- None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- pkg/controller/status/datagather_status_test.go

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog

None

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[CCXDEV-15190](https://issues.redhat.com/browse/CCXDEV-15190)
