### PR TITLE
CCXDEV-15399: add missing permissions for replicasets and events

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -502,9 +502,15 @@ rules:
       - apps
     resources:
       - deployments
+      - replicasets
     verbs:
       - get
-
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Add permissions to insights-operator role to read replicasets and create events in openshift-insights namespace to resolve permission errors during operator execution.

## Categories
<!-- Select the categories that your PR better fits on -->

- [x] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `None`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- None

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[CCXDEV-15399](https://issues.redhat.com/browse/CCXDEV-15399)
