### PR TITLE
OCPBUGS-78587: add WorkloadAnonymizer with obfuscation config

### DIFF
--- a/pkg/anonymization/anonymizer.go
+++ b/pkg/anonymization/anonymizer.go
@@ -30,7 +30,8 @@ import (
 type AnonymizerType string
 
 const (
-	NetworkAnonymizerType AnonymizerType = "networking"
+	NetworkAnonymizerType       AnonymizerType = "networking"
+	WorkloadNamesAnonymizerType AnonymizerType = "WorkloadNames"
 )
 
 type DataAnonymizer interface {
@@ -40,6 +41,9 @@ type DataAnonymizer interface {
 	IsEnabled() bool
 	// GetType returns the type of the anonymizer implementation.
 	GetType() AnonymizerType
+	// Skip is a temporary workaround to skip Workloads anonymizer until it is properly
+	// implemented https://redhat.atlassian.net/browse/CCXDEV-15394
+	Skip() bool
 }
 
 // Anonymizer is used to anonymize sensitive data.
@@ -63,7 +67,7 @@ func (anonymizer *Anonymizer) AnonymizeData(memoryRecord *record.MemoryRecord) (
 	anonymizedResult := memoryRecord
 
 	for _, specificAnonymizer := range anonymizer.Anonymizers {
-		if specificAnonymizer.IsEnabled() {
+		if specificAnonymizer.IsEnabled() && !specificAnonymizer.Skip() {
 			anonymizedResult, err = specificAnonymizer.AnonymizeData(memoryRecord)
 			if err != nil {
 				return nil, err

--- a/pkg/anonymization/network_anonymizer.go
+++ b/pkg/anonymization/network_anonymizer.go
@@ -316,6 +316,10 @@ func (na *NetworkAnonymizer) IsEnabled() bool {
 	return false
 }
 
+func (na *NetworkAnonymizer) Skip() bool {
+	return false
+}
+
 func (na *NetworkAnonymizer) readNetworkConfigs() error {
 	if !na.runningInCluster {
 		return nil

--- a/pkg/anonymization/workload_anonymizer.go
+++ b/pkg/anonymization/workload_anonymizer.go
@@ -1,0 +1,71 @@
+package anonymization
+
+import (
+	"context"
+	"slices"
+
+	insightsv1 "github.com/openshift/api/insights/v1"
+	"github.com/openshift/insights-operator/pkg/config"
+	"github.com/openshift/insights-operator/pkg/config/configobserver"
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+type WorkloadAnonymizer struct {
+	configurator configobserver.Interface
+	dataPolicy   insightsv1.DataPolicyOption
+}
+
+func NewWorkloadAnonymizer(
+	ctx context.Context,
+	configurator configobserver.Interface,
+) *WorkloadAnonymizer {
+	return &WorkloadAnonymizer{
+		configurator: configurator,
+	}
+}
+
+func (wa *WorkloadAnonymizer) WithDataPolicies(dataPolicy ...insightsv1.DataPolicyOption) *WorkloadAnonymizer {
+	if slices.Contains(dataPolicy, insightsv1.DataPolicyOptionObfuscateWorkloadNames) {
+		wa.dataPolicy = insightsv1.DataPolicyOptionObfuscateWorkloadNames
+	}
+	return wa
+}
+
+func (wa *WorkloadAnonymizer) IsEnabled() bool {
+	obfuscation := wa.configurator.Config().DataReporting.Obfuscation
+	// support secret still has precedence
+	if obfuscateWorkloadNames(obfuscation) {
+		return true
+	}
+
+	if wa.dataPolicy != "" {
+		return wa.dataPolicy == insightsv1.DataPolicyOptionObfuscateWorkloadNames
+	}
+
+	return false
+}
+
+// obfuscateWorkloadNames tells whether WorkloadNames should be "obfuscated" or not
+func obfuscateWorkloadNames(o config.Obfuscation) bool {
+	for _, ov := range o {
+		if ov == config.WorkloadNames {
+			return true
+		}
+	}
+	return false
+}
+
+func (wa *WorkloadAnonymizer) Skip() bool {
+	return true
+}
+
+// This function should implement WorkloadAnonymization logic, that is now directly in the
+// gather_dvo_metrics gatherer.
+// The issue is tracked here: https://redhat.atlassian.net/browse/CCXDEV-15394
+func (wa *WorkloadAnonymizer) AnonymizeData(memoryRecord *record.MemoryRecord) (*record.MemoryRecord, error) {
+	return nil, nil
+}
+
+func (wa *WorkloadAnonymizer) GetType() AnonymizerType {
+	return WorkloadNamesAnonymizerType
+}

--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -200,8 +200,10 @@ func (g *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 		return err
 	}
 
+	workloadAnonymizer := anonymization.NewWorkloadAnonymizer(ctx, configAggregator).WithDataPolicies(dataGatherCR.Spec.DataPolicy...)
+
 	// anonymizer is responsible for anonymizing sensitive data, it can be configured to disable specific anonymization
-	anonymizer, err := anonymization.NewAnonymizer(networkAnonymizer)
+	anonymizer, err := anonymization.NewAnonymizer(networkAnonymizer, workloadAnonymizer)
 	if err != nil {
 		return err
 	}

--- a/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
+++ b/pkg/gatherers/clusterconfig/gather_dvo_metrics.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
 
-	"github.com/openshift/insights-operator/pkg/config"
+	"github.com/openshift/insights-operator/pkg/anonymization"
 	"github.com/openshift/insights-operator/pkg/record"
 	"github.com/openshift/insights-operator/pkg/types"
 	"github.com/openshift/insights-operator/pkg/utils"
@@ -68,15 +68,17 @@ func (g *Gatherer) GatherDVOMetrics(ctx context.Context) ([]record.Record, []err
 	if err != nil {
 		return nil, []error{err}
 	}
-	obfuscation := g.config().DataReporting.Obfuscation
-	return gatherDVOMetrics(ctx, gatherKubeClient.CoreV1(), g.gatherKubeConfig.RateLimiter, obfuscation)
+
+	obfuscateWokloadNames := g.anonymizer.IsAnonymizerTypeEnabled(anonymization.WorkloadNamesAnonymizerType)
+
+	return gatherDVOMetrics(ctx, gatherKubeClient.CoreV1(), g.gatherKubeConfig.RateLimiter, obfuscateWokloadNames)
 }
 
 func gatherDVOMetrics(
 	ctx context.Context,
 	coreClient corev1client.CoreV1Interface,
 	rateLimiter flowcontrol.RateLimiter,
-	obfuscation config.Obfuscation,
+	obfuscation bool,
 ) ([]record.Record, []error) {
 	serviceList, err := coreClient.Services("").List(ctx, metav1.ListOptions{
 		LabelSelector: dvoServiceLabelSelector,
@@ -101,7 +103,7 @@ func gatherDVOMetrics(
 	for svcIdx := range serviceList.Items {
 		// Use pointer to make gocritic happy and avoid copying the whole Service struct.
 		service := &serviceList.Items[svcIdx]
-		useUIDs = service.Namespace == managedDVONamespaceName || obfuscateDVOMetrics(obfuscation)
+		useUIDs = service.Namespace == managedDVONamespaceName || obfuscation
 
 		for _, port := range service.Spec.Ports {
 			apiURL := url.URL{
@@ -217,14 +219,4 @@ func metricsServiceUp(ctx context.Context, client *rest.RESTClient, apiURL *url.
 		return fmt.Errorf("DVO metrics service was not available within the %s timeout: %v", timeout, err)
 	}
 	return nil
-}
-
-// obfuscateDVOMetrics tells whether DVO metrics should be "obfuscated" or not
-func obfuscateDVOMetrics(o config.Obfuscation) bool {
-	for _, ov := range o {
-		if ov == config.WorkloadNames {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR is adding WorkloadAnonymizer that is used to load correct configuration for obfuscation from ConfigMap, DataGather and InsightsDataGather. The anonymization logic is still implemented directly in the gatherer and should be implemented in the follow up task https://redhat.atlassian.net/browse/CCXDEV-15394.


## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `TODO`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/OCPBUGS-78587