### PR TITLE
OCPBUGS-87889: fall back to kube-system/global-pull-secret for Insights token

### DIFF
--- a/manifests/03-clusterrole.yaml
+++ b/manifests/03-clusterrole.yaml
@@ -491,6 +491,46 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: insights-operator-pull-secret
+  namespace: kube-system
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Insights
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - global-pull-secret
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: insights-operator-pull-secret
+  namespace: kube-system
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Insights
+roleRef:
+  kind: Role
+  name: insights-operator-pull-secret
+subjects:
+  - kind: ServiceAccount
+    name: operator
+    namespace: openshift-insights
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: insights-operator
   namespace: openshift-insights
   annotations:

--- a/pkg/config/configobserver/secretconfigobserver.go
+++ b/pkg/config/configobserver/secretconfigobserver.go
@@ -19,6 +19,14 @@ import (
 	"github.com/openshift/insights-operator/pkg/config"
 )
 
+const (
+	openshiftConfigNamespace = "openshift-config"
+	pullSecretName           = "pull-secret" //nolint: gosec
+	supportSecretName        = "support"     //nolint: gosec
+	kubeSystemNamespace      = "kube-system"
+	globalPullSecretName     = "global-pull-secret" //nolint: gosec
+)
+
 type ConfigReporter interface {
 	SetConfig(*config.Controller)
 }
