### PR TITLE
OCPBUGS-85710: add trusted-ca-bundle to gatherin job

### DIFF
--- a/pkg/controller/periodic/job.go
+++ b/pkg/controller/periodic/job.go
@@ -86,6 +86,17 @@ func (j *JobController) CreateGathererJob(
 								},
 							},
 						},
+						{
+							Name: trustedCABundle,
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: trustedCABundle,
+									},
+									Optional: ptr.To(true),
+								},
+							},
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -206,6 +217,11 @@ func (j *JobController) createVolumeMounts(storagePath string, storage insightsv
 		{
 			Name:      serviceCABundle,
 			MountPath: serviceCABundlePath,
+		},
+		{
+			Name:      trustedCABundle,
+			MountPath: trustedCABundlePath,
+			ReadOnly:  true,
 		},
 	}
 

--- a/pkg/controller/periodic/job_test.go
+++ b/pkg/controller/periodic/job_test.go
@@ -91,7 +91,7 @@ func TestCreateGathererJob(t *testing.T) {
 			}
 
 			// we mount to volumes
-			assert.Len(t, createdJob.Spec.Template.Spec.Containers[0].VolumeMounts, 2)
+			assert.Len(t, createdJob.Spec.Template.Spec.Containers[0].VolumeMounts, 3)
 			assert.Equal(t, tt.dataReporting.StoragePath, createdJob.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
 		})
 	}

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -43,6 +43,8 @@ const (
 	defaultStoragePath               = "/var/lib/insights-operator"
 	serviceCABundle                  = "service-ca-bundle"
 	serviceCABundlePath              = "/var/run/configmaps/service-ca-bundle"
+	trustedCABundle                  = "trusted-ca-bundle"
+	trustedCABundlePath              = "/var/run/configmaps/trusted-ca-bundle"
 	insightsNamespace                = "openshift-insights"
 	dataUplodedConditionNotAvailable = "DataUploadedConditionNotAvailable"
 	gatheringDisabledReason          = "GatheringDisabled"


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Add missing trusted-ca-bundle volume mount required for successful archive upload when HTTPS proxy is configured. Without this mount, the gathering job cannot verify proxy certificates.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `None`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- `None`

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/OCPBUGS-85710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Periodic job pods now support trusted CA bundle volumes sourced from ConfigMaps. Volumes are mounted as read-only in containers with configurable mount paths, maintaining compatibility with existing job configurations.

* **Tests**
  * Tests updated to verify proper volume mount configuration in periodic job pod specifications and definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->