### PR TITLE
use secure cipher suites for operator

### DIFF
--- a/config/pod.yaml
+++ b/config/pod.yaml
@@ -19,3 +19,12 @@ ocm:
   scaInterval: "8h"
   clusterTransferEndpoint: https://api.openshift.com/api/accounts_mgmt/v1/cluster_transfers/
   clusterTransferInterval: "12h"
+servingInfo:
+  cipherSuites:
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+  minTLSVersion: VersionTLS12


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

As the operator log shows it uses `Use of insecure cipher` suites such as:
```
I0907 04:29:30.795940       1 cmd.go:241] Using service-serving-cert provided certificates
I0907 04:29:30.796270       1 observer_polling.go:159] Starting file observer
W0907 04:29:30.814285       1 builder.go:267] unable to get owner reference (falling back to namespace): replicasets.apps "insights-operator-bccb45ccb" is forbidden: User "system:serviceaccount:openshift-insights:operator" cannot get resource "replicasets" in API group "apps" in the namespace "openshift-insights"
I0907 04:29:31.032609       1 operator.go:59] Starting insights-operator v0.0.0-master+$Format:%H$
I0907 04:29:31.032823       1 legacy_config.go:327] Current config: {"report":false,"storagePath":"/var/lib/insights-operator","interval":"2h","endpoint":"https://console.redhat.com/api/ingress/v1/upload","conditionalGathererEndpoint":"https://console.redhat.com/api/gathering/gathering_rules","pull_report":{"endpoint":"https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports","delay":"60s","timeout":"3000s","min_retry":"30s"},"impersonate":"system:serviceaccount:openshift-insights:gather","enableGlobalObfuscation":false,"ocm":{"scaEndpoint":"https://api.openshift.com/api/accounts_mgmt/v1/certificates","scaInterval":"8h","scaDisabled":false,"clusterTransferEndpoint":"https://api.openshift.com/api/accounts_mgmt/v1/cluster_transfers/","clusterTransferInterval":"12h"},"disableInsightsAlerts":false,"processingStatusEndpoint":"https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/status","reportEndpointTechPreview":"https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/request/%s/report"}
I0907 04:29:31.033166       1 secure_serving.go:57] Forcing use of http/1.1 only
W0907 04:29:31.033186       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' detected.
W0907 04:29:31.033191       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256' detected.
I0907 04:29:31.033197       1 simple_featuregate_reader.go:171] Starting feature-gate-detector
```

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
