### PR TITLE
WIP: feat: update the manifest crds to be applied during DevPreview and Custom featuresets

### DIFF
--- a/manifests/03-insightsdatagather-config-crd.yaml
+++ b/manifests/03-insightsdatagather-config-crd.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,DevPreviewNoUpgrade,TechPreviewNoUpgrade
   name: insightsdatagathers.config.openshift.io
 spec:
   group: config.openshift.io

--- a/manifests/04-datagather-insights-crd.yaml
+++ b/manifests/04-datagather-insights-crd.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,DevPreviewNoUpgrade,TechPreviewNoUpgrade
   name: datagathers.insights.openshift.io
 spec:
   group: insights.openshift.io

--- a/manifests/04-insightsdatagather-config-cr.yaml
+++ b/manifests/04-insightsdatagather-config-cr.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,DevPreviewNoUpgrade,TechPreviewNoUpgrade
     capability.openshift.io/name: Insights
     release.openshift.io/create-only: "true"
 spec: {}


### PR DESCRIPTION

Currently some of the API's used by the insights operator are tagged in the manifests folder as `TechPreviewNoUpgrade` but officially these API's are also flagged to work with `DevPreviewNoUpgrade` and by extension `CustomNoUpgrade`. Updating the annotations to correctly provide that information so when CVO applies the manifests they are not filtered out for non tech preview feature sets.


Currently validating this fix for TNF, we will need to make sure we do not break components that might not correctly parse the `release.openshift.io/feature-set` annotation

## Categories
<!-- Select the categories that your PR better fits on -->

- [x] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
