### PR TITLE
TRT-2313:Revert update DataGather condition when gathering job fails

### DIFF
--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -160,7 +160,7 @@ func (g *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 	defer cancel()
 	dataGatherCR, err := insightsV1alpha2Cli.DataGathers().Get(ctx, os.Getenv("DATAGATHER_NAME"), metav1.GetOptions{})
 	if err != nil {
-		klog.Errorf("failed to get corresponding DataGather custom resource: %v", err)
+		klog.Errorf("failed to get coresponding DataGather custom resource: %v", err)
 		return err
 	}
 
@@ -204,9 +204,9 @@ func (g *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 		configAggregator, insightsHTTPCli)
 	uploader := insightsuploader.New(nil, insightsHTTPCli, configAggregator, nil, nil, 0)
 
-	dataGatherCR, err = status.UpdateProgressingCondition(ctx, insightsV1alpha2Cli, dataGatherCR, dataGatherCR.Name, status.GatheringReason)
+	dataGatherCR, err = status.UpdateProgressingCondition(ctx, insightsV1alpha2Cli, dataGatherCR, status.GatheringReason)
 	if err != nil {
-		klog.Errorf("failed to update corresponding DataGather custom resource: %v", err)
+		klog.Errorf("failed to update coresponding DataGather custom resource: %v", err)
 		return err
 	}
 
@@ -361,7 +361,7 @@ func gatherAndReportFunctions(
 func updateDataGatherStatus(ctx context.Context, insightsClient insightsv1alpha2client.InsightsV1alpha2Interface,
 	dataGatherCR *insightsv1alpha2.DataGather, conditionToUpdate *metav1.Condition, gatheringStatus string,
 ) {
-	dataGatherUpdated, err := status.UpdateProgressingCondition(ctx, insightsClient, dataGatherCR, dataGatherCR.Name, gatheringStatus)
+	dataGatherUpdated, err := status.UpdateProgressingCondition(ctx, insightsClient, dataGatherCR, gatheringStatus)
 	if err != nil {
 		klog.Errorf("Failed to update DataGather resource %s state: %v", dataGatherCR.Name, err)
 	}

--- a/pkg/controller/periodic/job.go
+++ b/pkg/controller/periodic/job.go
@@ -2,7 +2,6 @@ package periodic
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -19,8 +18,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 )
-
-var ErrJobFailed = errors.New("job failed")
 
 // JobController type responsible for
 // creating a new gathering jobs
@@ -136,7 +133,7 @@ func (j *JobController) WaitForJobCompletion(ctx context.Context, job *batchv1.J
 			}
 
 			if event.Type == apiWatch.Deleted {
-				return fmt.Errorf("job '%s' deleted: %w", job.Name, ErrJobFailed)
+				return nil
 			}
 
 			if event.Type != apiWatch.Modified {
@@ -151,7 +148,7 @@ func (j *JobController) WaitForJobCompletion(ctx context.Context, job *batchv1.J
 				return nil
 			}
 			if job.Status.Failed > 0 {
-				return fmt.Errorf("checking status for job '%s': %w", job.Name, ErrJobFailed)
+				return fmt.Errorf("job %s failed", job.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Reverts openshift/insights-operator#1131

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Payload failures beginning with [4.21.0-0.nightly-2025-09-22-183616](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.21.0-0.nightly/release/4.21.0-0.nightly-2025-09-22-183616) with [failures](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-upgrade-from-stable-4.20-e2e-gcp-ovn-rt-upgrade/1970196763985842176) like:
```
Sep 22 21:24:08.217 E clusteroperator/insights condition/Available reason/UploadFailed status/False Unable to report: gateway server reported unexpected error code: 500 (request=): <html>
\n<head><title>500 Internal Server Error</title></head>
\n<body>
\n<center><h1>500 Internal Server Error</h1></center>
\n<hr><center>openresty</center>
\n</body>
\n</html>
```

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.21-e2e-aws-ovn-upgrade-fips
```

CC: @opokornyy 