### PR TITLE
CCXDEV-16094: add config option to disable runtime extractor 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,8 +34,13 @@ func (i *InsightsConfigurationSerialized) ToConfig() *InsightsConfiguration {
 			NoProxy:    i.Proxy.NoProxy,
 		},
 	}
+
 	if i.DataReporting.Interval != "" {
 		ic.DataReporting.Interval = parseInterval(i.DataReporting.Interval, defaultGatherFrequency, minimumGatherFrequency)
+	}
+
+	if i.DataReporting.DisableRuntimeExtractor != "" {
+		ic.DataReporting.DisableRuntimeExtractor = strings.EqualFold(i.DataReporting.DisableRuntimeExtractor, "true")
 	}
 
 	if i.SCA.Interval != "" {
@@ -134,13 +139,16 @@ func (d *DataReporting) String() string {
 		storagePath: %s,
 		downloadEndpoint: %s, 
 		conditionalGathererEndpoint: %s,
-		obfuscation: %s`,
+		obfuscation: %s,
+		disableRuntimeExtractor: %t`,
 		d.Interval,
 		d.UploadEndpoint,
 		d.StoragePath,
 		d.DownloadEndpoint,
 		d.ConditionalGathererEndpoint,
-		d.Obfuscation)
+		d.Obfuscation,
+		d.DisableRuntimeExtractor,
+	)
 	return s
 }
 

--- a/pkg/config/configobserver/config_aggregator.go
+++ b/pkg/config/configobserver/config_aggregator.go
@@ -146,6 +146,10 @@ func (c *ConfigAggregator) mergeDataReporting(defaultCfg, newCfg *config.Insight
 	if len(newCfg.DataReporting.Obfuscation) > 0 {
 		defaultCfg.DataReporting.Obfuscation = append(defaultCfg.DataReporting.Obfuscation, newCfg.DataReporting.Obfuscation...)
 	}
+
+	if newCfg.DataReporting.DisableRuntimeExtractor != defaultCfg.DataReporting.DisableRuntimeExtractor {
+		defaultCfg.DataReporting.DisableRuntimeExtractor = newCfg.DataReporting.DisableRuntimeExtractor
+	}
 }
 
 func (c *ConfigAggregator) mergeAlerting(defaultCfg, newCfg *config.InsightsConfiguration) {

--- a/pkg/config/configobserver/config_aggregator_test.go
+++ b/pkg/config/configobserver/config_aggregator_test.go
@@ -46,6 +46,7 @@ func TestMergeStatically(t *testing.T) {
 					Interval:                    2 * time.Hour,
 					ConditionalGathererEndpoint: "http://conditionalendpoint.here",
 					Obfuscation:                 config.Obfuscation{config.Networking},
+					DisableRuntimeExtractor:     false,
 				},
 				SCA: config.SCA{
 					Interval: 5 * time.Hour,
@@ -74,6 +75,7 @@ dataReporting:
   conditionalGathererEndpoint: https://overriden.conditional/endpoint
   processingStatusEndpoint: https://overriden.status/endpoint
   downloadEndpointTechPreview: https://overriden.downloadtechpreview/endpoint
+  disableRuntimeExtractor: true
   obfuscation:
   - workload_names
 alerting:
@@ -116,6 +118,7 @@ clusterTransfer:
 					ProcessingStatusEndpoint:    "https://overriden.status/endpoint",
 					DownloadEndpointTechPreview: "https://overriden.downloadtechpreview/endpoint",
 					Obfuscation:                 config.Obfuscation{config.Networking, config.WorkloadNames},
+					DisableRuntimeExtractor:     true,
 				},
 				Alerting: config.Alerting{
 					Disabled: true,
@@ -151,8 +154,9 @@ dataReporting:
 			},
 			expectedConfig: &config.InsightsConfiguration{
 				DataReporting: config.DataReporting{
-					Enabled:        false,
-					UploadEndpoint: "https://overriden.upload/endpoint",
+					Enabled:                 false,
+					UploadEndpoint:          "https://overriden.upload/endpoint",
+					DisableRuntimeExtractor: false,
 				},
 			},
 		},
@@ -197,6 +201,7 @@ dataReporting:
 					ProcessingStatusEndpoint:    "http://statusendpoint.here",
 					DownloadEndpointTechPreview: "http://downloadtpendpoint.here",
 					Obfuscation:                 config.Obfuscation{config.Networking},
+					DisableRuntimeExtractor:     false,
 				},
 				Alerting: config.Alerting{
 					Disabled: false,
@@ -270,6 +275,7 @@ func TestMergeUsingInformer(t *testing.T) {
 					Interval:                    2 * time.Hour,
 					ConditionalGathererEndpoint: "http://conditionalendpoint.here",
 					Obfuscation:                 config.Obfuscation{config.Networking},
+					DisableRuntimeExtractor:     false,
 				},
 				Alerting: config.Alerting{
 					Disabled: true,
@@ -303,6 +309,7 @@ dataReporting:
   conditionalGathererEndpoint: https://overriden.conditional/endpoint
   processingStatusEndpoint: https://overriden.status/endpoint
   downloadEndpointTechPreview: https://overriden.downloadtechpreview/endpoint
+  disableRuntimeExtractor: true
   obfuscation:
   - workload_names
 alerting:
@@ -353,6 +360,7 @@ proxy:
 					Interval:                    1 * time.Hour,
 					ConditionalGathererEndpoint: "https://overriden.conditional/endpoint",
 					Obfuscation:                 config.Obfuscation{config.Networking, config.WorkloadNames},
+					DisableRuntimeExtractor:     true,
 				},
 				Alerting: config.Alerting{
 					Disabled: true,
@@ -393,8 +401,9 @@ dataReporting:
 			},
 			expectedConfig: &config.InsightsConfiguration{
 				DataReporting: config.DataReporting{
-					Enabled:        false,
-					UploadEndpoint: "https://overriden.upload/endpoint",
+					Enabled:                 false,
+					UploadEndpoint:          "https://overriden.upload/endpoint",
+					DisableRuntimeExtractor: false,
 				},
 			},
 		},
