### PR TITLE
OCPBUGS-61073: Rerun missed `make update` after read-only filesystem security context added

### DIFF
--- a/manifests/06-deployment-ibm-cloud-managed.yaml
+++ b/manifests/06-deployment-ibm-cloud-managed.yaml
@@ -6,7 +6,6 @@ metadata:
     config.openshift.io/inject-proxy: insights-operator
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
-    capability.openshift.io/name: Insights
   name: insights-operator
   namespace: openshift-insights
 spec:
@@ -52,8 +51,11 @@ spec:
           capabilities:
             drop:
             - ALL
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /var/lib/insights-operator
           name: snapshots
         - mountPath: /var/run/configmaps/trusted-ca-bundle
@@ -85,6 +87,8 @@ spec:
         operator: Exists
         tolerationSeconds: 900
       volumes:
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: snapshots
       - configMap:


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
Bug: `make update` should have been run at this point

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
