### PR TITLE
set imagePullPolicy to default

### DIFF
--- a/manifests/10-insights-runtime-extractor.yaml
+++ b/manifests/10-insights-runtime-extractor.yaml
@@ -68,7 +68,6 @@ spec:
               memory: 100Mi
         - name: exporter
           image: quay.io/openshift/origin-insights-runtime-exporter:latest
-          imagePullPolicy: Always
           volumeMounts:
             - mountPath: /data
               name: data-volume
@@ -85,7 +84,6 @@ spec:
               memory: 200Mi
         - name: extractor
           image: quay.io/openshift/origin-insights-runtime-extractor:latest
-          imagePullPolicy: Always
           env:
             - name: CONTAINER_RUNTIME_ENDPOINT
               value: unix:///crio.sock


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

The `exporter` and `exporter` has no need to use the `imagePullPolicy: Always` for the containers, as the ocp will replace the `image: quay.io/openshift/origin-insights-runtime-exporter:latest` to sha256 digest when create ocp release, the `latest` tag  will not pull the latest image in the ocp version:
```
      - name: exporter
          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:3c414a2ccdc88d28f86d817df50747b324987666c043a090e84ab436a3750cab
          imagePullPolicy: Always
          volumeMounts:
            - mountPath: /data
              name: data-volume
          securityContext:
            privileged: false
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            capabilities:
              drop:
                - ALL
          resources: 
            requests:
              cpu: 10m
              memory: 200Mi
        - name: extractor
          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:01754384e79d97a9ef018c06032ffb80493de22e76f6c591e720d46d4e8f97a2
          imagePullPolicy: Always
```

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???
