### PR TITLE
OCPBUGS-78774: kube-rbac-proxy must honor Central TLS configuration

### DIFF
--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -450,7 +450,7 @@ func createTechPreviewInformers(
 
 // fetchTLSProfile reads the TLS security profile from the cluster's APIServer configuration.
 // Returns nil if the profile cannot be read, which will default to Intermediate.
-func fetchTLSProfile(ctx context.Context, configClient *configv1client.Clientset) *configv1.TLSSecurityProfile {
+func fetchTLSProfile(ctx context.Context, configClient configv1client.Interface) *configv1.TLSSecurityProfile {
 	apiServer, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		klog.Warningf("Failed to get APIServer config, defaulting to Intermediate TLS profile: %v", err)

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/features"
 	insightsv1 "github.com/openshift/api/insights/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
@@ -28,7 +29,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/insights-operator/pkg/anonymization"
@@ -145,21 +145,10 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 
 	// updateCh is used to signal a version update to the runtimeextractor controller
 	updateCh := make(chan struct{}, 1)
-	tlsProfileCh := make(chan struct{}, 1)
 
-	// Watch for TLS security profile changes on the APIServer resource
-	if _, err := configInformers.Config().V1().APIServers().Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			UpdateFunc: func(_, _ interface{}) {
-				select {
-				case tlsProfileCh <- struct{}{}:
-				default:
-				}
-			},
-		},
-	); err != nil {
-		return fmt.Errorf("failed to add APIServer event handler: %w", err)
-	}
+	// Fetch TLS profile once at startup. The operator is restarted by the SecurityProfileWatcher
+	// in manager.go when the TLS profile changes, so no watch is needed here.
+	tlsProfile := fetchTLSProfile(ctx, configClient)
 
 	// Create informer factory for runtime-extractor resources in openshift-insights namespace
 	runtimeExtractorInformerFactory := clientInformers.NewSharedInformerFactoryWithOptions(
@@ -185,9 +174,8 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	runtimeExtractorCtrl := runtimeextractor.NewRuntimeExtractorController(
 		configAggregator,
 		updateCh,
-		tlsProfileCh,
+		tlsProfile,
 		kubeClient,
-		configClient,
 		controller.EventRecorder,
 		runtimeExtractorResourceInformer,
 	)
@@ -458,6 +446,17 @@ func createTechPreviewInformers(
 		JobInformer:        jobInformer,
 		DataGatherInformer: dgInformer,
 	}, nil
+}
+
+// fetchTLSProfile reads the TLS security profile from the cluster's APIServer configuration.
+// Returns nil if the profile cannot be read, which will default to Intermediate.
+func fetchTLSProfile(ctx context.Context, configClient *configv1client.Clientset) *configv1.TLSSecurityProfile {
+	apiServer, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("Failed to get APIServer config, defaulting to Intermediate TLS profile: %v", err)
+		return nil
+	}
+	return apiServer.Spec.TLSSecurityProfile
 }
 
 // deleteAllRunningGatheringsPods deletes all the active jobs (and their Pods) with the "periodic-gathering-"

--- a/pkg/controller/operator.go
+++ b/pkg/controller/operator.go
@@ -28,6 +28,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/openshift/insights-operator/pkg/anonymization"
@@ -144,6 +145,21 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 
 	// updateCh is used to signal a version update to the runtimeextractor controller
 	updateCh := make(chan struct{}, 1)
