### PR TITLE
OCPBUGS-61893: set extractor as default container

### DIFF
--- a/manifests/10-insights-runtime-extractor.yaml
+++ b/manifests/10-insights-runtime-extractor.yaml
@@ -27,6 +27,7 @@ spec:
       annotations:
         openshift.io/required-scc: insights-runtime-extractor-scc
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        kubectl.kubernetes.io/default-container: extractor
     spec:
       serviceAccountName: insights-runtime-extractor-sa
       hostPID: true


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

As we use `kubectl logs -n openshift-insights insights-runtime-extractor-xxxx`, we see the default container logs is kube-rbac-proxy, like :
```
Defaulted container "kube-rbac-proxy" out of: kube-rbac-proxy, exporter, extractor
W0915 08:00:16.108839  options.go:149] 
==== Removed Flag Warning ======================

logtostderr is removed in the k8s upstream and has no effect any more.

===============================================

I0915 08:00:16.109835  kube-rbac-proxy.go:530] Reading config file: /etc/kube-rbac-proxy/config-file.yaml
I0915 08:00:16.109835  kube-rbac-proxy.go:233] Valid token audiences: 
```

But most of the time we just care about the container `extractor` or `exporter` logs , not the `kube-rbac-proxy`

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
