### PR TITLE
CCXDEV-15591: on demand gathering job limit

### DIFF
--- a/pkg/controller/periodic/datagather_informer.go
+++ b/pkg/controller/periodic/datagather_informer.go
@@ -2,9 +2,13 @@ package periodic
 
 import (
 	"context"
+	"slices"
 	"strings"
 
+	insightsv1 "github.com/openshift/api/insights/v1"
 	insightsInformers "github.com/openshift/client-go/insights/informers/externalversions"
+	insightsListers "github.com/openshift/client-go/insights/listers/insights/v1"
+	"github.com/openshift/insights-operator/pkg/controller/status"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -17,24 +21,39 @@ const (
 )
 
 // DataGatherInformer is an interface providing information
-// about newly create DataGather resources
+// about newly created DataGather resources
 type DataGatherInformer interface {
+	// Controller provides the base controller functionality from library-go
 	factory.Controller
+	// DataGatherCreated returns a receive-only channel that sends the name of newly created
+	// DataGather resources based on which the on-demand gathering is triggered
 	DataGatherCreated() <-chan string
+	// Lister returns a DataGatherLister that provides cached access to all DataGather resources
+	// without making API requests to the Kubernetes API server
+	Lister() insightsListers.DataGatherLister
+	// DataGatherStatusChanged returns a receive-only channel that signals when a DataGather
+	// resource's status changes to a finished state (GatheringFailed or GatheringSucceeded).
+	// This is used to check if data gathering has completed and trigger reconciliation of pending gatherings.
+	DataGatherStatusChanged() <-chan struct{}
 }
 
 // dataGatherController is type implementing DataGatherInformer
 type dataGatherController struct {
 	factory.Controller
-	ch chan string
+	ch            chan string
+	lister        insightsListers.DataGatherLister
+	statusChanged chan struct{}
 }
 
 // NewDataGatherInformer creates a new instance of the DataGatherInformer interface
 func NewDataGatherInformer(eventRecorder events.Recorder, insightsInf insightsInformers.SharedInformerFactory) (DataGatherInformer, error) {
 	inf := insightsInf.Insights().V1().DataGathers().Informer()
+	lister := insightsInf.Insights().V1().DataGathers().Lister()
 
 	dgCtrl := &dataGatherController{
-		ch: make(chan string),
+		ch:            make(chan string),
+		statusChanged: make(chan struct{}, 10), // buffered
+		lister:        lister,
 	}
 	_, err := inf.AddEventHandler(dgCtrl.eventHandler())
 	if err != nil {
@@ -70,6 +89,50 @@ func (d *dataGatherController) eventHandler() cache.ResourceEventHandler {
 			}
 			d.ch <- dgMetadata.GetName()
 		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldDG, ok := oldObj.(*insightsv1.DataGather)
+			if !ok {
+				klog.Errorf("Expected DataGather, got %T", oldObj)
+				return
+			}
+
+			newDG, ok := newObj.(*insightsv1.DataGather)
+			if !ok {
+				klog.Errorf("Expected DataGather, got %T", newObj)
+				return
+			}
+
+			// filter out dataGathers created for periodic gathering
+			if strings.HasPrefix(newDG.GetName(), periodicGatheringPrefix) {
+				return
+			}
+
+			newCondition := status.GetConditionByType(newDG, status.Progressing)
+			finishedReasons := []string{status.GatheringFailedReason, status.GatheringSucceededReason}
+			// Continue only if the new condition is one of the finished conditions
+			if newCondition == nil || !slices.Contains(finishedReasons, newCondition.Reason) {
+				return
+			}
+
+			oldCondition := status.GetConditionByType(oldDG, status.Progressing)
+			if oldCondition == nil {
+				return
+			}
+
+			// Send signal only if the old condition is not equal to the new condition, which means
+			// the state changed from running to some of the finished conditions.
+			if oldCondition.Status != newCondition.Status ||
+				oldCondition.Reason != newCondition.Reason ||
+				!oldCondition.LastTransitionTime.Equal(&newCondition.LastTransitionTime) {
+				klog.Infof("DataGather %s status changed, signaling reconciliation", newDG.Name)
+
+				select {
+				case d.statusChanged <- struct{}{}:
+				default:
+					// Channel full, signal already pending
+				}
+			}
+		},
 	}
 }
 