+	tlsProfileCh := make(chan struct{}, 1)
+
+	// Watch for TLS security profile changes on the APIServer resource
+	if _, err := configInformers.Config().V1().APIServers().Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(_, _ interface{}) {
+				select {
+				case tlsProfileCh <- struct{}{}:
+				default:
+				}
+			},
+		},
+	); err != nil {
+		return fmt.Errorf("failed to add APIServer event handler: %w", err)
+	}
 
 	// Create informer factory for runtime-extractor resources in openshift-insights namespace
 	runtimeExtractorInformerFactory := clientInformers.NewSharedInformerFactoryWithOptions(
@@ -169,7 +185,9 @@ func (s *Operator) Run(ctx context.Context, controller *controllercmd.Controller
 	runtimeExtractorCtrl := runtimeextractor.NewRuntimeExtractorController(
 		configAggregator,
 		updateCh,
+		tlsProfileCh,
 		kubeClient,
+		configClient,
 		controller.EventRecorder,
 		runtimeExtractorResourceInformer,
 	)

--- a/pkg/controller/runtimeextractor/controller.go
+++ b/pkg/controller/runtimeextractor/controller.go
@@ -3,10 +3,13 @@ package runtimeextractor
 import (
 	"context"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/controller/runtimeextractor/resources"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
@@ -23,7 +26,7 @@ type ConfigNotifier interface {
 // ResourceManager manages the lifecycle of runtime extractor Kubernetes resources
 type ResourceManager interface {
 	// ApplyRuntimeExtractorResources creates or updates all runtime extractor resources
-	ApplyRuntimeExtractorResources(ctx context.Context) error
+	ApplyRuntimeExtractorResources(ctx context.Context, tlsProfile *configv1.TLSSecurityProfile) error
 	// DeleteRuntimeExtractorResources removes all runtime extractor resources
 	DeleteRuntimeExtractorResources(ctx context.Context) error
 	// ResourcesExists checks if runtime extractor resources are deployed
@@ -51,6 +54,10 @@ type runtimeExtractorController struct {
 	config ConfigNotifier
 	// updateCh receives notifications when the cluster version changes, triggering DaemonSet image updates
 	updateCh chan struct{}
+	// configClient provides access to the OpenShift config API for reading TLS profiles
+	configClient configclientset.Interface
+	// tlsProfileCh receives notifications when the cluster TLS security profile changes
+	tlsProfileCh <-chan struct{}
 	// resourceInformer watches for external modifications to runtime-extractor resources
 	resourceInformer ResourceInformer
 	// resourceManager handles creation, update, and deletion of runtime extractor Kubernetes resources
@@ -62,7 +69,9 @@ type runtimeExtractorController struct {
 func NewRuntimeExtractorController(
 	configNotifier ConfigNotifier,
 	updateCh chan struct{},
+	tlsProfileCh <-chan struct{},
 	kubeClient *kubernetes.Clientset,
+	configClient configclientset.Interface,
 	recorder events.Recorder,
 	resourceInformer ResourceInformer,
 ) *runtimeExtractorController {
@@ -74,6 +83,8 @@ func NewRuntimeExtractorController(
 	return &runtimeExtractorController{
 		config:           configNotifier,
 		updateCh:         updateCh,
+		configClient:     configClient,
+		tlsProfileCh:     tlsProfileCh,
 		resourceManager:  rm,
 		resourceInformer: resourceInformer,
 	}
@@ -107,6 +118,9 @@ func (re *runtimeExtractorController) Run(ctx context.Context) {
 		case <-re.updateCh:
 			klog.Info("Runtime extractor cluster version updated")
 			re.handleVersionUpdate(ctx)
+		case <-re.tlsProfileCh:
+			klog.Info("TLS security profile changed, updating runtime extractor")
+			re.handleTLSProfileChange(ctx)
 		case <-resourceModifiedChan:
 			klog.Info("Runtime extractor resources modified externally, reconciling")
 			re.handleResourceDrift(ctx)
@@ -148,10 +162,22 @@ func (re *runtimeExtractorController) isCreated(ctx context.Context) bool {
 	return re.resourceManager.ResourcesExists(ctx)
 }
 
+// fetchTLSProfile reads the TLS security profile from the cluster's APIServer configuration.
+// Returns nil if the profile cannot be read, which will default to Intermediate.
+func (re *runtimeExtractorController) fetchTLSProfile(ctx context.Context) *configv1.TLSSecurityProfile {
+	apiServer, err := re.configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		klog.Warningf("Failed to get APIServer config, defaulting to Intermediate TLS profile: %v", err)
+		return nil
+	}
+	return apiServer.Spec.TLSSecurityProfile
+}
+
 func (re *runtimeExtractorController) createDeployment(ctx context.Context) {
 	klog.Info("Creating runtime extractor resources")
 
-	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx); err != nil {
+	tlsProfile := re.fetchTLSProfile(ctx)
+	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, tlsProfile); err != nil {
 		klog.Errorf("Failed to apply runtime extractor resources: %v", err)
 	}
 }
@@ -172,13 +198,13 @@ func (re *runtimeExtractorController) deleteDeployment(ctx context.Context) {
 func (re *runtimeExtractorController) updateDeployment(ctx context.Context) {
 	klog.Info("Updating runtime extractor resources")
 
-	// Avoid creating it when the cluster version is updated
 	if !re.isCreated(ctx) {
 		klog.Info("Runtime extractor resources not found, skipping update")
 		return
 	}
 
-	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx); err != nil {
+	tlsProfile := re.fetchTLSProfile(ctx)
+	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, tlsProfile); err != nil {
 		klog.Errorf("Failed to apply runtime extractor resources: %v", err)
 	}
 }
@@ -197,9 +223,31 @@ func (re *runtimeExtractorController) handleResourceDrift(ctx context.Context) {
 	}
 
 	// Reapply resources to correct any drift
-	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx); err != nil {
+	tlsProfile := re.fetchTLSProfile(ctx)
+	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, tlsProfile); err != nil {
 		klog.Errorf("Failed to correct runtime extractor resource drift: %v", err)
 	} else {
 		klog.Info("Successfully reconciled runtime extractor resources")
+	}
+}
+
+// handleTLSProfileChange responds to TLS security profile changes by updating
+// the runtime extractor DaemonSet with the new TLS configuration.
+func (re *runtimeExtractorController) handleTLSProfileChange(ctx context.Context) {
+	cfg := re.config.Config()
+
+	if cfg.DataReporting.DisableRuntimeExtractor {
+		klog.Info("Runtime extractor is disabled, skipping TLS profile update")
+		return
+	}
+
+	if !re.isCreated(ctx) {
+		klog.Info("Runtime extractor resources not found, skipping TLS profile update")
+		return
+	}
+
+	tlsProfile := re.fetchTLSProfile(ctx)
+	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, tlsProfile); err != nil {
+		klog.Errorf("Failed to update runtime extractor with new TLS profile: %v", err)
 	}
 }

--- a/pkg/controller/runtimeextractor/controller.go
+++ b/pkg/controller/runtimeextractor/controller.go
@@ -4,12 +4,10 @@ import (
 	"context"
 
 	configv1 "github.com/openshift/api/config/v1"
-	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/insights-operator/pkg/config"
 	"github.com/openshift/insights-operator/pkg/controller/runtimeextractor/resources"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 )
@@ -54,10 +52,9 @@ type runtimeExtractorController struct {
 	config ConfigNotifier
 	// updateCh receives notifications when the cluster version changes, triggering DaemonSet image updates
 	updateCh chan struct{}
-	// configClient provides access to the OpenShift config API for reading TLS profiles
-	configClient configclientset.Interface
-	// tlsProfileCh receives notifications when the cluster TLS security profile changes
-	tlsProfileCh <-chan struct{}
+	// tlsProfile is the cluster's TLS security profile, fetched once at startup.
+	// The operator is restarted by the SecurityProfileWatcher when the TLS profile changes.
+	tlsProfile *configv1.TLSSecurityProfile
 	// resourceInformer watches for external modifications to runtime-extractor resources
 	resourceInformer ResourceInformer
 	// resourceManager handles creation, update, and deletion of runtime extractor Kubernetes resources
@@ -69,9 +66,8 @@ type runtimeExtractorController struct {
 func NewRuntimeExtractorController(
 	configNotifier ConfigNotifier,
 	updateCh chan struct{},
-	tlsProfileCh <-chan struct{},
+	tlsProfile *configv1.TLSSecurityProfile,
 	kubeClient *kubernetes.Clientset,
-	configClient configclientset.Interface,
 	recorder events.Recorder,
 	resourceInformer ResourceInformer,
 ) *runtimeExtractorController {
@@ -83,8 +79,7 @@ func NewRuntimeExtractorController(
 	return &runtimeExtractorController{
 		config:           configNotifier,
 		updateCh:         updateCh,
-		configClient:     configClient,
-		tlsProfileCh:     tlsProfileCh,
+		tlsProfile:       tlsProfile,
 		resourceManager:  rm,
 		resourceInformer: resourceInformer,
 	}
@@ -118,9 +113,6 @@ func (re *runtimeExtractorController) Run(ctx context.Context) {
 		case <-re.updateCh:
 			klog.Info("Runtime extractor cluster version updated")
 			re.handleVersionUpdate(ctx)
-		case <-re.tlsProfileCh:
-			klog.Info("TLS security profile changed, updating runtime extractor")
-			re.handleTLSProfileChange(ctx)
 		case <-resourceModifiedChan:
 			klog.Info("Runtime extractor resources modified externally, reconciling")
 			re.handleResourceDrift(ctx)
@@ -162,22 +154,10 @@ func (re *runtimeExtractorController) isCreated(ctx context.Context) bool {
 	return re.resourceManager.ResourcesExists(ctx)
 }
 
-// fetchTLSProfile reads the TLS security profile from the cluster's APIServer configuration.
-// Returns nil if the profile cannot be read, which will default to Intermediate.
-func (re *runtimeExtractorController) fetchTLSProfile(ctx context.Context) *configv1.TLSSecurityProfile {
-	apiServer, err := re.configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		klog.Warningf("Failed to get APIServer config, defaulting to Intermediate TLS profile: %v", err)
-		return nil
-	}
-	return apiServer.Spec.TLSSecurityProfile
-}
-
 func (re *runtimeExtractorController) createDeployment(ctx context.Context) {
 	klog.Info("Creating runtime extractor resources")
 
-	tlsProfile := re.fetchTLSProfile(ctx)
-	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, tlsProfile); err != nil {
+	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, re.tlsProfile); err != nil {
 		klog.Errorf("Failed to apply runtime extractor resources: %v", err)
 	}
 }
@@ -203,8 +183,7 @@ func (re *runtimeExtractorController) updateDeployment(ctx context.Context) {
 		return
 	}
 
-	tlsProfile := re.fetchTLSProfile(ctx)
-	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, tlsProfile); err != nil {
+	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, re.tlsProfile); err != nil {
 		klog.Errorf("Failed to apply runtime extractor resources: %v", err)
 	}
 }
@@ -223,31 +202,9 @@ func (re *runtimeExtractorController) handleResourceDrift(ctx context.Context) {
 	}
 
 	// Reapply resources to correct any drift
-	tlsProfile := re.fetchTLSProfile(ctx)
-	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, tlsProfile); err != nil {
+	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, re.tlsProfile); err != nil {
 		klog.Errorf("Failed to correct runtime extractor resource drift: %v", err)
 	} else {
 		klog.Info("Successfully reconciled runtime extractor resources")
-	}
-}
-
-// handleTLSProfileChange responds to TLS security profile changes by updating
-// the runtime extractor DaemonSet with the new TLS configuration.
-func (re *runtimeExtractorController) handleTLSProfileChange(ctx context.Context) {
-	cfg := re.config.Config()
-
-	if cfg.DataReporting.DisableRuntimeExtractor {
-		klog.Info("Runtime extractor is disabled, skipping TLS profile update")
-		return
-	}
-
-	if !re.isCreated(ctx) {
-		klog.Info("Runtime extractor resources not found, skipping TLS profile update")
-		return
-	}
-
-	tlsProfile := re.fetchTLSProfile(ctx)
-	if err := re.resourceManager.ApplyRuntimeExtractorResources(ctx, tlsProfile); err != nil {
-		klog.Errorf("Failed to update runtime extractor with new TLS profile: %v", err)
 	}
 }

--- a/pkg/controller/runtimeextractor/resources/daemonset.go
+++ b/pkg/controller/runtimeextractor/resources/daemonset.go
@@ -130,9 +130,9 @@ func kubeRBACProxyTLSArgs(profile *configv1.TLSSecurityProfile) []string {
 	}
 
 	if len(supportedCiphers) == 0 {
-		klog.Warning("All TLS ciphers unsupported, falling back to Intermediate profile")
-		profileSpec = *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-		cipherNames = crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+		klog.Warning("All TLS ciphers unsupported, falling back to Intermediate cipher list")
+		intermediateCiphers := configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers
+		cipherNames = crypto.OpenSSLToIANACipherSuites(intermediateCiphers)
 		supportedCiphers = make([]string, 0, len(cipherNames))
 		for _, name := range cipherNames {
 			if _, err := crypto.CipherSuite(name); err == nil {

--- a/pkg/controller/runtimeextractor/resources/daemonset.go
+++ b/pkg/controller/runtimeextractor/resources/daemonset.go
@@ -5,7 +5,11 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
+	utiltls "github.com/openshift/controller-runtime-common/pkg/tls"
+	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,8 +31,9 @@ const (
 	exporterImageEnv     = "RELATED_IMAGE_INSIGHTS_RUNTIME_EXPORTER"
 	exporterDefaultImage = "quay.io/openshift/origin-insights-runtime-exporter:latest"
 
-	proxyImageEnv     = "RELATED_IMAGE_KUBE_RBAC_PROXY"
-	proxyDefaultImage = "quay.io/openshift/origin-kube-rbac-proxy:latest"
+	proxyImageEnv              = "RELATED_IMAGE_KUBE_RBAC_PROXY"
+	proxyDefaultImage          = "quay.io/openshift/origin-kube-rbac-proxy:latest"
+	kubeRbacProxyContainerName = "kube-rbac-proxy"
 
 	envImageErrMsg = "Failed to get image from environment variable %s, using default image %s"
 )
@@ -47,13 +52,14 @@ func loadRuntimeExtractorDaemonSet() (*appsv1.DaemonSet, error) {
 
 // applyDaemonSet creates or updates the runtime extractor DaemonSet
 // Retries on conflict errors using exponential backoff
-func (rm *ResourceManager) applyDaemonSet(ctx context.Context) (*appsv1.DaemonSet, error) {
+func (rm *ResourceManager) applyDaemonSet(ctx context.Context, tlsProfile *configv1.TLSSecurityProfile) (*appsv1.DaemonSet, error) {
 	daemonSet, err := loadRuntimeExtractorDaemonSet()
 	if err != nil {
 		return nil, err
 	}
 
 	rm.updateContainerImages(daemonSet)
+	updateKubeRBACProxyTLSArgs(daemonSet, tlsProfile)
 
 	// Retry with exponential backoff on conflict errors
 	var appliedDaemonSet *appsv1.DaemonSet
@@ -94,11 +100,64 @@ func (rm *ResourceManager) updateContainerImages(ds *appsv1.DaemonSet) {
 		case "exporter":
 			container.Image = exporterReleaseVersion
 			klog.Infof("Updated runtime exporter container image to %s", container.Image)
-		case "kube-rbac-proxy":
+		case kubeRbacProxyContainerName:
 			// kube-rbac-proxy uses its own versioning, keep as-is
 			// Could be updated separately if needed
 			container.Image = proxyReleaseVersion
 			klog.Infof("Updated kube-rbac-proxy container image to %s", container.Image)
+		}
+	}
+}
+
+// kubeRBACProxyTLSArgs generates --tls-cipher-suites and --tls-min-version
+// arguments for kube-rbac-proxy based on the cluster's TLS security profile.
+func kubeRBACProxyTLSArgs(profile *configv1.TLSSecurityProfile) []string {
+	profileSpec, err := utiltls.GetTLSProfileSpec(profile)
+	if err != nil {
+		klog.Warningf("Failed to get TLS profile spec, using Intermediate: %v", err)
+		profileSpec = *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+
+	cipherNames := crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+
+	var supportedCiphers []string
+	for _, name := range cipherNames {
+		if _, err := crypto.CipherSuite(name); err != nil {
+			klog.Warningf("Dropping unsupported TLS cipher %q", name)
+			continue
+		}
+		supportedCiphers = append(supportedCiphers, name)
+	}
+
+	if len(supportedCiphers) == 0 {
+		klog.Warning("All TLS ciphers unsupported, falling back to Intermediate profile")
+		profileSpec = *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		cipherNames = crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers)
+		supportedCiphers = make([]string, 0, len(cipherNames))
+		for _, name := range cipherNames {
+			if _, err := crypto.CipherSuite(name); err == nil {
+				supportedCiphers = append(supportedCiphers, name)
+			}
+		}
+	}
+
+	return []string{
+		"--tls-cipher-suites=" + strings.Join(supportedCiphers, ","),
+		"--tls-min-version=" + string(profileSpec.MinTLSVersion),
+	}
+}
+
+// updateKubeRBACProxyTLSArgs appends TLS cipher and version args to the
+// kube-rbac-proxy container based on the cluster's TLS security profile.
+func updateKubeRBACProxyTLSArgs(ds *appsv1.DaemonSet, profile *configv1.TLSSecurityProfile) {
+	tlsArgs := kubeRBACProxyTLSArgs(profile)
+	for i := range ds.Spec.Template.Spec.Containers {
+		if ds.Spec.Template.Spec.Containers[i].Name == kubeRbacProxyContainerName {
+			ds.Spec.Template.Spec.Containers[i].Args = append(
+				ds.Spec.Template.Spec.Containers[i].Args,
+				tlsArgs...,
+			)
+			return
 		}
 	}
 }

--- a/pkg/controller/runtimeextractor/resources/daemonset_test.go
+++ b/pkg/controller/runtimeextractor/resources/daemonset_test.go
@@ -3,8 +3,10 @@ package resources
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +59,7 @@ func Test_applyDaemonSet(t *testing.T) {
 			recorder := events.NewInMemoryRecorder("test", clock.RealClock{})
 			rm := NewResourceManager(coreClient.AppsV1(), recorder)
 
-			ds, err := rm.applyDaemonSet(context.Background())
+			ds, err := rm.applyDaemonSet(context.Background(), nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -371,4 +373,105 @@ func Test_loadImagesFromEnvs(t *testing.T) {
 			assert.Equal(t, tt.wantProxy, gotProxy)
 		})
 	}
+}
+
+func Test_kubeRBACProxyTLSArgs(t *testing.T) {
+	tests := []struct {
+		name               string
+		profile            *configv1.TLSSecurityProfile
+		wantMinVersion     string
+		wantCipherContains string
+		wantArgCount       int
+	}{
+		{
+			name:               "nil profile defaults to Intermediate",
+			profile:            nil,
+			wantMinVersion:     "VersionTLS12",
+			wantCipherContains: "TLS_ECDHE",
+			wantArgCount:       2,
+		},
+		{
+			name: "Intermediate profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileIntermediateType,
+			},
+			wantMinVersion:     "VersionTLS12",
+			wantCipherContains: "TLS_ECDHE",
+			wantArgCount:       2,
+		},
+		{
+			name: "Old profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileOldType,
+			},
+			wantMinVersion:     "VersionTLS10",
+			wantCipherContains: "TLS_",
+			wantArgCount:       2,
+		},
+		{
+			name: "Modern profile",
+			profile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileModernType,
+			},
+			wantMinVersion:     "VersionTLS13",
+			wantCipherContains: "TLS_",
+			wantArgCount:       2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := kubeRBACProxyTLSArgs(tt.profile)
+
+			assert.Len(t, args, tt.wantArgCount)
+
+			// Check --tls-cipher-suites arg
+			assert.True(t, strings.HasPrefix(args[0], "--tls-cipher-suites="), "first arg should be --tls-cipher-suites")
+			assert.Contains(t, args[0], tt.wantCipherContains)
+
+			// Check --tls-min-version arg
+			assert.Equal(t, "--tls-min-version="+tt.wantMinVersion, args[1])
+		})
+	}
+}
+
+func Test_updateKubeRBACProxyTLSArgs(t *testing.T) {
+	ds := &appsv1.DaemonSet{
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "kube-rbac-proxy",
+							Args: []string{
+								"--secure-listen-address=:8443",
+								"--upstream=http://127.0.0.1:8000",
+							},
+						},
+						{
+							Name: "extractor",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	updateKubeRBACProxyTLSArgs(ds, nil) // nil defaults to Intermediate
+
+	proxyContainer := ds.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, "kube-rbac-proxy", proxyContainer.Name)
+
+	// Should have original 2 args + 2 TLS args
+	assert.Len(t, proxyContainer.Args, 4)
+
+	// Original args preserved
+	assert.Equal(t, "--secure-listen-address=:8443", proxyContainer.Args[0])
+	assert.Equal(t, "--upstream=http://127.0.0.1:8000", proxyContainer.Args[1])
+
+	// TLS args appended
+	assert.True(t, strings.HasPrefix(proxyContainer.Args[2], "--tls-cipher-suites="))
+	assert.Equal(t, "--tls-min-version=VersionTLS12", proxyContainer.Args[3])
+
+	// Extractor container should be unchanged
+	assert.Empty(t, ds.Spec.Template.Spec.Containers[1].Args)
 }

--- a/pkg/controller/runtimeextractor/resources/manager.go
+++ b/pkg/controller/runtimeextractor/resources/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
@@ -28,9 +29,9 @@ func NewResourceManager(
 // ApplyRuntimeExtractorResources creates or updates the runtime extractor DaemonSet
 // This should be called when the runtime extractor should be deployed or updated
 func (rm *ResourceManager) ApplyRuntimeExtractorResources(
-	ctx context.Context,
+	ctx context.Context, tlsProfile *configv1.TLSSecurityProfile,
 ) error {
-	if _, err := rm.applyDaemonSet(ctx); err != nil {
+	if _, err := rm.applyDaemonSet(ctx, tlsProfile); err != nil {
 		return fmt.Errorf("failed to apply daemonset: %v", err)
 	}
 

--- a/pkg/controller/runtimeextractor/resources/retry_test.go
+++ b/pkg/controller/runtimeextractor/resources/retry_test.go
@@ -72,7 +72,7 @@ func Test_applyDaemonSet_RetryOnConflict(t *testing.T) {
 	)
 
 	// This should succeed after retry
-	_, err := rm.applyDaemonSet(ctx)
+	_, err := rm.applyDaemonSet(ctx, nil)
 	if err != nil {
 		t.Fatalf("Expected applyDaemonSet to succeed after retry, got error: %v", err)
 	}


### PR DESCRIPTION
The runtime extractor's kube-rbac-proxy sidecar was using default TLS settings instead of the cluster's centralized TLS security policy from the APIServer CR. This change reads the TLS profile from apiservers.config.openshift.io/cluster and injects --tls-cipher-suites and --tls-min-version arguments into the kube-rbac-proxy container.

The controller now watches for APIServer TLS profile changes and re-applies the DaemonSet when the profile is updated. Cipher names are converted from OpenSSL to IANA format using library-go, with graceful fallback to Intermediate profile when ciphers are unsupported.

- [X] Feature

## Unit Tests

- `pkg/controller/runtimeextractor/resources/daemonset_test.go`

## Breaking Changes

No

## References

https://redhat.atlassian.net/browse/OCPBUGS-78774


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime-extractor now retrieves the cluster’s APIServer TLS security profile at startup and applies it to runtime-extractor resources during deployments and drift reconciliation.
  * kube-rbac-proxy TLS settings (minimum TLS version and cipher suites) are now generated from the cluster TLS profile, with fallback behavior when needed.
* **Bug Fixes**
  * Reconciliation now skips runtime-extractor updates when the required resources are not present.
* **Tests**
  * Added unit tests for kube-rbac-proxy TLS argument generation and ensuring the arguments are applied correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->