@@ -134,7 +142,7 @@ func (c *Controller) fetchSecret(ctx context.Context, namespace, name string) (*
 // Updates the stored tokens from the secrets in the cluster. (if present)
 func (c *Controller) updateToken(ctx context.Context) error {
 	klog.V(2).Infof("Refreshing configuration from cluster pull secret")
-	secret, err := c.fetchSecret(ctx, "openshift-config", "pull-secret")
+	secret, err := c.fetchSecret(ctx, openshiftConfigNamespace, pullSecretName)
 	if err != nil {
 		return err
 	}
@@ -155,7 +163,7 @@ func (c *Controller) updateToken(ctx context.Context) error {
 	// Fall back to kube-system/global-pull-secret (used by HyperShift HCP clusters
 	// where the customer adds cloud.openshift.com via day-2 additional-pull-secret)
 	if len(nextConfig.Token) == 0 {
-		globalSecret, err := c.fetchSecret(ctx, "kube-system", "global-pull-secret")
+		globalSecret, err := c.fetchSecret(ctx, kubeSystemNamespace, globalPullSecretName)
 		if err != nil {
 			return err
 		}
@@ -179,7 +187,7 @@ func (c *Controller) updateToken(ctx context.Context) error {
 // Updates the stored configs from the secrets in the cluster. (if present)
 func (c *Controller) updateConfig(ctx context.Context) error {
 	klog.V(2).Infof("Refreshing configuration from cluster support secret")
-	secret, err := c.fetchSecret(ctx, "openshift-config", "support")
+	secret, err := c.fetchSecret(ctx, openshiftConfigNamespace, supportSecretName)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/configobserver/secretconfigobserver.go
+++ b/pkg/config/configobserver/secretconfigobserver.go
@@ -112,19 +112,19 @@ func (c *Controller) ConfigChanged() (configCh <-chan struct{}, closeFn func()) 
 }
 
 // Fetches the token from cluster secret key
-func (c *Controller) fetchSecret(ctx context.Context, name string) (*v1.Secret, error) {
-	secret, err := c.kubeClient.CoreV1().Secrets("openshift-config").Get(ctx, name, metav1.GetOptions{})
+func (c *Controller) fetchSecret(ctx context.Context, namespace, name string) (*v1.Secret, error) {
+	secret, err := c.kubeClient.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			klog.Infof("%s secret does not exist", name)
+			klog.Infof("%s/%s secret does not exist", namespace, name)
 			err = nil
 			secret = nil
 		} else if errors.IsForbidden(err) {
-			klog.V(2).Infof("Operator does not have permission to check %s: %v", name, err)
+			klog.V(2).Infof("Operator does not have permission to check %s/%s: %v", namespace, name, err)
 			err = nil
 			secret = nil
 		} else {
-			err = fmt.Errorf("could not check %s: %v", name, err)
+			err = fmt.Errorf("could not check %s/%s: %v", namespace, name, err)
 		}
 	}
 
@@ -134,7 +134,7 @@ func (c *Controller) fetchSecret(ctx context.Context, name string) (*v1.Secret, 
 // Updates the stored tokens from the secrets in the cluster. (if present)
 func (c *Controller) updateToken(ctx context.Context) error {
 	klog.V(2).Infof("Refreshing configuration from cluster pull secret")
-	secret, err := c.fetchSecret(ctx, "pull-secret")
+	secret, err := c.fetchSecret(ctx, "openshift-config", "pull-secret")
 	if err != nil {
 		return err
 	}
@@ -152,6 +152,25 @@ func (c *Controller) updateToken(ctx context.Context) error {
 		}
 	}
 
+	// Fall back to kube-system/global-pull-secret (used by HyperShift HCP clusters
+	// where the customer adds cloud.openshift.com via day-2 additional-pull-secret)
+	if len(nextConfig.Token) == 0 {
+		globalSecret, err := c.fetchSecret(ctx, "kube-system", "global-pull-secret")
+		if err != nil {
+			return err
+		}
+		if globalSecret != nil {
+			token, err := tokenFromSecret(globalSecret)
+			if err != nil {
+				return err
+			}
+			if len(token) > 0 {
+				nextConfig.Token = token
+				nextConfig.Report = true
+			}
+		}
+	}
+
 	c.setTokenConfig(&nextConfig)
 
 	return nil
@@ -160,7 +179,7 @@ func (c *Controller) updateToken(ctx context.Context) error {
 // Updates the stored configs from the secrets in the cluster. (if present)
 func (c *Controller) updateConfig(ctx context.Context) error {
 	klog.V(2).Infof("Refreshing configuration from cluster support secret")
-	secret, err := c.fetchSecret(ctx, "support")
+	secret, err := c.fetchSecret(ctx, "openshift-config", "support")
 	if err != nil {
 		return err
 	}

--- a/pkg/config/configobserver/secretconfigobserver_test.go
+++ b/pkg/config/configobserver/secretconfigobserver_test.go
@@ -25,8 +25,9 @@ type kubeClientResponder struct {
 }
 
 const (
-	pullSecretKey = "(/v1, Resource=secrets) openshift-config.pull-secret" //nolint: gosec
-	supportKey    = "(/v1, Resource=secrets) openshift-config.support"
+	pullSecretKey       = "(/v1, Resource=secrets) openshift-config.pull-secret"   //nolint: gosec
+	supportKey          = "(/v1, Resource=secrets) openshift-config.support"       //nolint: gosec
+	globalPullSecretKey = "(/v1, Resource=secrets) kube-system.global-pull-secret" //nolint: gosec
 )
 
 // nolint: lll, funlen
@@ -96,6 +97,34 @@ func Test_ConfigObserver_ChangeSupportConfig(t *testing.T) {
 				Interval: 15 * time.Minute,
 			},
 			expErr: nil,
+		},
+		{
+			name: "token-from-global-pull-secret-fallback",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"auths":{"arohcpocpprod.azurecr.io":{"auth":"acrtoken"}}}`),
+				}},
+				globalPullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"auths":{"cloud.openshift.com":{"auth":"globaltoken"}}}`),
+				}},
+			},
+			expConfig: &config.Controller{
+				Token: "globaltoken",
+			},
+		},
+		{
+			name: "primary-pull-secret-takes-precedence-over-global",
+			config: map[string]*corev1.Secret{
+				pullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"auths":{"cloud.openshift.com":{"auth":"primarytoken"}}}`),
+				}},
+				globalPullSecretKey: {Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"auths":{"cloud.openshift.com":{"auth":"fallbacktoken"}}}`),
+				}},
+			},
+			expConfig: &config.Controller{
+				Token: "primarytoken",
+			},
 		},
 		{
 			name: "set-all-config",


### PR DESCRIPTION
## Summary

On ARO HCP clusters, `openshift-config/pull-secret` only contains the ACR registry credential — no `cloud.openshift.com` token. Customers add their Red Hat pull secret (including `cloud.openshift.com`) day-2 via `kube-system/additional-pull-secret`, which HCCO merges into `kube-system/global-pull-secret`. The Insights Operator currently only checks `openshift-config/pull-secret`, so it reports `NoToken` / `GatheringDisabled` even though the token exists on the cluster.

This change makes `updateToken()` check `kube-system/global-pull-secret` as a read-only fallback when `openshift-config/pull-secret` has no `cloud.openshift.com` token.

**Changes:**
- Generalize `fetchSecret()` to accept a namespace parameter
- Add fallback lookup to `kube-system/global-pull-secret` in `updateToken()`
- Add read-only RBAC (`get` only, no update/patch) for `global-pull-secret` in `kube-system`
- Include namespace in `fetchSecret` log/error messages for debuggability
- Add tests for fallback and primary-wins-over-fallback precedence

**Behavior:**
- On standard OpenShift clusters: no change — `openshift-config/pull-secret` has the token, fallback is never reached
- On ARO HCP clusters: finds the token in `kube-system/global-pull-secret` when primary lacks `cloud.openshift.com`
- `global-pull-secret` is read-only — the operator does not manage, write, or claim ownership of this secret
- If `global-pull-secret` doesn't exist (NotFound) or is inaccessible (Forbidden), the fallback is silently skipped

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make lint` — 0 issues
- [x] New test: fallback finds token from `kube-system/global-pull-secret` when primary lacks `cloud.openshift.com`
- [x] New test: primary `openshift-config/pull-secret` takes precedence when both have `cloud.openshift.com`
- [ ] Verify on ARO HCP test cluster that operator picks up token from `global-pull-secret`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Added scoped permissions and a retrieval fallback to a global pull secret so reporting can use an alternate pull secret when the primary is unavailable.
* **Tests**
  * Added test cases to validate token selection and priority between the primary pull secret and the global fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->