### PR TITLE
[release-4.18] OCPBUGS-76963: Extends the time for the extractor liveness probe

### DIFF
--- a/manifests/10-insights-runtime-extractor.yaml
+++ b/manifests/10-insights-runtime-extractor.yaml
@@ -91,9 +91,11 @@ spec:
             exec:
               command:
                 - crictl
+                - --timeout
+                - 10s
                 - info
-              periodSeconds: 10
-              failureThreshold: 2
+              periodSeconds: 30
+              timeoutSeconds: 10
           resources: 
             requests:
               cpu: 10m


### PR DESCRIPTION
## Categories

- [X] Backporting

Before:
  * `crictl info` was timing out after 2 seconds
  * the command was executed every 10 seconds
  * 2 failures were making the container unhealthy
  * => 10 seconds of unavailability was making the pod crash

This was too constraining as there are occasions where `crictl` can be unavailable for a longer period of time (eg when the TLS CA bundle requires to restart some pods)

Now:
  * `crictl info` is timing out after 10 seconds
  * the command is executed every 30 seconds
  * 3 failures (default) are making the container unhealthy
  * => 1m30s of unaivailability is making the pod crash

Note: The liveness probe is used instead of the readiness probe as the container MUST crash if the crictl connection has been changed (eg following a TLS CA bundle update) and at this point, the pod must be recreated to be able to connect to cri-o socket with an updated TLS certificate.

This fixes https://issues.redhat.com/browse/OCPBUGS-76963
Upstream issue is https://issues.redhat.com/browse/OCPBUGS-66996
