### PR TITLE
OCPBUGS-60043: lastReportTime field of clusteroperator.insights should be updated accordingly

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -229,6 +229,12 @@ rules:
       - list
       - watch
   - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusteroperators/status
+    verbs:
+      - update
+  - apiGroups:
       - policy
     resources:
       - poddisruptionbudgets

--- a/pkg/insights/insightsuploader/insightsuploader.go
+++ b/pkg/insights/insightsuploader/insightsuploader.go
@@ -230,9 +230,8 @@ func (c *Controller) Upload(ctx context.Context, s *insightsclient.Source, confi
 
 	klog.Infof("Uploaded report successfully in %s", time.Since(start))
 
-	err = updateClusterOperatorLastReportTime(ctx, configClient)
-	if err != nil {
-		klog.Errorf("Failed to update LastReportTime: %v", err)
+	if err := updateClusterOperatorLastReportTime(ctx, configClient); err != nil {
+		klog.Errorf("Failed to update ClusterOperator lastReportTime: %v", err)
 	}
 
 	return requestID, statusCode, nil

--- a/pkg/insights/insightsuploader/insightsuploader.go
+++ b/pkg/insights/insightsuploader/insightsuploader.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,10 +13,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	"github.com/openshift/insights-operator/pkg/authorizer"
 	"github.com/openshift/insights-operator/pkg/config/configobserver"
+	"github.com/openshift/insights-operator/pkg/controller/status"
 	"github.com/openshift/insights-operator/pkg/controllerstatus"
 	"github.com/openshift/insights-operator/pkg/insights/insightsclient"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Authorizer interface {
@@ -201,7 +205,7 @@ func (c *Controller) ArchiveUploaded() <-chan struct{} {
 
 // Upload is an alternative simple upload method used only in TechPreview clusters.
 // Returns Insights request ID and error=nil in case of successful data upload.
-func (c *Controller) Upload(ctx context.Context, s *insightsclient.Source) (string, int, error) {
+func (c *Controller) Upload(ctx context.Context, s *insightsclient.Source, configClient configv1.ConfigV1Interface) (string, int, error) {
 	defer s.Contents.Close()
 	start := time.Now()
 	s.ID = start.Format(time.RFC3339)
@@ -223,7 +227,12 @@ func (c *Controller) Upload(ctx context.Context, s *insightsclient.Source) (stri
 	if err != nil {
 		return "", statusCode, err
 	}
+
 	klog.Infof("Uploaded report successfully in %s", time.Since(start))
+
+	// Update LastReportTime after successful upload
+	updateClusterOperatorLastReportTime(ctx, configClient)
+
 	return requestID, statusCode, nil
 }
 
@@ -243,5 +252,32 @@ func reportToLogs(source io.Reader) error {
 		}
 		klog.Infof("Dry-run: %s %7d %s", hdr.ModTime.Format(time.RFC3339), hdr.Size, hdr.Name)
 	}
+	return nil
+}
+
+// Update the ClusterOperator's lastReportTime extension field
+func updateClusterOperatorLastReportTime(ctx context.Context, client configv1.ConfigV1Interface) error {
+	insightsCo, err := client.ClusterOperators().Get(ctx, "insights", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	reported := status.Reported{
+		LastReportTime: metav1.Time{Time: time.Now().UTC()},
+	}
+
+	data, err := json.Marshal(reported)
+	if err != nil {
+		return fmt.Errorf("unable to marshal status extension: %v", err)
+	}
+	insightsCo.Status.Extension.Raw = data
+
+	_, err = client.ClusterOperators().UpdateStatus(ctx, insightsCo, metav1.UpdateOptions{})
+
+	if err != nil {
+		klog.Errorf("Failed to update LastReportTime: %v", err)
+	}
+
+	klog.Infof("Successfully updated LastReportTime to %s", reported.LastReportTime)
 	return nil
 }

--- a/pkg/insights/insightsuploader/insightsuploader_test.go
+++ b/pkg/insights/insightsuploader/insightsuploader_test.go
@@ -1,0 +1,160 @@
+package insightsuploader
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/openshift/insights-operator/pkg/controller/status"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Test_updateClusterOperatorLastReportTime(t *testing.T) {
+	tests := []struct {
+		name            string
+		clusterOperator *configv1.ClusterOperator
+		expErr          bool
+		expTimeSet      bool
+		expErrContains  string
+	}{
+		{
+			name: "Successfully updates lastReportTime on existing ClusterOperator",
+			clusterOperator: &configv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "insights",
+				},
+				Status: configv1.ClusterOperatorStatus{
+					Extension: runtime.RawExtension{
+						Raw: []byte(`{}`),
+					},
+				},
+			},
+			expErr:     false,
+			expTimeSet: true,
+		},
+		{
+			name: "Updates lastReportTime when extension has existing data",
+			clusterOperator: &configv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "insights",
+				},
+				Status: configv1.ClusterOperatorStatus{
+					Extension: runtime.RawExtension{
+						Raw: []byte(`{"lastReportTime":"2024-01-01T00:00:00Z"}`),
+					},
+				},
+			},
+			expErr:     false,
+			expTimeSet: true,
+		},
+		{
+			name:            "Returns error when ClusterOperator doesn't exist",
+			clusterOperator: nil,
+			expErr:          true,
+			expTimeSet:      false,
+			expErrContains:  "not found",
+		},
+		{
+			name: "Handles invalid JSON in extension by overwriting",
+			clusterOperator: &configv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "insights",
+				},
+				Status: configv1.ClusterOperatorStatus{
+					Extension: runtime.RawExtension{
+						Raw: []byte(`{invalid json}`),
+					},
+				},
+			},
+			expErr:     false,
+			expTimeSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var operators []runtime.Object
+			if tt.clusterOperator != nil {
+				operators = append(operators, tt.clusterOperator)
+			}
+			fakeClient := configfake.NewSimpleClientset(operators...)
+
+			timeBefore := time.Now().UTC().Truncate(time.Second)
+
+			ctx := context.Background()
+			err := updateClusterOperatorLastReportTime(ctx, fakeClient.ConfigV1())
+
+			timeAfter := time.Now().UTC().Truncate(time.Second).Add(time.Second)
+
+			if tt.expErr {
+				assert.Error(t, err)
+				if tt.expErrContains != "" {
+					assert.Contains(t, err.Error(), tt.expErrContains)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if tt.expTimeSet {
+				reportTime := getLastReportTime(t, ctx, fakeClient).UTC()
+
+				assert.True(t, !reportTime.Before(timeBefore),
+					"LastReportTime (%v) should be at or after timeBefore (%v)", reportTime, timeBefore)
+				assert.True(t, !reportTime.After(timeAfter),
+					"LastReportTime (%v) should be at or before timeAfter (%v)", reportTime, timeAfter)
+			}
+		})
+	}
+}
+
+func Test_updateClusterOperatorLastReportTime_TimestampProgression(t *testing.T) {
+	clusterOperator := createBasicClusterOperator()
+
+	fakeClient := configfake.NewSimpleClientset(clusterOperator)
+	ctx := context.Background()
+
+	err := updateClusterOperatorLastReportTime(ctx, fakeClient.ConfigV1())
+	assert.NoError(t, err)
+
+	firstTime := getLastReportTime(t, ctx, fakeClient)
+
+	time.Sleep(10 * time.Millisecond)
+
+	err = updateClusterOperatorLastReportTime(ctx, fakeClient.ConfigV1())
+	assert.NoError(t, err)
+
+	secondTime := getLastReportTime(t, ctx, fakeClient)
+
+	assert.True(t, !secondTime.Before(firstTime),
+		"Second timestamp (%v) should be at or after first timestamp (%v)", secondTime, firstTime)
+}
+
+// Create a basic ClusterOperator for testing
+func createBasicClusterOperator() *configv1.ClusterOperator {
+	return &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "insights",
+		},
+		Status: configv1.ClusterOperatorStatus{},
+	}
+}
+
+// Retrieve and unmarshal the LastReportTime
+func getLastReportTime(t *testing.T, ctx context.Context, client *configfake.Clientset) time.Time {
+	updatedCo, err := client.ConfigV1().ClusterOperators().Get(ctx, "insights", metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, updatedCo.Status.Extension.Raw)
+
+	var reported status.Reported
+	err = json.Unmarshal(updatedCo.Status.Extension.Raw, &reported)
+	assert.NoError(t, err)
+	assert.False(t, reported.LastReportTime.IsZero())
+
+	return reported.LastReportTime.Time
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a fix, so that lastReportTime field of clusteroperator.insights should be updated accordingly.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

None

## Documentation
<!-- Are these changes reflected in documentation? -->

None

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/insights/insightsuploader/insightsuploader_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/OCPBUGS-60043
