### PR TITLE
OCPBUGS-85109: move required-scc annotation to pod template in gathering job

### DIFF
--- a/pkg/controller/periodic/job.go
+++ b/pkg/controller/periodic/job.go
@@ -49,9 +49,6 @@ func (j *JobController) CreateGathererJob(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dataGather.Name,
 			Namespace: insightsNamespace,
-			Annotations: map[string]string{
-				"openshift.io/required-scc": "restricted-v2",
-			},
 			Labels: map[string]string{
 				"insights-gathering": "",
 			},
@@ -60,6 +57,11 @@ func (j *JobController) CreateGathererJob(
 			// backoff limit is 0 - we dont' want to restart the gathering immediately in case of failure
 			BackoffLimit: new(int32),
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "restricted-v2",
+					},
+				},
 				Spec: corev1.PodSpec{
 					PriorityClassName:  "system-cluster-critical",
 					RestartPolicy:      corev1.RestartPolicyNever,


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR fixes the location of the required-scc annotation in the `periodic-gathering` job pod template.

Failing monitor tests: https://sippy.dptools.openshift.org/sippy-ng/tests/5.0/analysis?test=%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-insights%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation

Fixing this will allow us to drop the [exception](https://github.com/openshift/origin/blob/main/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go#L45) from the `required-scc-annotation-checker` monitor test.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No -- the pinned SCC is the one that the job pods are already getting admitted with (`restricted-v2`).

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CNTRLPLANE-3386

https://redhat.atlassian.net/browse/OCPBUGS-85109
