### PR TITLE
RFE-4152: Add missing readonlyRootFilesystem

### DIFF
--- a/manifests/10-insights-runtime-extractor.yaml
+++ b/manifests/10-insights-runtime-extractor.yaml
@@ -52,6 +52,7 @@ spec:
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
               - ALL
@@ -73,6 +74,7 @@ spec:
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
@@ -99,6 +101,7 @@ spec:
               memory: 200Mi
           securityContext:
             privileged: true
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL

--- a/pkg/controller/periodic/job.go
+++ b/pkg/controller/periodic/job.go
@@ -95,6 +95,7 @@ func (j *JobController) CreateGathererJob(
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(false),
+								ReadOnlyRootFilesystem:   ptr.To(true),
 								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 							},
 							VolumeMounts: volumeMounts,


### PR DESCRIPTION
https://github.com/openshift/insights-operator/pull/1101 enabled readOnlyRootFilesystem on some of the pieces of the insights-operator, this adds it to more.