### PR TITLE
OCPBUGS-61142: Revert #1122 "OCPBUGS-61073: Rerun missed `make update` after read-only filesystem security context added"

### DIFF
--- a/manifests/06-deployment-ibm-cloud-managed.yaml
+++ b/manifests/06-deployment-ibm-cloud-managed.yaml
@@ -6,6 +6,7 @@ metadata:
     config.openshift.io/inject-proxy: insights-operator
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    capability.openshift.io/name: Insights
   name: insights-operator
   namespace: openshift-insights
 spec:
@@ -51,11 +52,8 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /tmp
-          name: tmp
         - mountPath: /var/lib/insights-operator
           name: snapshots
         - mountPath: /var/run/configmaps/trusted-ca-bundle
@@ -87,8 +85,6 @@ spec:
         operator: Exists
         tolerationSeconds: 900
       volumes:
-      - emptyDir: {}
-        name: tmp
       - emptyDir: {}
         name: snapshots
       - configMap:


### PR DESCRIPTION

Reverts #1122 ; tracked by OCPBUGS-61142

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Hypershift payload failures

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-hypershift-release-4.20-periodics-e2e-aws-ovn
```

CC: @jacobsee

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
