### PR TITLE
OCPBUGS-61771: Use correct feature gate for InsightsDataGather

### DIFF
--- a/pkg/cmd/start/start.go
+++ b/pkg/cmd/start/start.go
@@ -237,7 +237,7 @@ func checkFeatureGates(ctx context.Context, clientConfig *rest.Config, operator 
 		klog.Exit(err)
 	}
 
-	operator.InsightsConfigAPIEnabled = featureGates.Enabled(features.FeatureGateInsightsConfigAPI)
+	operator.InsightsConfigEnabled = featureGates.Enabled(features.FeatureGateInsightsConfig)
 }
 
 func createClientConfig(

--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -45,7 +45,7 @@ const (
 // GatherJob is the type responsible for controlling a non-periodic Gather execution
 type GatherJob struct {
 	config.Controller
-	InsightsConfigAPIEnabled bool
+	InsightsConfigEnabled bool
 }
 
 // processingStatusClient is an interface to call the "processingStatusEndpoint" in


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Use InsightsConfig instead of InsightsConfigAPI to match the actual feature gate that controls the InsightsDataGather resource.


## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `None`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- `None`

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

- `None`

