### PR TITLE
OCPBUGS-77351: fix: add terminationMessagePolicy to runtime extractor containers

### DIFF
--- a/manifests/10-insights-runtime-extractor.yaml
+++ b/manifests/10-insights-runtime-extractor.yaml
@@ -69,6 +69,7 @@ spec:
         - name: exporter
           image: quay.io/openshift/origin-insights-runtime-exporter:latest
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /data
               name: data-volume
@@ -79,13 +80,14 @@ spec:
             capabilities:
               drop:
                 - ALL
-          resources: 
+          resources:
             requests:
               cpu: 10m
               memory: 200Mi
         - name: extractor
           image: quay.io/openshift/origin-insights-runtime-extractor:latest
           imagePullPolicy: Always
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: CONTAINER_RUNTIME_ENDPOINT
               value: unix:///crio.sock
@@ -98,7 +100,7 @@ spec:
                 - info
               periodSeconds: 30
               timeoutSeconds: 10
-          resources: 
+          resources:
             requests:
               cpu: 10m
               memory: 200Mi


### PR DESCRIPTION
The exporter and extractor containers in the insights-runtime-extractor DaemonSet were missing terminationMessagePolicy=FallbackToLogsOnError, causing CI test failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved infrastructure stability and resource management by configuring container resource requests (CPU/memory) and implementing proper termination handling policies for the runtime extractor deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->