@@ -77,4 +140,16 @@ func (d *dataGatherController) eventHandler() cache.ResourceEventHandler {
 // newly created DataGather resource
 func (d *dataGatherController) DataGatherCreated() <-chan string {
 	return d.ch
+}
+
+// Lister returns a DataGatherLister that can be used to query
+// the informer's cache without making API requests
+func (d *dataGatherController) Lister() insightsListers.DataGatherLister {
+	return d.lister
+}
+
+// DataGatherStatusChanged returns a channel providing the name of
+// updated DataGather resource
+func (d *dataGatherController) DataGatherStatusChanged() <-chan struct{} {
+	return d.statusChanged
 }

--- a/pkg/controller/periodic/datagather_informer_test.go
+++ b/pkg/controller/periodic/datagather_informer_test.go
@@ -1,0 +1,308 @@
+package periodic
+
+import (
+	"testing"
+
+	insightsv1 "github.com/openshift/api/insights/v1"
+	"github.com/openshift/insights-operator/pkg/controller/status"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_eventHandler_addFunc(t *testing.T) {
+	tests := []struct {
+		name             string
+		dataGather       insightsv1.DataGather
+		expectChannelMsg bool
+		expectedName     string
+	}{
+		{
+			name: "non-periodic DataGather triggers channel message",
+			dataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "on-demand-gather",
+				},
+			},
+			expectChannelMsg: true,
+			expectedName:     "on-demand-gather",
+		},
+		{
+			name: "periodic DataGather is filtered out",
+			dataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "periodic-gathering-12345",
+				},
+			},
+			expectChannelMsg: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataGatherController := &dataGatherController{
+				ch:            make(chan string, 1),
+				statusChanged: make(chan struct{}),
+			}
+			handler := dataGatherController.eventHandler()
+
+			// Act
+			handler.OnAdd(&tt.dataGather, false)
+
+			// Assert
+			if tt.expectChannelMsg {
+				select {
+				case msg := <-dataGatherController.ch:
+					assert.Equal(t, tt.expectedName, msg,
+						"expected channel message %q, got %q", tt.expectedName, msg,
+					)
+				default:
+					assert.Fail(t, "expected channel message but got none")
+				}
+			} else {
+				select {
+				case msg := <-dataGatherController.ch:
+					assert.Fail(t, "expected no channel message but got %q", msg)
+				default:
+					// Expected: no message
+				}
+			}
+		})
+	}
+}
+
+func Test_eventHandler_updateFunc(t *testing.T) {
+	tests := []struct {
+		name               string
+		oldDataGather      insightsv1.DataGather
+		newDataGather      insightsv1.DataGather
+		expectStatusSignal bool
+	}{
+		{
+			name: "status changed from running to succeeded triggers signal",
+			oldDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionTrue,
+							Reason:             status.GatheringReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			newDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionFalse,
+							Reason:             status.GatheringSucceededReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectStatusSignal: true,
+		},
+		{
+			name: "status changed from running to failed triggers signal",
+			oldDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionTrue,
+							Reason:             status.GatheringReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			newDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionFalse,
+							Reason:             status.GatheringFailedReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectStatusSignal: true,
+		},
+		{
+			name: "periodic DataGather update is filtered out",
+			oldDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "periodic-gathering-12345",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionTrue,
+							Reason:             status.GatheringReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			newDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "periodic-gathering-12345",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionFalse,
+							Reason:             status.GatheringSucceededReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectStatusSignal: false,
+		},
+		{
+			name: "no status change does not trigger signal",
+			oldDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionTrue,
+							Reason:             status.GatheringReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			newDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionTrue,
+							Reason:             status.GatheringReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectStatusSignal: false,
+		},
+		{
+			name: "update to non-finished does not trigger signal",
+			oldDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionFalse,
+							Reason:             status.DataGatheringPendingReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			newDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionTrue,
+							Reason:             status.GatheringReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectStatusSignal: false,
+		},
+		{
+			name: "old DataGather without condition does not trigger signal",
+			oldDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{},
+				},
+			},
+			newDataGather: insightsv1.DataGather{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gather",
+				},
+				Status: insightsv1.DataGatherStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               status.Progressing,
+							Status:             metav1.ConditionFalse,
+							Reason:             status.GatheringSucceededReason,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				},
+			},
+			expectStatusSignal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataGatherController := &dataGatherController{
+				ch:            make(chan string),
+				statusChanged: make(chan struct{}, 10),
+			}
+			handler := dataGatherController.eventHandler()
+
+			// Act
+			handler.OnUpdate(&tt.oldDataGather, &tt.newDataGather)
+
+			// Assert
+			if tt.expectStatusSignal {
+				select {
+				case <-dataGatherController.statusChanged:
+					// Expected: signal received
+				default:
+					assert.Fail(t, "expected status change signal but got none")
+				}
+			} else {
+				select {
+				case <-dataGatherController.statusChanged:
+					assert.Fail(t, "expected no status change signal but got one")
+				default:
+					// Expected: no signal
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR adds an informer that watches updates to the DataGather CR and introduces functionality to limit the number of running on-demand gathering jobs.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/periodic/periodic_test.go`
- `pkg/controller/periodic/datagather_informer_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- `None`

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[CCXDEV-15591](https://issues.redhat.com/browse/CCXDEV-15591)