### PR TITLE
OCPBUGS-52568: add permissions to gather clusterrole

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -366,6 +366,22 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - ingress.operator.openshift.io
+    resources:
+      - dnsrecords
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - network.operator.openshift.io
+    resources:
+      - operatorpkis
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR is adding missing permissions to dnsrecords and operatorpkis resources to allow the operator to gather the information without errors.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `None`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- `None`
## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->
