### PR TITLE
CCXDEV-16214: obfuscation preference

### DIFF
--- a/docs/arch.md
+++ b/docs/arch.md
@@ -536,6 +536,32 @@ The following options are available:
 * **`ObfuscateNetworking`**: Obfuscates all IP addresses and cluster domain names found in the gathered data.
 * **`WorkloadNames`**: Obfuscates specific workload names for the Deployment Validation Operator.
 
+### Obfuscation Configuration Precedence
+
+The obfuscation configuration is determined by merging settings from multiple sources:
+
+#### Periodic Gathering
+For periodic gathering, obfuscation settings are determined using the following logic:
+1. **ConfigMap (`insights-config`)** - The `dataReporting.obfuscation` field is always applied if configured
+2. **InsightsDataGather CR** - The `spec.gatherConfig.dataPolicy` field adds additional obfuscation if it is more permissive than the ConfigMap
+3. The final configuration is the **union** of both sources
+
+**Example**: If the ConfigMap specifies `obfuscation: [networking]` and the InsightsDataGather CR specifies `dataPolicy: [WorkloadNames]`, periodic gathering will obfuscate both networking data **and** workload names.
+
+#### On-Demand Gathering
+For on-demand gathering using individual `DataGather` resources:
+1. **ConfigMap (`insights-config`)** - The `dataReporting.obfuscation` field is **always respected**
+2. If the `DataGather` resource specifies `spec.dataPolicy`, it **overrides only the InsightsDataGather CR** settings, not the ConfigMap
+3. If the `DataGather` resource does **not** specify `spec.dataPolicy`, it inherits the same merged configuration as periodic gathering (ConfigMap + InsightsDataGather CR)
+4. The final configuration is the **union** of ConfigMap settings plus DataGather-specific or InsightsDataGather settings
+
+**Example**:
+- ConfigMap has `obfuscation: [networking]`, InsightsDataGather has `dataPolicy: [WorkloadNames]`
+- A DataGather with no `dataPolicy` specified will obfuscate both networking and workload names (ConfigMap + InsightsDataGather)
+- A DataGather with `dataPolicy: [WorkloadNames]` will obfuscate both networking and workload names (ConfigMap is always respected + DataGather overrides InsightsDataGather)
+- A DataGather with `dataPolicy: []` (empty) will obfuscate networking only (ConfigMap is always respected, empty DataGather overrides InsightsDataGather)
+
+
 ```yaml
 apiVersion: insights.openshift.io/v1
 kind: DataGather

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -422,6 +422,34 @@ func (c *Controller) prepareDataGatherCRWithImage(ctx context.Context, dgName st
 		return nil, err
 	}
 
+	// Get InsightsDataGather configuration
+	gatherConfig := c.apiConfigurator.GatherConfig()
+	// Get ConfigMap obfuscation value
+	dataPolicy := c.getConfigMapObfuscation()
+
+	// Merge obfuscation settings from multiple sources with correct precedence:
+	// 1. Start with ConfigMap obfuscation settings (base configuration)
+	// 2. Merge with DataGather.Spec.DataPolicy if present (resource-specific override)
+	// 3. Fall back to InsightsDataGather configuration if DataGather has no policy set
+	// All unique values from each source are combined to ensure comprehensive obfuscation.
+	if len(dataGather.Spec.DataPolicy) > 0 {
+		for _, dataPolicyOption := range dataGather.Spec.DataPolicy {
+			if !slices.Contains(dataPolicy, dataPolicyOption) {
+				dataPolicy = append(dataPolicy, dataPolicyOption)
+			}
+		}
+		// If DataGather has no policy, check InsightsDataGather for cluster-wide defaults
+	} else if gatherConfig != nil && len(gatherConfig.DataPolicy) > 0 {
+		for _, dataPolicyOption := range gatherConfig.DataPolicy {
+			if !slices.Contains(dataPolicy, insightsv1.DataPolicyOption(dataPolicyOption)) {
+				dataPolicy = append(dataPolicy, insightsv1.DataPolicyOption(dataPolicyOption))
+			}
+		}
+	}
+
+	// Assign merged dataPolicy configuration
+	dataGather.Spec.DataPolicy = dataPolicy
+
 	// Avoid running DataGathering for already run jobs
 	if len(dataGather.Status.Conditions) != 0 {
 		klog.Infof("DataGather %s resource not triggering any data gathering, gathering was already run", dgName)
@@ -877,15 +905,10 @@ func (c *Controller) getDataGather(ctx context.Context, dgName string) (*insight
 	return dg, nil
 }
 
-// createDataGatherAttributeValues reads the current "insightsdatagather.config.openshift.io" configuration.
-// It determines which gatherers should be run, based on the configured gathering mode and custom settings.
-// It also extracts the applicable data policies and storage configuration.
-func (c *Controller) createDataGatherAttributeValues() (
-	insightsv1.Gatherers, []insightsv1.DataPolicyOption, insightsv1.Storage,
-) {
-	gatherConfig := c.apiConfigurator.GatherConfig()
-
-	// Read data policy from ConfigMap first
+// getConfigMapObfuscation reads the obfuscation configuration from the ConfigMap
+// (via the config aggregator) and converts it to DataPolicy options used in DataGather resources.
+// It returns a slice of DataPolicyOption values based on the configured obfuscation settings.
+func (c *Controller) getConfigMapObfuscation() []insightsv1.DataPolicyOption {
 	var dataPolicy []insightsv1.DataPolicyOption
 	for _, obfuscationValue := range c.configAggregator.Config().DataReporting.Obfuscation {
 		switch obfuscationValue {
@@ -895,18 +918,29 @@ func (c *Controller) createDataGatherAttributeValues() (
 			dataPolicy = append(dataPolicy, insightsv1.DataPolicyOptionObfuscateWorkloadNames)
 		}
 	}
+	return dataPolicy
+}
 
-	// ConfigMap should take precedence for the obfuscation configuration so use the
-	// InsightsDataGather configuration only if there was none set in a ConfigMap
-	// If there is not configuration in both then no obfuscation should be applied
-	if len(dataPolicy) == 0 && gatherConfig != nil && len(gatherConfig.DataPolicy) > 0 {
-		klog.Infof("Using data policy from InsightsDataGather CR because ConfigMap has no obfuscation settings")
+// createDataGatherAttributeValues reads the current "insightsdatagather.config.openshift.io" configuration.
+// It determines which gatherers should be run, based on the configured gathering mode and custom settings.
+// It also extracts the applicable data policies and storage configuration.
+func (c *Controller) createDataGatherAttributeValues() (
+	insightsv1.Gatherers, []insightsv1.DataPolicyOption, insightsv1.Storage,
+) {
+	// Get InsightsDataGather configuration
+	gatherConfig := c.apiConfigurator.GatherConfig()
+
+	// Get ConfigMap obfuscation value
+	dataPolicy := c.getConfigMapObfuscation()
+
+	// Merge obfuscation settings from multiple sources with correct precedence:
+	// 1. Start with ConfigMap obfuscation settings (base configuration)
+	// 2. Merge with InsightsDataGather if present (resource-specific override)
+	// All unique values from each source are combined to ensure comprehensive obfuscation.
+	if gatherConfig != nil && len(gatherConfig.DataPolicy) > 0 {
 		for _, dataPolicyOption := range gatherConfig.DataPolicy {
-			switch dataPolicyOption {
-			case configv1.DataPolicyOptionObfuscateNetworking:
-				dataPolicy = append(dataPolicy, insightsv1.DataPolicyOptionObfuscateNetworking)
-			case configv1.DataPolicyOptionObfuscateWorkloadNames:
-				dataPolicy = append(dataPolicy, insightsv1.DataPolicyOptionObfuscateWorkloadNames)
+			if !slices.Contains(dataPolicy, insightsv1.DataPolicyOption(dataPolicyOption)) {
+				dataPolicy = append(dataPolicy, insightsv1.DataPolicyOption(dataPolicyOption))
 			}
 		}
 	}

--- a/pkg/controller/periodic/periodic_test.go
+++ b/pkg/controller/periodic/periodic_test.go
@@ -798,7 +798,7 @@ func TestCreateDataGatherAttributeValues_ConfigMapObfuscationPrecedence(t *testi
 		expectedPolicy       []insightsv1.DataPolicyOption
 	}{
 		{
-			name: "ConfigMap obfuscation takes precedence over InsightsDataGather CR",
+			name: "Both ConfigMap InsightsDataGather CR configuration is used",
 			gatherConfig: configv1.GatherConfig{
 				DataPolicy: []configv1.DataPolicyOption{
 					configv1.DataPolicyOptionObfuscateWorkloadNames,
@@ -810,6 +810,7 @@ func TestCreateDataGatherAttributeValues_ConfigMapObfuscationPrecedence(t *testi
 			configMapObfuscation: config.Obfuscation{config.Networking},
 			expectedPolicy: []insightsv1.DataPolicyOption{
 				insightsv1.DataPolicyOptionObfuscateNetworking,
+				insightsv1.DataPolicyOptionObfuscateWorkloadNames,
 			},
 		},
 		{
@@ -830,7 +831,7 @@ func TestCreateDataGatherAttributeValues_ConfigMapObfuscationPrecedence(t *testi
 			},
 		},
 		{
-			name: "ConfigMap with both obfuscation types overrides InsightsDataGather CR",
+			name: "ConfigMap with both obfuscation options and empty InsightsDataGather",
 			gatherConfig: configv1.GatherConfig{
 				DataPolicy: []configv1.DataPolicyOption{},
 				Gatherers: configv1.Gatherers{
@@ -1970,7 +1971,24 @@ func TestGetDataGatherCR(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			insightsClientset := insightsFakeCli.NewClientset(tt.dataGather)
 			kubeClientset := kubefake.NewClientset(tt.deployment)
-			mockController := NewWithTechPreview(nil, nil, nil, nil, kubeClientset, insightsClientset.InsightsV1(), nil, nil, nil, nil)
+			apiConfig := NewInsightsDataGatherObserverMock(
+				[]configv1.DataPolicyOption{},
+				configv1.Gatherers{},
+			)
+			mockConfigMapConfigurator := config.NewMockConfigMapConfigurator(&config.InsightsConfiguration{
+				DataReporting: config.DataReporting{
+					Obfuscation: config.Obfuscation{},
+				},
+			})
+			mockController := NewWithTechPreview(
+				nil,
+				mockConfigMapConfigurator,
+				apiConfig,
+				nil,
+				kubeClientset,
+				insightsClientset.InsightsV1(),
+				nil, nil, nil, nil,
+			)
 			mockController.image = tt.controllerImage
 
 			result, err := mockController.prepareDataGatherCRWithImage(context.Background(), tt.dataGather.Name)


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR implements obfuscation precedence for on-demand and periodic jobs to match the rules defined in `docs/arch.md`.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [X] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/arch.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/controller/periodic/periodic_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CCXDEV-16214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide on obfuscation configuration precedence with explicit examples covering ConfigMap, periodic (cluster-wide), and on-demand gather behaviors, including empty overrides.

* **Refactor**
  * Updated obfuscation merge logic to always start from ConfigMap-derived settings and produce a de-duplicated union with periodic and on-demand policies.

* **Tests**
  * Updated test scenarios and mocks to validate the new merged obfuscation precedence and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->