### PR TITLE
OCPBUGS-87821: Optimize the CPU usage of insights-runtime-extractor

### DIFF
--- a/docs/prd/prd-0001-container-ids-filtering.md
+++ b/docs/prd/prd-0001-container-ids-filtering.md
@@ -1,0 +1,554 @@
+# PRD-0001: Container IDs Filtering for Runtime Extraction
+
+**Status**: Draft  
+**Author**: Jeff Mesnil  
+**Created**: 2026-02-02  
+**Jira**: [CCXDEV-15960](https://issues.redhat.com/browse/CCXDEV-15960)  
+**Related**: [insights-runtime-extractor prd-0001](https://github.com/jmesnil/insights-runtime-extractor/blob/e18320a7988c5a0d7238af8b7ad2d8878f3ec725/docs/prd/prd-0001-container-ids-filtering.md)
+
+## Summary
+
+This PRD describes changes to the insights-operator to improve the performance of runtime information gathering by leveraging the new container ID filtering capability in insights-runtime-extractor. Instead of scanning all running containers on each node, the insights-operator will provide specific container IDs to the extractor, reducing resource consumption and response times.
+
+**Deployment Order**: The insights-runtime-extractor will be updated with POST endpoint support **before** any changes are made to the insights-operator. This guarantees the new endpoint is available when the operator starts using it, eliminating the need for fallback mechanisms.
+
+## Background
+
+### Current Architecture
+
+The workloads gatherer (`pkg/gatherers/workloads/`) runs on a 12-hour interval and collects runtime information from all nodes in the cluster:
+
+1. **Pod Discovery**: Lists all pods in the cluster via Kubernetes API (up to 8000 pods)
+2. **Runtime Extraction**: For each node running `insights-runtime-extractor`, makes an HTTPS GET request to `https://{pod-ip}:8443/gather_runtime_info`
+3. **Data Processing**: Merges runtime info with pod shape fingerprints
+4. **Archive Creation**: Generates `config/workload_info.json` with anonymized data
+
+### Current Flow
+
+```
+insights-operator                    insights-runtime-extractor
+      |                                        |
+      |  GET /gather_runtime_info              |
+      |--------------------------------------->|
+      |                                        |
+      |                                        | (scans ALL containers on node) 
+      |                                        |
+      |  JSON response with all runtime info   |
+      |<---------------------------------------|
+```
+
+### Problem Statement
+
+The current implementation has performance inefficiencies:
+
+1. **Redundant Scanning**: The insights-runtime-extractor scans ALL running containers on a node, even though the insights-operator may only need runtime info for a subset of pods
+1. **Increased CPU load**: Scanning all containers increases the CPU loads on worker nodes and can affect their performance on high-density cluster nodes
+1. **Increased Latency**: Scanning all containers increases response time, especially on nodes with many running containers
+1. **Timeout Risk**: The 2-minute timeout per node may be exceeded on nodes with high container density
+
+## Proposal
+
+### Solution Overview
+
+Leverage the new POST endpoint in insights-runtime-extractor that accepts a list of container IDs to scan. The insights-operator will:
+
+1. Determine which container IDs are needed based on the pods it's processing
+2. Send only those container IDs to the insights-runtime-extractor via POST request
+3. Receive runtime info only for the requested containers
+
+### New Flow
+
+```
+insights-operator                    insights-runtime-extractor
+      |                                        |
+      |  POST /gather_runtime_info             |
+      |  Body: {"containerIds": ["id1","id2"]} |
+      |--------------------------------------->|
+      |                                        |
+      |                                        |  (scans ONLY specified containers)
+      |                                        |
+      |  JSON response with filtered info      |
+      |<---------------------------------------|
+```
+
+## Implementation Details
+
+### Execution Order Requirement
+
+The insights-runtime-extractor must be called **after** all `workloadContainerShape` structures have been collected (or when `limitReached` is true). This ensures:
+
+1. Only containers that will be included in the final output are scanned
+2. No wasted scanning of containers that exceed the pod limit (8000)
+3. Container IDs are extracted from the actual shapes being reported
+
+**Current flow** (inefficient):
+```
+1. Start gathering runtime info (all containers)
+2. List pods and build shapes
+3. Merge runtime info into shapes
+```
+
+**New flow** (optimized):
+```
+1. List pods, build shapes, and collect container IDs
+2. Call insights-runtime-extractor with collected container IDs
+3. Merge runtime info into shapes
+```
+
+### New Data Structure
+
+To avoid keeping all pod objects in memory while still tracking the information needed for runtime extraction, introduce a lightweight structure that accumulates container IDs by node as pods are processed:
+
+```go
+// containerIDsByNode maps node name to list of container IDs running on that node
+type containerIDsByNode map[string][]string
+
+// addPodContainers adds container IDs from a pod to the tracking structure
+// Called during pod processing, before the pod object is discarded
+// Only adds containers that are not terminated (running or waiting)
+func (c containerIDsByNode) addPodContainers(pod *corev1.Pod) {
+    if pod.Status.Phase != corev1.PodRunning {
+        return
+    }
+    nodeName := pod.Spec.NodeName
+    for _, containerStatus := range pod.Status.ContainerStatuses {
+        // Skip terminated containers - they no longer have a running process to scan
+        if containerStatus.State.Terminated != nil {
+            continue
+        }
+        if containerStatus.ContainerID != "" {
+            c[nodeName] = append(c[nodeName], containerStatus.ContainerID)
+        }
+    }
+}
+```
+
+This structure:
+- Uses minimal memory (only node names and container ID strings)
+- Is populated incrementally as pods are processed
+- Does not require keeping full `corev1.Pod` objects in memory
+- Can be passed to `gatherWorkloadRuntimeInfos` after shape collection is complete
+
+### Changes to `pkg/gatherers/workloads/gather_workloads_runtime_infos.go`
+
+#### Modify HTTP Request to Use POST
+
+Change from GET to POST request with container IDs in the request body:
+
+```go
+type gatherRuntimeInfoRequest struct {
+    ContainerIDs []string `json:"containerIds"`
+}
+
+func getNodeWorkloadRuntimeInfos(
+	ctx context.Context,
+	url string,
+	token string,
+	httpCli *http.Client,
+    containerIDs []string
+) workloadRuntimesResult {
+     ...
+
+    reqBody := gatherRuntimeInfoRequest{
+        ContainerIDs: containerIDs,
+    }
+    body, err := json.Marshal(reqBody)
+    if err != nil {
+        return nil, fmt.Errorf("failed to marshal request: %w", err)
+    }
+    request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return workloadRuntimesResult{
+			Error: err,
+		}
+    req.Header.Set("Content-Type", "application/json")
+    req.Header.Set("Authorization", "Bearer "+token)
+
+    resp, err := client.Do(req)
+    // ... handle response
+}
+```
+
+#### Update `gatherWorkloadRuntimeInfos` Function
+
+Modify the main gathering function to:
+1. Accept container IDs grouped by node (extracted from collected shapes)
+2. Only be called after shape collection is complete
+3. Pass container IDs to each node request
+
+```go
+func gatherWorkloadRuntimeInfos(
+    ctx context.Context,
+    coreClient corev1client.CoreV1Interface,
+    containersByNode containerIDsByNode,
+) (workloadRuntimes, []error) {
+
+    ...
+
+  	for i := range runtimePodIPs {
+		go func(podInfo podWithNodeName) {
+			defer wg.Done()
+
+            containerIDs := containersByNode[podInfo.nodeName]
+            // Skip nodes with no containers to scan
+            if len(containerIDs) == 0 {
+                return
+            }
+
+			klog.Infof("Gathering workload runtime info for node %s...\n", podInfo.nodeName)
+			hostPort := net.JoinHostPort(podInfo.podIP, "8443")
+			extractorURL := fmt.Sprintf("https://%s/gather_runtime_info", hostPort)
+			httpCli, err := createHTTPClient()
+			if err != nil {
+				klog.Errorf("Failed to initialize the HTTP client: %v", err)
+				return
+			}
+			tokenData, err := readToken()
+			if err != nil {
+				klog.Errorf("Failed to read the serviceaccount token: %v", err)
+				return
+			}
+			nodeWorkloadCh <- getNodeWorkloadRuntimeInfos(ctx, extractorURL, string(tokenData), httpCli, containerIDs)
+		}(runtimePodIPs[i])
+	}
+
+    ...
+}
+```
+
+### Changes to `pkg/gatherers/workloads/gather_workloads_info.go`
+
+#### Update `workloadInfo` Function
+
+The `workloadInfo` function is modified to track container IDs as pods are processed. It returns the `containerIDsByNode` structure along with its existing return values:
+
+```go
+func workloadInfo(
+    ctx context.Context,
+    coreClient corev1client.CoreV1Interface,
+    imageCh chan string,
+) (bool, workloadPods, containerIDsByNode, error) {
+    defer close(imageCh)
+    limitReached := false
+    containersByNode := make(containerIDsByNode)
+
+    // ... existing initialization ...
+
+    for {
+        pods, err := coreClient.Pods("").List(ctx, metav1.ListOptions{
+            Limit:    workloadGatherPageSize,
+            Continue: continueValue,
+        })
+        if err != nil {
+            return false, workloadPods{}, nil, err
+        }
+
+        for podIdx := range pods.Items {
+            pod := pods.Items[podIdx]
+
+            // ... existing namespace handling ...
+
+            if info.PodCount >= podsLimit || info.PodCount+namespacePods.Count >= podsLimit {
+                pods.Continue = ""
+                limitReached = true
+                break
+            }
+            namespacePods.Count++
+
+            switch {
+            case isPodTerminated(&pod):
+                namespacePods.TerminalCount++
+                continue
+            case podCanBeIgnored(&pod):
+                namespacePods.IgnoredCount++
+                continue
+            }
+
+            podShape, ok := calculatePodShape(h, &pod, nil) // No runtime info yet
+            if !ok {
+                namespacePods.InvalidCount++
+                continue
+            }
+
+            // NEW: Track container IDs for pods that contribute to shapes
+            containersByNode.addPodContainers(&pod)
+
+            // ... existing shape deduplication and image channel logic ...
+        }
+
+        if pods.Continue == "" {
+            break
+        }
+        continueValue = pods.Continue
+    }
+
+    // ... existing finalization ...
+
+    return limitReached, info, containersByNode, nil
+}
+```
+
+#### Update `gatherWorkloadInfo` Function
+
+The orchestration function is updated to:
+1. Call `workloadInfo` first (without runtime info)
+2. Call `gatherWorkloadRuntimeInfos` with the collected container IDs
+3. Merge runtime info into the shapes
+
+```go
+func gatherWorkloadInfo(
+    ctx context.Context,
+    coreClient corev1client.CoreV1Interface,
+    imageClient imageclient.ImageV1Interface,
+) ([]record.Record, []error) {
+    var errs = []error{}
+
+    imageCh, imagesDoneCh := gatherWorkloadImageInfo(ctx, imageClient.Images())
+
+    start := time.Now()
+    // Step 1: Build shapes and collect container IDs (no runtime info yet)
+    limitReached, info, containersByNode, err := workloadInfo(ctx, coreClient, imageCh)
+    if err != nil {
+        errs = append(errs, err)
+        return nil, errs
+    }
+
+    // Step 2: Gather runtime info for only the containers in collected shapes
+    workloadInfos, runtimeInfoErrs := gatherWorkloadRuntimeInfos(ctx, coreClient, containersByNode)
+    errs = append(errs, runtimeInfoErrs...)
+
+    // Step 3: Merge runtime info into shapes
+    mergeRuntimeInfoIntoShapes(&info, workloadInfos)
+
+    // ... existing image handling and record creation ...
+    workloadImageResize(info.PodCount)
+
+    ...
+}
+```
+
+This approach:
+- Minimal changes to `workloadInfo` - only adds container ID tracking
+- Preserves the existing streaming/paginated pod processing
+- Does not require keeping full `corev1.Pod` objects in memory
+- Tracks only the minimal data needed (node name + container IDs)
+- Stops tracking when `limitReached` is true
+- Calls the extractor only after all shape decisions are finalized
+
+#### Add `mergeRuntimeInfoIntoShapes` Function
+
+This new function injects runtime info into the already-built shapes after runtime data has been gathered from the extractor.
+
+**Background**: Currently, `calculatePodShape` receives runtime info as a parameter and looks up each container's runtime info during shape creation. With the new flow, shapes are built first (without runtime info), then runtime info is gathered, then merged in.
+
+**Approach**: Each container shape must store a key that can be used to look up its runtime info later. Reuse the existing `containerInfo` type (defined in `gather_workloads_info.go`):
+
+```go
+type containerInfo struct {
+    namespace   string
+    pod         string
+    containerID string
+}
+```
+
+**Changes to `workloadContainerShape`**:
+
+```go
+type workloadContainerShape struct {
+    ImageID      string                         `json:"imageID"`
+    FirstCommand string                         `json:"firstCommand,omitempty"`
+    FirstArg     string                         `json:"firstArg,omitempty"`
+    RuntimeInfo  *workloadRuntimeInfoContainer  `json:"runtimeInfo,omitempty"`
+
+    // runtimeKey is used to look up runtime info after shapes are built
+    // Must not be serialized to JSON - it's only used internally
+    runtimeKey   containerInfo `json:"-"`
+}
+```
+
+**Note**: The `runtimeKey` field uses the `json:"-"` tag to exclude it from JSON serialization. This field is only used internally during the gathering process and must not appear in the collected `workload_info.json` output.
+
+**The merge function**:
+
+```go
+// mergeRuntimeInfoIntoShapes updates the shapes in workloadPods with runtime info
+// This is called after shapes are built and runtime info is gathered
+func mergeRuntimeInfoIntoShapes(info *workloadPods, runtimeInfos workloadRuntimes) {
+    for nsHash, nsPods := range info.Namespaces {
+        for shapeIdx := range nsPods.Shapes {
+            shape := &nsPods.Shapes[shapeIdx]
+
+            // Merge runtime info for regular containers only
+            for containerIdx := range shape.Containers {
+                container := &shape.Containers[containerIdx]
+                if ri, ok := runtimeInfos[container.runtimeKey]; ok {
+                    container.RuntimeInfo = &ri
+                }
+            }
+        }
+        info.Namespaces[nsHash] = nsPods
+    }
+}
+```
+
+**When to populate `runtimeKey`**: During `calculateWorkloadContainerShapes` (or the container shape calculation), set the `runtimeKey` for each container:
+
+```go
+containerShape := workloadContainerShape{
+    ImageID:      imageID,
+    FirstCommand: commandHash,
+    FirstArg:     argHash,
+    runtimeKey: containerInfo{
+        namespace:   podMeta.Namespace,
+        pod:         podMeta.Name,
+        containerID: status[i].ContainerID,
+    },
+}
+```
+
+### API Contract
+
+#### Request
+
+```http
+POST /gather_runtime_info HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+    "containerIds": [
+        "cri-o://abc123def456...",
+        "cri-o://789xyz012..."
+    ]
+}
+```
+
+#### Response
+
+Same JSON structure as the current GET endpoint, but filtered to only include requested containers.
+
+#### Container ID Format
+
+- Full 64-character container IDs with optional `cri-o://` prefix
+- The insights-runtime-extractor automatically strips the `cri-o://` prefix if present
+- IDs are obtained from `pod.Status.ContainerStatuses[].ContainerID`
+
+## Backward Compatibility
+
+### Deployment Order Guarantee
+
+Since the insights-runtime-extractor will be updated **before** the insights-operator changes are deployed, backward compatibility with older extractor versions is not required. The POST endpoint will always be available when the updated operator is deployed.
+
+This simplifies the implementation:
+- No fallback to GET endpoint needed
+- No version detection or feature flags required
+- Direct POST requests without retry logic for method compatibility
+
+### Response Format Compatibility
+
+The POST endpoint returns the same JSON response format as the existing GET endpoint, ensuring the operator's response parsing logic remains unchanged.
+
+## Performance Considerations
+
+### Expected Improvements
+
+| Metric | Before | After | Notes |
+|--------|--------|-------|-------|
+| Containers scanned per node | All running | Only needed | Depends on pod distribution |
+| Response time per node | O(n) all containers | O(m) requested containers | m <= n |
+| Memory usage on extractor | Higher | Lower | Less data to hold |
+| Timeout risk | Higher | Lower | Faster responses |
+
+### Typical Scenarios
+
+1. **Mixed workload cluster**: Node runs 50 containers, operator needs 10 => 80% reduction in scanning
+2. **System-heavy node**: Node runs 30 system pods, 5 user pods => Only scan 5 containers
+3. **Dense node**: Node at capacity with many containers => Significant timeout risk reduction
+
+## Testing Strategy
+
+### Unit Tests
+
+1. Test `containerIDsByNode.addPodContainers` method:
+   - Pod in Running phase adds container IDs
+   - Pod in non-Running phase is skipped
+   - Terminated containers are skipped (State.Terminated != nil)
+   - Running and waiting containers are included
+   - Pod with missing container IDs handled gracefully
+   - Multiple pods on same node accumulate IDs
+   - Pods on different nodes tracked separately
+
+2. Test POST request construction:
+   - Valid container ID list
+   - Empty container ID list (should skip node)
+   - Container ID format handling (with/without `cri-o://` prefix)
+
+3. Test error handling:
+   - HTTP errors from extractor
+   - Timeout handling
+   - Malformed response handling
+
+4. Test execution order:
+   - Verify runtime info is not requested before shapes are collected
+   - Verify only containers from processed pods are requested
+   - Verify containers are not tracked after limitReached is true
+
+### Integration Tests
+
+1. Verify POST request is sent with correct container IDs
+2. Verify response parsing matches existing behavior
+3. Verify correct container IDs are extracted from pod statuses
+
+### End-to-End Tests
+
+1. **Sequential deployment validation**:
+   - Deploy updated insights-runtime-extractor first
+   - Verify existing operator still works with GET endpoint
+   - Deploy updated insights-operator
+   - Verify POST endpoint is used correctly
+2. Verify workload_info.json contains expected runtime data
+3. Measure performance improvement on cluster with many containers
+
+## Security Considerations
+
+- No new privileges required
+- Container IDs are not sensitive (they are also visible in pod status)
+- Same authentication mechanism (service account bearer token)
+- Same TLS requirements
+
+## Rollout Plan
+
+The rollout follows a strict sequential order to ensure compatibility:
+
+### Phase 1: insights-runtime-extractor Update (First)
+
+1. Deploy insights-runtime-extractor with POST endpoint support ([openshift/insights-runtime-extractor#60](https://github.com/openshift/insights-runtime-extractor/pull/60))
+2. Existing GET endpoint continues to work unchanged for current operator
+3. Validate POST endpoint works correctly in staging/test environments
+4. **Must complete before Phase 2 begins**
+
+### Phase 2: insights-operator Update (Second)
+
+1. Update insights-operator to use POST endpoint with container IDs
+2. No fallback logic needed since extractor is already updated
+3. Deploy to clusters where extractor update has been confirmed
+
+### Phase 3: Cleanup (Optional, Future)
+
+1. Deprecate GET endpoint in extractor after all operators are updated
+2. Remove GET endpoint in future major version of extractor
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `pkg/gatherers/workloads/gather_workloads_runtime_infos.go` | Add `POST` request support, accept container IDs parameter |
+| `pkg/gatherers/workloads/gather_workloads_info.go` | Track container IDs in `workloadInfo`, add `mergeRuntimeInfoIntoShapes`, reorder calls in `gatherWorkloadInfo` |
+| `pkg/gatherers/workloads/gather_workloads_info_test.go` | Add tests for container ID tracking and merging |
+| `pkg/gatherers/workloads/gather_workloads_runtime_infos_test.go` | Add tests for `POST` request functionality |
+
+## References
+
+- [openshift/insights-runtime-extractor#60](https://github.com/openshift/insights-runtime-extractor/pull/60)
+- [CCXDEV-15960](https://issues.redhat.com/browse/CCXDEV-15960)
+- [Workloads Gatherer Implementation](../gathered-data.md#workloadinfo)

--- a/manifests/10-insights-runtime-extractor-proxy-configmap.yaml
+++ b/manifests/10-insights-runtime-extractor-proxy-configmap.yaml
@@ -20,4 +20,3 @@ data:
           resourceRequest: false
           user:
             name: system:serviceaccount:openshift-insights:operator
-          verb: get

--- a/pkg/gatherers/workloads/gather_workloads_info.go
+++ b/pkg/gatherers/workloads/gather_workloads_info.go
@@ -48,6 +48,31 @@ type containerInfo struct {
 	containerID string
 }
 
+// containerIDsByNode maps node name to list of container IDs running on that node.
+// This structure is used to track which container IDs need runtime info extraction,
+// accumulated as pods are processed.
+type containerIDsByNode map[string][]string
+
+// addPodContainers adds container IDs from a pod to the tracking structure.
+// Called during pod processing, before the pod object is discarded.
+// Only adds containers that are not terminated (running or waiting).
+func (c containerIDsByNode) addPodContainers(pod *corev1.Pod) {
+	if pod.Status.Phase != corev1.PodRunning {
+		return
+	}
+	nodeName := pod.Spec.NodeName
+	for i := range pod.Status.ContainerStatuses {
+		containerStatus := &pod.Status.ContainerStatuses[i]
+		// Skip terminated containers - they no longer have a running process to scan
+		if containerStatus.State.Terminated != nil {
+			continue
+		}
+		if containerStatus.ContainerID != "" {
+			c[nodeName] = append(c[nodeName], containerStatus.ContainerID)
+		}
+	}
+}
+
 // GatherWorkloadInfo Collects summarized info about the workloads on a cluster
 // in a generic fashion
 //
@@ -104,17 +129,22 @@ func gatherWorkloadInfo(
 ) ([]record.Record, []error) {
 	errs := []error{}
 
-	workloadInfos, runtimeInfoErrs := gatherWorkloadRuntimeInfos(ctx, coreClient, configClient)
-	errs = append(errs, runtimeInfoErrs...)
-
 	imageCh, imagesDoneCh := gatherWorkloadImageInfo(ctx, imageClient.Images())
 
 	start := time.Now()
-	limitReached, info, err := workloadInfo(ctx, coreClient, imageCh, workloadInfos)
+	// Build shapes and collect container IDs (no runtime info yet)
+	limitReached, info, containersByNode, err := workloadInfo(ctx, coreClient, imageCh)
 	if err != nil {
 		errs = append(errs, err)
 		return nil, errs
 	}
+
+	// Gather runtime info for only the containers in collected shapes
+	workloadInfos, runtimeInfoErrs := gatherWorkloadRuntimeInfos(ctx, coreClient, configClient, containersByNode)
+	errs = append(errs, runtimeInfoErrs...)
+
+	// Merge runtime info into shapes
+	mergeRuntimeInfoIntoShapes(&info, workloadInfos)
 
 	workloadImageResize(info.PodCount)
 
@@ -140,10 +170,10 @@ func workloadInfo(
 	ctx context.Context,
 	coreClient corev1client.CoreV1Interface,
 	imageCh chan string,
-	workloadInfos workloadRuntimes,
-) (bool, workloadPods, error) {
+) (bool, workloadPods, containerIDsByNode, error) {
 	defer close(imageCh)
 	limitReached := false
+	containersByNode := make(containerIDsByNode)
 
 	var info workloadPods
 	var namespace, namespaceHash, continueValue string
@@ -157,7 +187,7 @@ func workloadInfo(
 			Continue: continueValue,
 		})
 		if err != nil {
-			return false, workloadPods{}, err
+			return false, workloadPods{}, nil, err
 		}
 
 		for podIdx := range pods.Items {
@@ -196,7 +226,7 @@ func workloadInfo(
 				continue
 			}
 
-			podShape, ok := calculatePodShape(h, &pod, workloadInfos)
+			podShape, ok := calculatePodShape(h, &pod)
 			if !ok {
 				namespacePods.InvalidCount++
 				continue
@@ -207,6 +237,7 @@ func workloadInfo(
 				continue
 			}
 			namespacePods.Shapes = append(namespacePods.Shapes, podShape)
+			containersByNode.addPodContainers(&pod)
 
 			for _, container := range podShape.InitContainers {
 				imageCh <- container.ImageID
@@ -234,7 +265,7 @@ func workloadInfo(
 		info.PodCount += namespacePods.Count
 	}
 
-	return limitReached, info, nil
+	return limitReached, info, containersByNode, nil
 }
 
 func isPodTerminated(pod *corev1.Pod) bool {
@@ -248,17 +279,35 @@ func podCanBeIgnored(pod *corev1.Pod) bool {
 		len(pod.Status.ContainerStatuses) != len(pod.Spec.Containers)
 }
 
-func calculatePodShape(h hash.Hash, pod *corev1.Pod, workloadInfo workloadRuntimes) (workloadPodShape, bool) {
+// mergeRuntimeInfoIntoShapes updates the shapes in workloadPods with runtime info.
+// This is called after shapes are built and runtime info is gathered.
+func mergeRuntimeInfoIntoShapes(info *workloadPods, runtimeInfos workloadRuntimes) {
+	for nsHash, nsPods := range info.Namespaces {
+		for shapeIdx := range nsPods.Shapes {
+			shape := &nsPods.Shapes[shapeIdx]
+			// Merge runtime info only for regular containers
+			for containerIdx := range shape.Containers {
+				container := &shape.Containers[containerIdx]
+				if ri, ok := runtimeInfos[container.runtimeKey]; ok {
+					container.RuntimeInfo = &ri
+				}
+			}
+		}
+		info.Namespaces[nsHash] = nsPods
+	}
+}
+
+func calculatePodShape(h hash.Hash, pod *corev1.Pod) (workloadPodShape, bool) {
 	var podShape workloadPodShape
 	var ok bool
 	podShape.InitContainers, ok = calculateWorkloadContainerShapes(h, &pod.ObjectMeta, pod.Spec.InitContainers,
-		pod.Status.InitContainerStatuses, workloadInfo)
+		pod.Status.InitContainerStatuses)
 	if !ok {
 		return workloadPodShape{}, false
 	}
 
 	podShape.Containers, ok = calculateWorkloadContainerShapes(h, &pod.ObjectMeta, pod.Spec.Containers,
-		pod.Status.ContainerStatuses, workloadInfo)
+		pod.Status.ContainerStatuses)
 	if !ok {
 		return workloadPodShape{}, false
 	}
@@ -489,12 +538,12 @@ func idForImageReference(s string) string {
 // calculateWorkloadContainerShapes takes a spec and status slice and attempts
 // to calculate an array of container shapes. If the preconditions of the shape
 // can't be met (invalid status, no imageID) false is returned.
+// The runtimeKey field is populated for later runtime info merging.
 func calculateWorkloadContainerShapes(
 	h hash.Hash,
 	podMeta *metav1.ObjectMeta,
 	spec []corev1.Container,
 	status []corev1.ContainerStatus,
-	runtimesInfo workloadRuntimes,
 ) ([]workloadContainerShape, bool) {
 	shapes := make([]workloadContainerShape, 0, len(status))
 	for i := range status {
@@ -529,16 +578,12 @@ func calculateWorkloadContainerShapes(
 			ImageID:      imageID,
 			FirstCommand: firstCommand,
 			FirstArg:     firstArg,
-		}
-
-		conInfo := containerInfo{
-			namespace:   podMeta.Namespace,
-			pod:         podMeta.Name,
-			containerID: status[i].ContainerID,
-		}
-
-		if workloadRuntimeInfo, ok := runtimesInfo[conInfo]; ok {
-			containerShape.RuntimeInfo = &workloadRuntimeInfo
+			// Store the runtime key for later runtime info merging
+			runtimeKey: containerInfo{
+				namespace:   podMeta.Namespace,
+				pod:         podMeta.Name,
+				containerID: status[i].ContainerID,
+			},
 		}
 
 		shapes = append(shapes, containerShape)

--- a/pkg/gatherers/workloads/gather_workloads_info_test.go
+++ b/pkg/gatherers/workloads/gather_workloads_info_test.go
@@ -531,7 +531,6 @@ func Test_workloadImageCache(t *testing.T) {
 
 func Test_calculatePodShape(t *testing.T) {
 	h := sha256.New()
-	workloadInfo := workloadRuntimes{}
 
 	// Valid SHA256 digests (64 hex characters)
 	validDigest1 := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
@@ -640,7 +639,7 @@ func Test_calculatePodShape(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			shape, ok := calculatePodShape(h, tt.pod, workloadInfo)
+			shape, ok := calculatePodShape(h, tt.pod)
 			assert.Equal(t, tt.expectOk, ok)
 			if ok {
 				assert.NotNil(t, shape.Containers)
@@ -650,6 +649,311 @@ func Test_calculatePodShape(t *testing.T) {
 					assert.False(t, shape.RestartsAlways)
 				}
 			}
+		})
+	}
+}
+
+func Test_containerIDsByNode_addPodContainers(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected containerIDsByNode
+	}{
+		{
+			name: "pod in Running phase adds container IDs",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:        "app",
+							ContainerID: "cri-o://abc123",
+							State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			expected: containerIDsByNode{
+				"node-1": []string{"cri-o://abc123"},
+			},
+		},
+		{
+			name: "pod in non-Running phase is skipped",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:        "app",
+							ContainerID: "cri-o://abc123",
+						},
+					},
+				},
+			},
+			expected: containerIDsByNode{},
+		},
+		{
+			name: "terminated containers are skipped",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:        "app",
+							ContainerID: "cri-o://abc123",
+							State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+						{
+							Name:        "sidecar",
+							ContainerID: "cri-o://def456",
+							State:       corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{}},
+						},
+					},
+				},
+			},
+			expected: containerIDsByNode{
+				"node-1": []string{"cri-o://abc123"},
+			},
+		},
+		{
+			name: "running and waiting containers are included",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:        "app",
+							ContainerID: "cri-o://abc123",
+							State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+						{
+							Name:        "init",
+							ContainerID: "cri-o://def456",
+							State:       corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}},
+						},
+					},
+				},
+			},
+			expected: containerIDsByNode{
+				"node-1": []string{"cri-o://abc123", "cri-o://def456"},
+			},
+		},
+		{
+			name: "pod with missing container IDs handled gracefully",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:        "app",
+							ContainerID: "",
+							State:       corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						},
+					},
+				},
+			},
+			expected: containerIDsByNode{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := make(containerIDsByNode)
+			c.addPodContainers(tt.pod)
+			assert.Equal(t, tt.expected, c)
+		})
+	}
+}
+
+func Test_containerIDsByNode_multiplePods(t *testing.T) {
+	c := make(containerIDsByNode)
+
+	// Add pods on same node - should accumulate IDs
+	pod1 := &corev1.Pod{
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app1", ContainerID: "cri-o://abc123", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+	pod2 := &corev1.Pod{
+		Spec: corev1.PodSpec{NodeName: "node-1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app2", ContainerID: "cri-o://def456", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+	// Pod on different node
+	pod3 := &corev1.Pod{
+		Spec: corev1.PodSpec{NodeName: "node-2"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app3", ContainerID: "cri-o://ghi789", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+			},
+		},
+	}
+
+	c.addPodContainers(pod1)
+	c.addPodContainers(pod2)
+	c.addPodContainers(pod3)
+
+	assert.Equal(t, 2, len(c))
+	assert.Equal(t, []string{"cri-o://abc123", "cri-o://def456"}, c["node-1"])
+	assert.Equal(t, []string{"cri-o://ghi789"}, c["node-2"])
+}
+
+func Test_mergeRuntimeInfoIntoShapes(t *testing.T) {
+	tests := []struct {
+		name         string
+		info         workloadPods
+		runtimeInfos workloadRuntimes
+		checkResult  func(t *testing.T, info *workloadPods)
+	}{
+		{
+			name: "merges runtime info into matching containers",
+			info: workloadPods{
+				Namespaces: map[string]workloadNamespacePods{
+					"ns-hash": {
+						Shapes: []workloadPodShape{
+							{
+								Containers: []workloadContainerShape{
+									{
+										ImageID: "sha256:abc",
+										runtimeKey: containerInfo{
+											namespace:   "test-ns",
+											pod:         "test-pod",
+											containerID: "cri-o://container-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			runtimeInfos: workloadRuntimes{
+				{namespace: "test-ns", pod: "test-pod", containerID: "cri-o://container-1"}: {
+					Os:   "rhel",
+					Kind: "java",
+				},
+			},
+			checkResult: func(t *testing.T, info *workloadPods) {
+				container := &info.Namespaces["ns-hash"].Shapes[0].Containers[0]
+				assert.NotNil(t, container.RuntimeInfo)
+				assert.Equal(t, "rhel", container.RuntimeInfo.Os)
+				assert.Equal(t, "java", container.RuntimeInfo.Kind)
+			},
+		},
+		{
+			name: "no runtime info for non-matching containers",
+			info: workloadPods{
+				Namespaces: map[string]workloadNamespacePods{
+					"ns-hash": {
+						Shapes: []workloadPodShape{
+							{
+								Containers: []workloadContainerShape{
+									{
+										ImageID: "sha256:abc",
+										runtimeKey: containerInfo{
+											namespace:   "test-ns",
+											pod:         "test-pod",
+											containerID: "cri-o://container-1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			runtimeInfos: workloadRuntimes{
+				{namespace: "other-ns", pod: "other-pod", containerID: "cri-o://other"}: {
+					Os:   "rhel",
+					Kind: "java",
+				},
+			},
+			checkResult: func(t *testing.T, info *workloadPods) {
+				container := &info.Namespaces["ns-hash"].Shapes[0].Containers[0]
+				assert.Nil(t, container.RuntimeInfo)
+			},
+		},
+		{
+			name: "only merges runtime info into regular containers",
+			info: workloadPods{
+				Namespaces: map[string]workloadNamespacePods{
+					"ns-hash": {
+						Shapes: []workloadPodShape{
+							{
+								InitContainers: []workloadContainerShape{
+									{
+										ImageID: "sha256:init",
+										runtimeKey: containerInfo{
+											namespace:   "test-ns",
+											pod:         "test-pod",
+											containerID: "cri-o://init-container",
+										},
+									},
+								},
+								Containers: []workloadContainerShape{
+									{
+										ImageID: "sha256:app",
+										runtimeKey: containerInfo{
+											namespace:   "test-ns",
+											pod:         "test-pod",
+											containerID: "cri-o://app-container",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			runtimeInfos: workloadRuntimes{
+				{namespace: "test-ns", pod: "test-pod", containerID: "cri-o://init-container"}: {
+					Os: "ubuntu",
+				},
+				{namespace: "test-ns", pod: "test-pod", containerID: "cri-o://app-container"}: {
+					Os:   "rhel",
+					Kind: "nodejs",
+				},
+			},
+			checkResult: func(t *testing.T, info *workloadPods) {
+				initContainer := &info.Namespaces["ns-hash"].Shapes[0].InitContainers[0]
+				assert.Nil(t, initContainer.RuntimeInfo)
+
+				appContainer := &info.Namespaces["ns-hash"].Shapes[0].Containers[0]
+				assert.NotNil(t, appContainer.RuntimeInfo)
+				assert.Equal(t, "rhel", appContainer.RuntimeInfo.Os)
+				assert.Equal(t, "nodejs", appContainer.RuntimeInfo.Kind)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mergeRuntimeInfoIntoShapes(&tt.info, tt.runtimeInfos)
+			tt.checkResult(t, &tt.info)
 		})
 	}
 }

--- a/pkg/gatherers/workloads/gather_workloads_runtime_infos.go
+++ b/pkg/gatherers/workloads/gather_workloads_runtime_infos.go
@@ -1,6 +1,7 @@
 package workloads
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -27,10 +28,16 @@ type podWithNodeName struct {
 	nodeName string
 }
 
+// gatherRuntimeInfoRequest is the request body for the POST endpoint
+type gatherRuntimeInfoRequest struct {
+	ContainerIDs []string `json:"containerIds"`
+}
+
 func gatherWorkloadRuntimeInfos(
 	ctx context.Context,
 	coreClient corev1client.CoreV1Interface,
 	configClient configv1client.Interface,
+	containersByNode containerIDsByNode,
 ) (workloadRuntimes, []error) {
 	start := time.Now()
 
@@ -62,7 +69,14 @@ func gatherWorkloadRuntimeInfos(
 	for i := range runtimePodIPs {
 		go func(podInfo podWithNodeName) {
 			defer wg.Done()
-			klog.Infof("Gathering workload runtime info for node %s...\n", podInfo.nodeName)
+
+			containerIDs := containersByNode[podInfo.nodeName]
+			// Skip nodes with no containers to scan
+			if len(containerIDs) == 0 {
+				return
+			}
+
+			klog.Infof("Gathering workload runtime info for node %s (%d containers)...\n", podInfo.nodeName, len(containerIDs))
 			hostPort := net.JoinHostPort(podInfo.podIP, "8443")
 			extractorURL := fmt.Sprintf("https://%s/gather_runtime_info", hostPort)
 			httpCli, err := createHTTPClient(configClient)
@@ -75,7 +89,7 @@ func gatherWorkloadRuntimeInfos(
 				klog.Errorf("Failed to read the serviceaccount token: %v", err)
 				return
 			}
-			nodeWorkloadCh <- getNodeWorkloadRuntimeInfos(ctx, extractorURL, string(tokenData), httpCli)
+			nodeWorkloadCh <- getNodeWorkloadRuntimeInfos(ctx, extractorURL, string(tokenData), httpCli, containerIDs)
 		}(runtimePodIPs[i])
 	}
 
@@ -171,22 +185,36 @@ func readToken() ([]byte, error) {
 	return os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 }
 
-// Get all WorkloadRuntimeInfos for a single Node (using the insights-runtime-extractor pod running on this node)
+// Get WorkloadRuntimeInfos for specified containers on a single node
+// (using the insights-runtime-extractor pod running on this node)
 func getNodeWorkloadRuntimeInfos(
 	ctx context.Context,
 	url string,
 	token string,
 	httpCli *http.Client,
+	containerIDs []string,
 ) workloadRuntimesResult {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	// Create the POST request with container IDs in the body
+	reqBody := gatherRuntimeInfoRequest{
+		ContainerIDs: containerIDs,
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return workloadRuntimesResult{
+			Error: fmt.Errorf("failed to marshal request: %w", err),
+		}
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return workloadRuntimesResult{
 			Error: err,
 		}
 	}
+	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Authorization", "Bearer "+token)
 	resp, err := httpCli.Do(request) // nolint:gosec
 	if err != nil {
@@ -194,6 +222,7 @@ func getNodeWorkloadRuntimeInfos(
 			Error: err,
 		}
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		return workloadRuntimesResult{
 			Error: insightsclient.HttpError{
@@ -202,7 +231,6 @@ func getNodeWorkloadRuntimeInfos(
 			},
 		}
 	}
-	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/gatherers/workloads/gather_workloads_runtime_infos_test.go
+++ b/pkg/gatherers/workloads/gather_workloads_runtime_infos_test.go
@@ -2,7 +2,9 @@ package workloads
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -269,6 +271,9 @@ func TestGetNodeWorkloadRuntimeInfos(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var receivedAuthHeader string
 			httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify it's a POST request with correct content type
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 				if tt.checkAuthHeader {
 					receivedAuthHeader = r.Header.Get("Authorization")
 				}
@@ -281,7 +286,9 @@ func TestGetNodeWorkloadRuntimeInfos(t *testing.T) {
 			defer httpServer.Close()
 
 			ctx := context.Background()
-			result := getNodeWorkloadRuntimeInfos(ctx, httpServer.URL, tt.token, http.DefaultClient)
+			// Pass container IDs to the function
+			containerIDs := []string{"cri-o://test-container-1", "cri-o://test-container-2"}
+			result := getNodeWorkloadRuntimeInfos(ctx, httpServer.URL, tt.token, http.DefaultClient, containerIDs)
 
 			if tt.expectedErr != nil {
 				assert.Contains(t, result.Error.Error(), tt.expectedErr.Error())
@@ -444,9 +451,37 @@ func TestGatherWorkloadRuntimeInfos_NoPods(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
-	result, errors := gatherWorkloadRuntimeInfos(ctx, cli.CoreV1(), configCli)
+	// Pass empty containerIDsByNode
+	containersByNode := make(containerIDsByNode)
+	result, errors := gatherWorkloadRuntimeInfos(ctx, cli.CoreV1(), configCli, containersByNode)
 
 	assert.Nil(t, result)
 	assert.Len(t, errors, 1)
 	assert.Contains(t, errors[0].Error(), "no running pods found")
+}
+
+func TestGetNodeWorkloadRuntimeInfos_POSTRequestBody(t *testing.T) {
+	var receivedBody []byte
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify it's a POST request
+		assert.Equal(t, http.MethodPost, r.Method)
+		// Read and save the request body
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		receivedBody = body
+		// Return empty response
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer httpServer.Close()
+
+	ctx := context.Background()
+	containerIDs := []string{"cri-o://container-1", "cri-o://container-2", "cri-o://container-3"}
+	_ = getNodeWorkloadRuntimeInfos(ctx, httpServer.URL, "test-token", http.DefaultClient, containerIDs)
+
+	// Verify the request body contains the container IDs
+	var reqBody gatherRuntimeInfoRequest
+	err := json.Unmarshal(receivedBody, &reqBody)
+	assert.NoError(t, err)
+	assert.Equal(t, containerIDs, reqBody.ContainerIDs)
 }

--- a/pkg/gatherers/workloads/types.go
+++ b/pkg/gatherers/workloads/types.go
@@ -100,6 +100,9 @@ type workloadContainerShape struct {
 	FirstArg string `json:"firstArg,omitempty"`
 	// Runtime info on the container, if any info were gathered
 	RuntimeInfo *workloadRuntimeInfoContainer `json:"runtimeInfo,omitempty"`
+	// runtimeKey is used to look up runtime info after shapes are built.
+	// Must not be serialized to JSON - it's only used internally.
+	runtimeKey containerInfo `json:"-"`
 }
 
 type workloadRuntimeInfoContainer struct {


### PR DESCRIPTION
Add the PRD that describe the required changes in the Insights Operator.

The changes to the insights-runtime-extractor are handled in https://github.com/openshift/insights-runtime-extractor/pull/60.

JIRA: https://issues.redhat.com/browse/CCXDEV-15960

- [X] Bugfix

## Changelog

Integration of the insights-runtime-extractor and its API have been changed to collect only runtime data
from the subset of containers that are gathered by the Insights Operator

## Breaking Changes

No

## References

https://issues.redhat.com/browse/CCXDEV-15960


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Runtime data collection now requests info only for identified container IDs, reducing compute and latency during gathers.

- **Updates**
  - Runtime extractor now uses POST requests with container ID payloads; access rule for the extractor endpoint simplified.

- **Documentation**
  - Added product requirements describing the new container-ID filtering flow and rollout considerations.

- **Tests**
  - Added unit tests covering container-ID aggregation and runtime-info merging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->