### PR TITLE
fix: operator is not set as degraded when failed

### DIFF
--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -408,7 +408,6 @@ func (c *Controller) runJobAndCheckResults(ctx context.Context, dataGather *insi
 	err = c.jobController.WaitForJobCompletion(ctx, gj)
 	if err != nil {
 		c.handleJobErrors(ctx, dataGather, gj, err)
-		return
 	}
 
 	klog.Infof("Job completed %s", gj.Name)

--- a/pkg/controller/status/datagather_status.go
+++ b/pkg/controller/status/datagather_status.go
@@ -145,10 +145,10 @@ func UpdateProgressingCondition(ctx context.Context,
 	}
 
 	switch gatheringState {
-	case GatheringSucceededReason:
-		dataGatherCR.Status.FinishTime = ptr.To(metav1.Now())
-	case GatheringFailedReason:
-		dataGatherCR.Status.FinishTime = ptr.To(metav1.Now())
+	case GatheringSucceededReason, GatheringFailedReason:
+		if dataGatherCR.Status.FinishTime == nil {
+			dataGatherCR.Status.FinishTime = ptr.To(metav1.Now())
+		}
 	case GatheringReason:
 		if dataGatherCR.Status.StartTime == nil {
 			dataGatherCR.Status.StartTime = ptr.To(metav1.Now())


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

The insights operator status needs to be set as Degraded when the gathering fails to upload the archive.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `None`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[OCPBUGS-62215](https://issues.redhat.com/browse/OCPBUGS-62215)