@@ -424,11 +433,12 @@ dataReporting:
 			},
 			expectedConfig: &config.InsightsConfiguration{
 				DataReporting: config.DataReporting{
-					Enabled:          true,
-					UploadEndpoint:   "http://testing.here",
-					DownloadEndpoint: "http://reportendpoint.here",
-					Interval:         2 * time.Hour,
-					Obfuscation:      config.Obfuscation{config.Networking},
+					Enabled:                 true,
+					UploadEndpoint:          "http://testing.here",
+					DownloadEndpoint:        "http://reportendpoint.here",
+					Interval:                2 * time.Hour,
+					Obfuscation:             config.Obfuscation{config.Networking},
+					DisableRuntimeExtractor: false,
 				},
 				Alerting: config.Alerting{
 					Disabled: false, // this was not provide in the empty config map and zero value (false) is used

--- a/pkg/config/legacy_config.go
+++ b/pkg/config/legacy_config.go
@@ -34,6 +34,7 @@ type Serialized struct {
 	DisableInsightsAlerts     bool   `json:"disableInsightsAlerts"`
 	ProcessingStatusEndpoint  string `json:"processingStatusEndpoint"`
 	ReportEndpointTechPreview string `json:"reportEndpointTechPreview"`
+	DisableRuntimeExtractor   bool   `json:"disableRuntimeExtractor"`
 }
 
 // Controller defines the standard config for this operator.
@@ -49,6 +50,7 @@ type Controller struct {
 	ReportMinRetryTime          time.Duration
 	ReportPullingTimeout        time.Duration
 	Impersonate                 string
+	DisableRuntimeExtractor     bool
 	// EnableGlobalObfuscation enables obfuscation of domain names and IP addresses
 	// To see the detailed info about how anonymization works, go to the docs of package anonymization.
 	EnableGlobalObfuscation bool
@@ -199,6 +201,7 @@ func ToController(s *Serialized, cfg *Controller) (*Controller, error) { // noli
 	cfg.DisableInsightsAlerts = s.DisableInsightsAlerts
 	cfg.ProcessingStatusEndpoint = s.ProcessingStatusEndpoint
 	cfg.ReportEndpointTechPreview = s.ReportEndpointTechPreview
+	cfg.DisableRuntimeExtractor = s.DisableRuntimeExtractor
 
 	if len(s.Interval) > 0 {
 		d, err := time.ParseDuration(s.Interval)
@@ -293,6 +296,7 @@ func ToDisconnectedController(s *Serialized, cfg *Controller) (*Controller, erro
 	cfg.EnableGlobalObfuscation = s.EnableGlobalObfuscation
 	cfg.ConditionalGathererEndpoint = s.ConditionalGathererEndpoint
 	cfg.DisableInsightsAlerts = s.DisableInsightsAlerts
+	cfg.DisableRuntimeExtractor = s.DisableRuntimeExtractor
 
 	if len(s.Interval) > 0 {
 		d, err := time.ParseDuration(s.Interval)

--- a/pkg/config/legacy_config_test.go
+++ b/pkg/config/legacy_config_test.go
@@ -33,6 +33,7 @@ func TestLoadConfig(t *testing.T) {
 					ClusterTransferEndpoint: "default-ct-endpoint",
 					ClusterTransferInterval: 24 * time.Hour,
 				},
+				DisableRuntimeExtractor: false,
 			},
 			obj: map[string]interface{}{
 				"report":      true,
@@ -51,6 +52,7 @@ func TestLoadConfig(t *testing.T) {
 					"clusterTransferEndpoint": "real-ct-endpoint",
 					"clusterTransferInterval": "12h",
 				},
+				"disableRuntimeExtractor": true,
 			},
 			expectedOutput: Controller{
 				Report:               true,
@@ -67,6 +69,7 @@ func TestLoadConfig(t *testing.T) {
 					ClusterTransferEndpoint: "real-ct-endpoint",
 					ClusterTransferInterval: 12 * time.Hour,
 				},
+				DisableRuntimeExtractor: true,
 			},
 			err: nil,
 		},

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -35,6 +35,7 @@ type DataReportingSerialized struct {
 	ConditionalGathererEndpoint string      `json:"conditionalGathererEndpoint,omitempty"`
 	ProcessingStatusEndpoint    string      `json:"processingStatusEndpoint,omitempty"`
 	Obfuscation                 Obfuscation `json:"obfuscation,omitempty"`
+	DisableRuntimeExtractor     string      `json:"disableRuntimeExtractor,omitempty"`
 }
 
 type AlertingSerialized struct {
@@ -83,6 +84,7 @@ type DataReporting struct {
 	ReportPullingDelay          time.Duration
 	ProcessingStatusEndpoint    string
 	Obfuscation                 Obfuscation
+	DisableRuntimeExtractor     bool
 }
 
 // Alerting is a helper type for configuring Insights alerting


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR adds the `disableRuntimeExtractor` option to the insights ConfigMap so that users can disable the runtime-extractor functionality.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/config/configobserver/config_aggregator_test.go`
- `pkg/config/legacy_config_test.go`
- 
## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???](https://issues.redhat.com/browse/CCXDEV-16094)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new boolean configuration option `disableRuntimeExtractor` has been added, allowing operators to control runtime extraction behavior on a per-deployment basis. This option is configurable through standard configuration files as well as through dynamic configuration map overrides, enabling flexible management of runtime extraction across various environments and deployment configurations without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->