### PR TITLE
OCPBUGS-56259: copy proxy envs from IO pod to gathering pods

### DIFF
--- a/pkg/controller/periodic/job_test.go
+++ b/pkg/controller/periodic/job_test.go
@@ -99,3 +99,59 @@ func TestCreateGathererJob(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateEnvVar(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectedEnv []v1.EnvVar
+	}{
+		{
+			name: "without-proxy-configuration",
+			expectedEnv: []v1.EnvVar{
+				{
+					Name:  "RELEASE_VERSION",
+					Value: "test-version",
+				},
+				{
+					Name:  "DATAGATHER_NAME",
+					Value: "without-proxy-configuration",
+				},
+			},
+		},
+		{
+			name: "with-proxy-configuration",
+			expectedEnv: []v1.EnvVar{
+				{
+					Name:  "HTTP_PROXY",
+					Value: "http://test-proxy.com",
+				},
+				{
+					Name:  "HTTPS_PROXY",
+					Value: "https://test-proxy.com",
+				},
+				{
+					Name:  "NO_PROXY",
+					Value: "http://test-no-proxy.com",
+				},
+				{
+					Name:  "RELEASE_VERSION",
+					Value: "test-version",
+				},
+				{
+					Name:  "DATAGATHER_NAME",
+					Value: "with-proxy-configuration",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, env := range tt.expectedEnv {
+				t.Setenv(env.Name, env.Value)
+			}
+
+			assert.Equal(t, tt.expectedEnv, createEnvVar(tt.name))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR adds functionality to copy the cluster-wide proxy environment variables from the IO pod to the gathering pod, ensuring the proxy is used for uploads from gathering pods as well.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- None

## Documentation
<!-- Are these changes reflected in documentation? -->

- None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/periodic/job_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- None

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[OCPBUGS-56259](https://issues.redhat.com/browse/OCPBUGS-56259)