### PR TITLE
[release-4.16] OCPBUGS-61108: avoid possible Go panic when searching existing conditions

### DIFF
--- a/pkg/controller/status/datagather_status.go
+++ b/pkg/controller/status/datagather_status.go
@@ -84,8 +84,10 @@ func GetConditionByType(dataGather *insightsv1alpha1.DataGather, conType string)
 	return c
 }
 
+// getConditionIndexByType tries to find an index of the condition with the provided type.
+// If no match is found, it returns -1.
 func getConditionIndexByType(conType string, conditions []metav1.Condition) int {
-	var idx int
+	idx := -1
 	for i := range conditions {
 		con := conditions[i]
 		if con.Type == conType {
@@ -103,7 +105,11 @@ func UpdateDataGatherConditions(ctx context.Context,
 	newConditions := make([]metav1.Condition, len(dataGather.Status.Conditions))
 	_ = copy(newConditions, dataGather.Status.Conditions)
 	idx := getConditionIndexByType(condition.Type, newConditions)
-	newConditions[idx] = *condition
+	if idx != -1 {
+		newConditions[idx] = *condition
+	} else {
+		newConditions = append(newConditions, *condition)
+	}
 	dataGather.Status.Conditions = newConditions
 	return insightsClient.DataGathers().UpdateStatus(ctx, dataGather, metav1.UpdateOptions{})
 }

--- a/pkg/controller/status/datagather_status_test.go
+++ b/pkg/controller/status/datagather_status_test.go
@@ -73,6 +73,21 @@ func TestUpdateDataGatherConditions(t *testing.T) {
 			expectedDataProcessed: DataProcessedCondition(metav1.ConditionUnknown, "test", ""),
 			expectedDataUploaded:  DataUploadedCondition(metav1.ConditionUnknown, "test", ""),
 		},
+		{
+			name: "Updating non-existing condition appends the condition",
+			dataGather: &v1alpha1.DataGather{
+				Status: v1alpha1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						DataProcessedCondition(metav1.ConditionUnknown, "test", ""),
+						DataRecordedCondition(metav1.ConditionUnknown, "test", ""),
+						DataUploadedCondition(metav1.ConditionUnknown, "test", ""),
+					},
+				},
+			},
+			expectedDataRecorded:  DataRecordedCondition(metav1.ConditionUnknown, "test", ""),
+			expectedDataProcessed: DataProcessedCondition(metav1.ConditionUnknown, "test", ""),
+			expectedDataUploaded:  DataUploadedCondition(metav1.ConditionUnknown, "test", ""),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/insights-operator/pull/1046