### PR TITLE
OCPBUGS-98382: controlplanemachinesets gatherer

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -801,6 +801,33 @@ The gatherer finds the Pods (and containers) that match the requested data and f
 to match the specific messages up to a maximum of 6 hours old.
 
 
+## ControlPlaneMachineSet
+
+Collects `ControlPlaneMachineSet` information.
+
+### API Reference
+- https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/machine_apis/controlplanemachineset-machine-openshift-io-v1
+
+### Sample data
+- [docs/insights-archive-sample/config/controlplanemachinesets/openshift-machine-api/cluster.json](./insights-archive-sample/config/controlplanemachinesets/openshift-machine-api/cluster.json)
+
+### Location in archive
+- `config/controlplanemachinesets/{resource}`
+- `config/controlplanemachinesets/{namespace}/{resource}`
+
+### Config ID
+`clusterconfig/control_plane_machine_sets`
+
+### Released version
+- 4.23.0
+
+### Backported versions
+- 4.19
+
+### Changes
+None
+
+
 ## CostManagementMetricsConfigs
 
 Collects `CostManagementMetricsConfigs` definitions.

--- a/docs/insights-archive-sample/config/controlplanemachinesets/openshift-machine-api/cluster.json
+++ b/docs/insights-archive-sample/config/controlplanemachinesets/openshift-machine-api/cluster.json
@@ -1,186 +1,70 @@
 {
-  "apiVersion": "machine.openshift.io/v1",
-  "kind": "ControlPlaneMachineSet",
-  "metadata": {
-    "creationTimestamp": "2026-05-25T07:17:02Z",
-    "finalizers": ["controlplanemachineset.machine.openshift.io"],
-    "generation": 1,
-    "labels": {
-      "machine.openshift.io/cluster-api-cluster": "ci-ln-ih1mx5b-76ef8-x2hzs"
+    "apiVersion": "machine.openshift.io/v1",
+    "kind": "ControlPlaneMachineSet",
+    "metadata": {
+        "creationTimestamp": "2026-05-27T10:18:50Z",
+        "finalizers": ["controlplanemachineset.machine.openshift.io"],
+        "generation": 1,
+        "labels": {
+            "machine.openshift.io/cluster-api-cluster": "ci-ln-vwyf9k2-76ef8-r5shb"
+        },
+        "name": "cluster",
+        "namespace": "openshift-machine-api",
+        "resourceVersion": "16052",
+        "uid": "00ceb81c-e5c8-49d0-b240-87e997bb3f8c"
     },
-    "name": "cluster",
-    "namespace": "openshift-machine-api",
-    "resourceVersion": "15315",
-    "uid": "fb397d63-c31e-469d-a87d-acaeb31f9ea0"
-  },
-  "spec": {
-    "replicas": 3,
-    "selector": {
-      "matchLabels": {
-        "machine.openshift.io/cluster-api-cluster": "ci-ln-ih1mx5b-76ef8-x2hzs",
-        "machine.openshift.io/cluster-api-machine-role": "master",
-        "machine.openshift.io/cluster-api-machine-type": "master"
-      }
+    "spec": {
+        "replicas": 3,
+        "selector": {
+            "matchLabels": {
+                "machine.openshift.io/cluster-api-cluster": "ci-ln-vwyf9k2-76ef8-r5shb",
+                "machine.openshift.io/cluster-api-machine-role": "master",
+                "machine.openshift.io/cluster-api-machine-type": "master"
+            }
+        },
+        "state": "Active",
+        "strategy": { "type": "RollingUpdate" },
+        "template": null,
+        "templates": null
     },
-    "state": "Active",
-    "strategy": { "type": "RollingUpdate" },
-    "template": {
-      "machineType": "machines_v1beta1_machine_openshift_io",
-      "machines_v1beta1_machine_openshift_io": {
-        "failureDomains": {
-          "aws": [
+    "status": {
+        "conditions": [
             {
-              "placement": { "availabilityZone": "us-west-1a" },
-              "subnet": {
-                "filters": [
-                  {
-                    "name": "tag:Name",
-                    "values": [
-                      "ci-ln-ih1mx5b-76ef8-x2hzs-subnet-private-us-west-1a"
-                    ]
-                  }
-                ],
-                "type": "Filters"
-              }
+                "lastTransitionTime": "2026-05-27T10:22:45Z",
+                "message": "",
+                "observedGeneration": 1,
+                "reason": "AsExpected",
+                "status": "False",
+                "type": "Error"
             },
             {
-              "placement": { "availabilityZone": "us-west-1c" },
-              "subnet": {
-                "filters": [
-                  {
-                    "name": "tag:Name",
-                    "values": [
-                      "ci-ln-ih1mx5b-76ef8-x2hzs-subnet-private-us-west-1c"
-                    ]
-                  }
-                ],
-                "type": "Filters"
-              }
+                "lastTransitionTime": "2026-05-27T10:27:53Z",
+                "message": "",
+                "observedGeneration": 1,
+                "reason": "AllReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "lastTransitionTime": "2026-05-27T10:27:53Z",
+                "message": "",
+                "observedGeneration": 1,
+                "reason": "AsExpected",
+                "status": "False",
+                "type": "Degraded"
+            },
+            {
+                "lastTransitionTime": "2026-05-27T10:26:53Z",
+                "message": "",
+                "observedGeneration": 1,
+                "reason": "AllReplicasUpdated",
+                "status": "False",
+                "type": "Progressing"
             }
-          ],
-          "platform": "AWS"
-        },
-        "metadata": {
-          "labels": {
-            "machine.openshift.io/cluster-api-cluster": "ci-ln-ih1mx5b-76ef8-x2hzs",
-            "machine.openshift.io/cluster-api-machine-role": "master",
-            "machine.openshift.io/cluster-api-machine-type": "master"
-          }
-        },
-        "spec": {
-          "lifecycleHooks": {},
-          "metadata": {},
-          "providerSpec": {
-            "value": {
-              "ami": { "id": "ami-068a9cb3ccfa0ef0f" },
-              "apiVersion": "machine.openshift.io/v1beta1",
-              "blockDevices": [
-                {
-                  "ebs": {
-                    "encrypted": true,
-                    "iops": 0,
-                    "kmsKey": { "arn": "" },
-                    "volumeSize": 120,
-                    "volumeType": "gp3"
-                  }
-                }
-              ],
-              "capacityReservationId": "",
-              "credentialsSecret": { "name": "aws-cloud-credentials" },
-              "deviceIndex": 0,
-              "iamInstanceProfile": {
-                "id": "ci-ln-ih1mx5b-76ef8-x2hzs-master-profile"
-              },
-              "instanceType": "m6a.xlarge",
-              "kind": "AWSMachineProviderConfig",
-              "loadBalancers": [
-                { "name": "ci-ln-ih1mx5b-76ef8-x2hzs-int", "type": "network" },
-                { "name": "ci-ln-ih1mx5b-76ef8-x2hzs-ext", "type": "network" }
-              ],
-              "metadata": {},
-              "metadataServiceOptions": {},
-              "placement": { "region": "us-west-1" },
-              "securityGroups": [
-                {
-                  "filters": [
-                    {
-                      "name": "tag:Name",
-                      "values": ["ci-ln-ih1mx5b-76ef8-x2hzs-node"]
-                    }
-                  ]
-                },
-                {
-                  "filters": [
-                    {
-                      "name": "tag:Name",
-                      "values": ["ci-ln-ih1mx5b-76ef8-x2hzs-lb"]
-                    }
-                  ]
-                },
-                {
-                  "filters": [
-                    {
-                      "name": "tag:Name",
-                      "values": ["ci-ln-ih1mx5b-76ef8-x2hzs-controlplane"]
-                    }
-                  ]
-                }
-              ],
-              "subnet": {},
-              "tags": [
-                {
-                  "name": "kubernetes.io/cluster/ci-ln-ih1mx5b-76ef8-x2hzs",
-                  "value": "owned"
-                },
-                { "name": "ci-nat-replace", "value": "true" },
-                { "name": "clusterName", "value": "ci-ln-ih1mx5b-76ef8" },
-                { "name": "expirationDate", "value": "2026-05-25T15:00+00:00" }
-              ],
-              "userDataSecret": { "name": "master-user-data" }
-            }
-          }
-        }
-      }
+        ],
+        "observedGeneration": 1,
+        "readyReplicas": 3,
+        "replicas": 3,
+        "updatedReplicas": 3
     }
-  },
-  "status": {
-    "conditions": [
-      {
-        "lastTransitionTime": "2026-05-25T07:20:05Z",
-        "message": "",
-        "observedGeneration": 1,
-        "reason": "AsExpected",
-        "status": "False",
-        "type": "Error"
-      },
-      {
-        "lastTransitionTime": "2026-05-25T07:25:09Z",
-        "message": "",
-        "observedGeneration": 1,
-        "reason": "AllReplicasAvailable",
-        "status": "True",
-        "type": "Available"
-      },
-      {
-        "lastTransitionTime": "2026-05-25T07:25:09Z",
-        "message": "",
-        "observedGeneration": 1,
-        "reason": "AsExpected",
-        "status": "False",
-        "type": "Degraded"
-      },
-      {
-        "lastTransitionTime": "2026-05-25T07:23:09Z",
-        "message": "",
-        "observedGeneration": 1,
-        "reason": "AllReplicasUpdated",
-        "status": "False",
-        "type": "Progressing"
-      }
-    ],
-    "observedGeneration": 1,
-    "readyReplicas": 3,
-    "replicas": 3,
-    "updatedReplicas": 3
-  }
 }

--- a/docs/insights-archive-sample/config/controlplanemachinesets/openshift-machine-api/cluster.json
+++ b/docs/insights-archive-sample/config/controlplanemachinesets/openshift-machine-api/cluster.json
@@ -1,0 +1,186 @@
+{
+  "apiVersion": "machine.openshift.io/v1",
+  "kind": "ControlPlaneMachineSet",
+  "metadata": {
+    "creationTimestamp": "2026-05-25T07:17:02Z",
+    "finalizers": ["controlplanemachineset.machine.openshift.io"],
+    "generation": 1,
+    "labels": {
+      "machine.openshift.io/cluster-api-cluster": "ci-ln-ih1mx5b-76ef8-x2hzs"
+    },
+    "name": "cluster",
+    "namespace": "openshift-machine-api",
+    "resourceVersion": "15315",
+    "uid": "fb397d63-c31e-469d-a87d-acaeb31f9ea0"
+  },
+  "spec": {
+    "replicas": 3,
+    "selector": {
+      "matchLabels": {
+        "machine.openshift.io/cluster-api-cluster": "ci-ln-ih1mx5b-76ef8-x2hzs",
+        "machine.openshift.io/cluster-api-machine-role": "master",
+        "machine.openshift.io/cluster-api-machine-type": "master"
+      }
+    },
+    "state": "Active",
+    "strategy": { "type": "RollingUpdate" },
+    "template": {
+      "machineType": "machines_v1beta1_machine_openshift_io",
+      "machines_v1beta1_machine_openshift_io": {
+        "failureDomains": {
+          "aws": [
+            {
+              "placement": { "availabilityZone": "us-west-1a" },
+              "subnet": {
+                "filters": [
+                  {
+                    "name": "tag:Name",
+                    "values": [
+                      "ci-ln-ih1mx5b-76ef8-x2hzs-subnet-private-us-west-1a"
+                    ]
+                  }
+                ],
+                "type": "Filters"
+              }
+            },
+            {
+              "placement": { "availabilityZone": "us-west-1c" },
+              "subnet": {
+                "filters": [
+                  {
+                    "name": "tag:Name",
+                    "values": [
+                      "ci-ln-ih1mx5b-76ef8-x2hzs-subnet-private-us-west-1c"
+                    ]
+                  }
+                ],
+                "type": "Filters"
+              }
+            }
+          ],
+          "platform": "AWS"
+        },
+        "metadata": {
+          "labels": {
+            "machine.openshift.io/cluster-api-cluster": "ci-ln-ih1mx5b-76ef8-x2hzs",
+            "machine.openshift.io/cluster-api-machine-role": "master",
+            "machine.openshift.io/cluster-api-machine-type": "master"
+          }
+        },
+        "spec": {
+          "lifecycleHooks": {},
+          "metadata": {},
+          "providerSpec": {
+            "value": {
+              "ami": { "id": "ami-068a9cb3ccfa0ef0f" },
+              "apiVersion": "machine.openshift.io/v1beta1",
+              "blockDevices": [
+                {
+                  "ebs": {
+                    "encrypted": true,
+                    "iops": 0,
+                    "kmsKey": { "arn": "" },
+                    "volumeSize": 120,
+                    "volumeType": "gp3"
+                  }
+                }
+              ],
+              "capacityReservationId": "",
+              "credentialsSecret": { "name": "aws-cloud-credentials" },
+              "deviceIndex": 0,
+              "iamInstanceProfile": {
+                "id": "ci-ln-ih1mx5b-76ef8-x2hzs-master-profile"
+              },
+              "instanceType": "m6a.xlarge",
+              "kind": "AWSMachineProviderConfig",
+              "loadBalancers": [
+                { "name": "ci-ln-ih1mx5b-76ef8-x2hzs-int", "type": "network" },
+                { "name": "ci-ln-ih1mx5b-76ef8-x2hzs-ext", "type": "network" }
+              ],
+              "metadata": {},
+              "metadataServiceOptions": {},
+              "placement": { "region": "us-west-1" },
+              "securityGroups": [
+                {
+                  "filters": [
+                    {
+                      "name": "tag:Name",
+                      "values": ["ci-ln-ih1mx5b-76ef8-x2hzs-node"]
+                    }
+                  ]
+                },
+                {
+                  "filters": [
+                    {
+                      "name": "tag:Name",
+                      "values": ["ci-ln-ih1mx5b-76ef8-x2hzs-lb"]
+                    }
+                  ]
+                },
+                {
+                  "filters": [
+                    {
+                      "name": "tag:Name",
+                      "values": ["ci-ln-ih1mx5b-76ef8-x2hzs-controlplane"]
+                    }
+                  ]
+                }
+              ],
+              "subnet": {},
+              "tags": [
+                {
+                  "name": "kubernetes.io/cluster/ci-ln-ih1mx5b-76ef8-x2hzs",
+                  "value": "owned"
+                },
+                { "name": "ci-nat-replace", "value": "true" },
+                { "name": "clusterName", "value": "ci-ln-ih1mx5b-76ef8" },
+                { "name": "expirationDate", "value": "2026-05-25T15:00+00:00" }
+              ],
+              "userDataSecret": { "name": "master-user-data" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "status": {
+    "conditions": [
+      {
+        "lastTransitionTime": "2026-05-25T07:20:05Z",
+        "message": "",
+        "observedGeneration": 1,
+        "reason": "AsExpected",
+        "status": "False",
+        "type": "Error"
+      },
+      {
+        "lastTransitionTime": "2026-05-25T07:25:09Z",
+        "message": "",
+        "observedGeneration": 1,
+        "reason": "AllReplicasAvailable",
+        "status": "True",
+        "type": "Available"
+      },
+      {
+        "lastTransitionTime": "2026-05-25T07:25:09Z",
+        "message": "",
+        "observedGeneration": 1,
+        "reason": "AsExpected",
+        "status": "False",
+        "type": "Degraded"
+      },
+      {
+        "lastTransitionTime": "2026-05-25T07:23:09Z",
+        "message": "",
+        "observedGeneration": 1,
+        "reason": "AllReplicasUpdated",
+        "status": "False",
+        "type": "Progressing"
+      }
+    ],
+    "observedGeneration": 1,
+    "readyReplicas": 3,
+    "replicas": 3,
+    "updatedReplicas": 3
+  }
+}

--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -247,6 +247,7 @@ rules:
       - machine.openshift.io
     resources:
       - machinesets
+      - controlplanemachineset
     verbs:
       - get
       - list

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -36,6 +36,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"config_maps":                      (*Gatherer).GatherConfigMaps,
 	"container_images":                 (*Gatherer).GatherContainerImages,
 	"container_runtime_configs":        (*Gatherer).GatherContainerRuntimeConfig,
+	"control_plane_machine_sets":       (*Gatherer).GatherControlPlaneMachineSet,
 	"cost_management_metrics_configs":  (*Gatherer).GatherCostManagementMetricsConfigs,
 	"crds":                             (*Gatherer).GatherCRD,
 	"dvo_metrics":                      (*Gatherer).GatherDVOMetrics,

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -98,6 +98,11 @@ var (
 		Version:  "v1alpha1",
 		Resource: "subscriptions",
 	}
+	controlPlaneMachineSetVersionResource = schema.GroupVersionResource{
+		Group:    "machine.openshift.io",
+		Version:  "v1",
+		Resource: "controlplanemachinesets",
+	}
 
 	nodeNetConfPoliciesV1GVR = schema.GroupVersionResource{Group: "nmstate.io", Version: "v1", Resource: "nodenetworkconfigurationpolicies"}
 	nodeNetStatesV1Beta1GVR  = schema.GroupVersionResource{Group: "nmstate.io", Version: "v1beta1", Resource: "nodenetworkstates"}

--- a/pkg/gatherers/clusterconfig/gather_control_plane_machine_sets.go
+++ b/pkg/gatherers/clusterconfig/gather_control_plane_machine_sets.go
@@ -7,7 +7,9 @@ import (
 	"github.com/openshift/insights-operator/pkg/record"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
 )
 
 // GatherControlPlaneMachineSet Collects `ControlPlaneMachineSet` information.
@@ -51,17 +53,32 @@ func gatherControlPlaneMachineSet(ctx context.Context, dynamicClient dynamic.Int
 		return nil, []error{err}
 	}
 
+	var errs []error
 	var records []record.Record
 	for _, ms := range controlPlaneMachineSets.Items {
 		recordName := fmt.Sprintf("config/controlplanemachinesets/%s", ms.GetName())
 		if ms.GetNamespace() != "" {
 			recordName = fmt.Sprintf("config/controlplanemachinesets/%s/%s", ms.GetNamespace(), ms.GetName())
 		}
+
+		// remove the sensitive content by overwriting the values
+		err = unstructured.SetNestedField(ms.Object, nil, "spec", "templates")
+		if err != nil {
+			klog.Errorf("unable to set nested field: %v", err)
+			errs = append(errs, err)
+		}
+
+		err = unstructured.SetNestedField(ms.Object, nil, "spec", "template")
+		if err != nil {
+			klog.Errorf("unable to set nested field: %v", err)
+			errs = append(errs, err)
+		}
+
 		records = append(records, record.Record{
 			Name: recordName,
 			Item: record.ResourceMarshaller{Resource: &ms},
 		})
 	}
 
-	return records, nil
+	return records, errs
 }

--- a/pkg/gatherers/clusterconfig/gather_control_plane_machine_sets.go
+++ b/pkg/gatherers/clusterconfig/gather_control_plane_machine_sets.go
@@ -1,0 +1,67 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+// GatherControlPlaneMachineSet Collects `ControlPlaneMachineSet` information.
+//
+// ### API Reference
+// - https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/machine_apis/controlplanemachineset-machine-openshift-io-v1
+//
+// ### Sample data
+// - docs/insights-archive-sample/config/controlplanemachinesets/openshift-machine-api/cluster.json
+//
+// ### Location in archive
+// - `config/controlplanemachinesets/{resource}`
+// - `config/controlplanemachinesets/{namespace}/{resource}`
+//
+// ### Config ID
+// `clusterconfig/control_plane_machine_sets`
+//
+// ### Released version
+// - 4.23.0
+//
+// ### Backported versions
+// - 4.19
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherControlPlaneMachineSet(ctx context.Context) ([]record.Record, []error) {
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherControlPlaneMachineSet(ctx, dynamicClient)
+}
+
+func gatherControlPlaneMachineSet(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	controlPlaneMachineSets, err := dynamicClient.Resource(controlPlaneMachineSetVersionResource).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	var records []record.Record
+	for _, ms := range controlPlaneMachineSets.Items {
+		recordName := fmt.Sprintf("config/controlplanemachinesets/%s", ms.GetName())
+		if ms.GetNamespace() != "" {
+			recordName = fmt.Sprintf("config/controlplanemachinesets/%s/%s", ms.GetNamespace(), ms.GetName())
+		}
+		records = append(records, record.Record{
+			Name: recordName,
+			Item: record.ResourceMarshaller{Resource: &ms},
+		})
+	}
+
+	return records, nil
+}

--- a/pkg/gatherers/clusterconfig/gather_control_plane_machine_sets_test.go
+++ b/pkg/gatherers/clusterconfig/gather_control_plane_machine_sets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/openshift/insights-operator/pkg/record"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -19,6 +20,19 @@ apiVersion: machine.openshift.io/v1
 kind: ControlPlaneMachineSet
 metadata:
     name: cluster
+spec:
+    replicas: 3
+    template:
+        machineType: machines_v1beta1_machine_openshift_io
+        machines_v1beta1_machine_openshift_io:
+            metadata:
+                labels:
+                    machine.openshift.io/cluster-api-cluster: cluster
+            spec:
+                providerSpec:
+                    value:
+                        apiVersion: machine.openshift.io/v1beta1
+                        kind: AWSMachineProviderConfig
 `
 
 	controlPlaneMachineSet2YAML = `
@@ -27,6 +41,19 @@ kind: ControlPlaneMachineSet
 metadata:
     name: cluster-2
     namespace: openshift-machine-api
+spec:
+    replicas: 3
+    templates:
+        - machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+              metadata:
+                  labels:
+                      machine.openshift.io/cluster-api-cluster: cluster
+              spec:
+                  providerSpec:
+                      value:
+                          apiVersion: machine.openshift.io/v1beta1
+                          kind: AWSMachineProviderConfig
 `
 )
 
@@ -109,8 +136,37 @@ func Test_GatherControlPlaneMachineSet(t *testing.T) {
 			assert.Len(t, records, tt.expectedRecordCount)
 
 			recordNames := make(map[string]bool)
-			for _, record := range records {
-				recordNames[record.Name] = true
+			for _, rec := range records {
+				recordNames[rec.Name] = true
+
+				// Verify that sensitive fields have been removed
+				if tt.expectedRecordCount > 0 {
+					marshaller := rec.Item.(record.ResourceMarshaller)
+					unstructuredObj, ok := marshaller.Resource.(*unstructured.Unstructured)
+					assert.True(t, ok, "expected unstructured.Unstructured type")
+					if ok {
+						// Verify spec.template is removed
+						template, found, err := unstructured.NestedFieldNoCopy(unstructuredObj.Object, "spec", "template")
+						assert.NoError(t, err)
+						if found {
+							assert.Nil(t, template, "spec.template should be nil after sanitization")
+						}
+
+						// Verify spec.templates is removed
+						templates, found, err := unstructured.NestedFieldNoCopy(unstructuredObj.Object, "spec", "templates")
+						assert.NoError(t, err)
+						if found {
+							assert.Nil(t, templates, "spec.templates should be nil after sanitization")
+						}
+
+						// Verify other fields like replicas are still present
+						replicas, found, err := unstructured.NestedInt64(unstructuredObj.Object, "spec", "replicas")
+						assert.NoError(t, err)
+						if found {
+							assert.Equal(t, int64(3), replicas, "spec.replicas should still be present")
+						}
+					}
+				}
 			}
 			for _, expectedName := range tt.expectedRecordNames {
 				assert.True(t, recordNames[expectedName], "missing expected record: %s", expectedName)

--- a/pkg/gatherers/clusterconfig/gather_control_plane_machine_sets_test.go
+++ b/pkg/gatherers/clusterconfig/gather_control_plane_machine_sets_test.go
@@ -1,0 +1,120 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+const (
+	controlPlaneMachineSetYAML = `
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+    name: cluster
+`
+
+	controlPlaneMachineSet2YAML = `
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+    name: cluster-2
+    namespace: openshift-machine-api
+`
+)
+
+func Test_GatherControlPlaneMachineSet(t *testing.T) {
+	tests := []struct {
+		name                string
+		objects             []string
+		namespaces          []string
+		expectedRecordCount int
+		expectedRecordNames []string
+	}{
+		{
+			name:                "single resource with namespace",
+			objects:             []string{controlPlaneMachineSetYAML},
+			namespaces:          []string{"openshift-machine-api"},
+			expectedRecordCount: 1,
+			expectedRecordNames: []string{"config/controlplanemachinesets/openshift-machine-api/cluster"},
+		},
+		{
+			name:                "single resource without namespace",
+			objects:             []string{controlPlaneMachineSetYAML},
+			namespaces:          []string{""},
+			expectedRecordCount: 1,
+			expectedRecordNames: []string{"config/controlplanemachinesets/cluster"},
+		},
+		{
+			name:                "empty list",
+			objects:             []string{},
+			namespaces:          []string{},
+			expectedRecordCount: 0,
+			expectedRecordNames: []string{},
+		},
+		{
+			name:                "multiple resources",
+			objects:             []string{controlPlaneMachineSetYAML, controlPlaneMachineSet2YAML},
+			namespaces:          []string{"openshift-machine-api", "openshift-machine-api"},
+			expectedRecordCount: 2,
+			expectedRecordNames: []string{
+				"config/controlplanemachinesets/openshift-machine-api/cluster",
+				"config/controlplanemachinesets/openshift-machine-api/cluster-2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+				controlPlaneMachineSetVersionResource: "ControlPlaneMachineSetList",
+			})
+			decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+
+			for i, objYAML := range tt.objects {
+				obj := &unstructured.Unstructured{}
+				_, _, err := decUnstructured.Decode([]byte(objYAML), nil, obj)
+				if err != nil {
+					t.Fatalf("unable to decode controlplanemachineset %d: %v", i, err)
+				}
+
+				if tt.namespaces[i] != "" {
+					_, err = client.Resource(controlPlaneMachineSetVersionResource).Namespace(tt.namespaces[i]).Create(
+						context.Background(),
+						obj,
+						metav1.CreateOptions{},
+					)
+				} else {
+					_, err = client.Resource(controlPlaneMachineSetVersionResource).Create(
+						context.Background(),
+						obj,
+						metav1.CreateOptions{},
+					)
+				}
+				if err != nil {
+					t.Fatalf("unable to create fake controlplanemachineset %d: %v", i, err)
+				}
+			}
+
+			ctx := context.Background()
+			records, errs := gatherControlPlaneMachineSet(ctx, client)
+			assert.Empty(t, errs)
+			assert.Len(t, records, tt.expectedRecordCount)
+
+			recordNames := make(map[string]bool)
+			for _, record := range records {
+				recordNames[record.Name] = true
+			}
+			for _, expectedName := range tt.expectedRecordNames {
+				assert.True(t, recordNames[expectedName], "missing expected record: %s", expectedName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

This PR implements a ControlPlaneMachineSet gatherer.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/controlplanemachinesets/openshift-machine-api/cluster.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_control_plane_machine_sets_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CCXDEV-16092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added capability to gather and collect control plane machine set information from OpenShift clusters, including configuration and status details.

* **Documentation**
  * Updated documentation with details on control plane machine set data collection, including sample data locations and archival patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->