### PR TITLE
OCPBUGS-52838: Update error message for missing SCA certificates

### DIFF
--- a/pkg/ocm/sca/sca.go
+++ b/pkg/ocm/sca/sca.go
@@ -203,7 +203,7 @@ func (c *Controller) processResponses(ctx context.Context, responses Response, c
 			return err
 		}
 	} else {
-		return fmt.Errorf("master node architecture not found, default secret is not created nor updated")
+		return fmt.Errorf("certificates for node architecture not found, default secret is not created nor updated")
 	}
 
 	// Create architecture specific secrets with sca certificates


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a better error message for missing SCA certificates in processing.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

None

## Documentation
<!-- Are these changes reflected in documentation? -->

None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

None

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-52838
