### PR TITLE
OCPBUGS-50663: incorrect anonymization of domains

### DIFF
--- a/pkg/anonymization/anonymizer.go
+++ b/pkg/anonymization/anonymizer.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"net/url"
 	"regexp"
 	"strings"
 	"sync"
@@ -312,13 +313,11 @@ func NewAnonymizerFromConfig(
 	if err != nil {
 		return nil, err
 	}
-	sensitiveVals[extractDomain(protoKubeConfig.Host)] = ClusterHostPlaceholder
 
 	gatherKubeClient, err := kubernetes.NewForConfig(gatherProtoKubeConfig)
 	if err != nil {
 		return nil, err
 	}
-	sensitiveVals[extractDomain(gatherProtoKubeConfig.Host)] = ClusterHostPlaceholder
 
 	configClient, err := configv1client.NewForConfig(gatherKubeConfig)
 	if err != nil {
@@ -329,7 +328,20 @@ func NewAnonymizerFromConfig(
 	if err != nil {
 		return nil, err
 	}
-	sensitiveVals[extractDomain(gatherKubeConfig.Host)] = ClusterHostPlaceholder
+
+	infrastructure, err := configClient.Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	clientHosts := []string{
+		protoKubeConfig.Host,
+		gatherProtoKubeConfig.Host,
+		gatherKubeConfig.Host,
+	}
+	if err := addAPIDomainsForAnonymization(clientHosts, infrastructure, sensitiveVals); err != nil {
+		return nil, fmt.Errorf("failed to add API domains for anonymization: %w", err)
+	}
 
 	return NewAnonymizerFromConfigClient(ctx,
 		kubeClient, gatherKubeClient, configClient, networkClient,
@@ -550,15 +562,39 @@ func getNextIP(originalIP net.IP, mask net.IPMask) (net.IP, bool) {
 	return resultIP, false
 }
 
-// extractDomain truncates protocol, host and port of the URL argument
-// and returns the base domain
-func extractDomain(url string) string {
-	baseDomain := strings.Join(strings.Split(url, ".")[1:], ".") // removes protocol and host parts
-	domain := strings.Split(baseDomain, ":")[0]                  // removes port (if any)
-
-	if domain == "" { // in case the URL is malformed
-		return url
+// addAPIDomainsForAnonymization registers API server domains for anonymization.
+// Uses infrastructure.Status.APIServerURL if available, otherwise processes all clientHosts.
+func addAPIDomainsForAnonymization(clientHosts []string, infrastructure *configv1.Infrastructure, domainMap map[string]string) error {
+	if infrastructure != nil && infrastructure.Status.APIServerURL != "" {
+		// add the API server URL to the map
+		return addParsedDomainToMap(infrastructure.Status.APIServerURL, domainMap, ClusterHostPlaceholder)
 	}
 
-	return domain
+	for _, clientHost := range clientHosts {
+		// add the client host to the map
+		if err := addParsedDomainToMap(clientHost, domainMap, ClusterHostPlaceholder); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// addParsedDomainToMap extracts hostname from address and adds it to the anonymization map.
+// If URL parsing fails or no hostname found, uses the entire address as-is.
+func addParsedDomainToMap(address string, domainMap map[string]string, placeholder string) error {
+	parsedURL, err := url.Parse(address)
+	if err != nil {
+		return err
+	}
+
+	if parsedURL == nil || parsedURL.Hostname() == "" {
+		domainMap[address] = placeholder
+		return nil
+	}
+
+	// add domain to the map
+	domainMap[parsedURL.Hostname()] = placeholder
+
+	return nil
 }

--- a/pkg/anonymization/anonymizer_test.go
+++ b/pkg/anonymization/anonymizer_test.go
@@ -473,3 +473,154 @@ func TestNewAnonymizerFromConfigClient(t *testing.T) {
 		})
 	}
 }
+
+func TestAddParsedDomainToMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		address       string
+		placeholder   string
+		expectedKey   string
+		expectedValue string
+		expectError   bool
+	}{
+		{
+			name:          "valid URL with hostname",
+			address:       "https://api.example.com:6443",
+			placeholder:   "<CLUSTER_HOST>",
+			expectedKey:   "api.example.com",
+			expectedValue: "<CLUSTER_HOST>",
+			expectError:   false,
+		},
+		{
+			name:          "hostname only",
+			address:       "api.example.com",
+			placeholder:   "<CLUSTER_HOST>",
+			expectedKey:   "api.example.com",
+			expectedValue: "<CLUSTER_HOST>",
+			expectError:   false,
+		},
+		{
+			name:          "IP address with scheme",
+			address:       "https://192.168.1.1:6443",
+			placeholder:   "<CLUSTER_HOST>",
+			expectedKey:   "192.168.1.1",
+			expectedValue: "<CLUSTER_HOST>",
+			expectError:   false,
+		},
+		{
+			name:          "invalid URL with special characters",
+			address:       "ht\ttp://invalid",
+			placeholder:   "<CLUSTER_HOST>",
+			expectedKey:   "",
+			expectedValue: "",
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			domainMap := make(map[string]string)
+			err := addParsedDomainToMap(tt.address, domainMap, tt.placeholder)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Len(t, domainMap, 1)
+			assert.Equal(t, tt.expectedValue, domainMap[tt.expectedKey])
+		})
+	}
+}
+
+func TestAddAPIDomainsForAnonymization(t *testing.T) {
+	tests := []struct {
+		name            string
+		clientHosts     []string
+		infrastructure  *configv1.Infrastructure
+		expectedDomains map[string]string
+		expectError     bool
+	}{
+		{
+			name:        "infrastructure with valid API server URL",
+			clientHosts: []string{"host1.example.com", "host2.example.com"},
+			infrastructure: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					APIServerURL: "https://api.cluster.example.com:6443",
+				},
+			},
+			expectedDomains: map[string]string{
+				"api.cluster.example.com": ClusterHostPlaceholder,
+			},
+			expectError: false,
+		},
+		{
+			name:        "infrastructure with empty API server URL - uses client hosts",
+			clientHosts: []string{"host1.example.com", "host2.example.com"},
+			infrastructure: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					APIServerURL: "",
+				},
+			},
+			expectedDomains: map[string]string{
+				"host1.example.com": ClusterHostPlaceholder,
+				"host2.example.com": ClusterHostPlaceholder,
+			},
+			expectError: false,
+		},
+		{
+			name:           "nil infrastructure - uses client hosts",
+			clientHosts:    []string{"host1.example.com", "host2.example.com"},
+			infrastructure: nil,
+			expectedDomains: map[string]string{
+				"host1.example.com": ClusterHostPlaceholder,
+				"host2.example.com": ClusterHostPlaceholder,
+			},
+			expectError: false,
+		},
+		{
+			name:            "empty client hosts with nil infrastructure",
+			clientHosts:     []string{},
+			infrastructure:  nil,
+			expectedDomains: map[string]string{},
+			expectError:     false,
+		},
+		{
+			name:           "mixed client hosts - URLs and hostnames",
+			clientHosts:    []string{"https://host1.example.com:6443", "host2.example.com", "192.168.1.1"},
+			infrastructure: nil,
+			expectedDomains: map[string]string{
+				"host1.example.com": ClusterHostPlaceholder,
+				"host2.example.com": ClusterHostPlaceholder,
+				"192.168.1.1":       ClusterHostPlaceholder,
+			},
+			expectError: false,
+		},
+		{
+			name:            "client hosts with invalid URL",
+			clientHosts:     []string{"ht\ttp://invalid"},
+			infrastructure:  nil,
+			expectedDomains: map[string]string{},
+			expectError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			domainMap := make(map[string]string)
+			err := addAPIDomainsForAnonymization(tt.clientHosts, tt.infrastructure, domainMap)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(tt.expectedDomains), len(domainMap))
+			for expectedKey, expectedValue := range tt.expectedDomains {
+				assert.Equal(t, expectedValue, domainMap[expectedKey], "Domain %s should map to %s", expectedKey, expectedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes domain anonymization in hosted clusters with OVN networks. Previously, client host addresses were used for anonymization which is not working on these kind of clusters. Now infrastructure.Status.APIServerURL is used instead, with client hosts as fallback when infrastructure URL is unavailable.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `/pkg/anonymization/anonymizer_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[OCPBUGS-50663](https://issues.redhat.com/browse/OCPBUGS-50663)