### PR TITLE
CCXDEV-16450: document disableRuntimeExtractor config option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ The operator uses `wait.Until` for periodic tasks:
 - **Disk Pruner**: Removes old archives (runs every second interval)
 - **SCA Controller**: Simple Content Access certificate management
 - **Cluster Transfer Controller**: Handles cluster transfer operations
+- **Runtime Extractor Controller**: Manages the insights-runtime-extractor DaemonSet lifecycle (can be disabled via `dataReporting/disableRuntimeExtractor` config)
 
 ### Service Accounts
 - `operator`: Main service account for the insights-operator deployment

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -17,6 +17,7 @@ dataReporting:
     downloadEndpoint: https://console.redhat.com/api/insights-results-aggregator/v2/cluster/%s/reports
     conditionalGathererEndpoint: https://console.redhat.com/api/gathering/gathering_rules
     obfuscation: [workload_names networking]
+    disableRuntimeExtractor: false
 sca:
     disabled: false
     endpoint: https://api.openshift.com/api/accounts_mgmt/v1/entitlement_certificates
@@ -49,6 +50,11 @@ The `support` secret provides following configuration attributes:
 - `clusterTransferInterval`  - frequency of checking available cluster transfers. Overwritten by `clusterTransfer/interval` from the configmap. Default value is `24h`.
 - `conditionalGathererEndpoint` - the endpoing providing conditional gathering rules definitions. Overwritten by `dataReporting/conditionalGathererEndpoint` from the configmap. Default value is `https://console.redhat.com/api/gathering/gathering_rules`.
 - `disableInsightsAlerts` - disables all the alerts registered by the Insights Operator. Overwritten by `alerting/disabled` from the configmap. Default value is `false`.
+
+The `insights-config` configmap provides the following additional configuration attributes not available in the `support` secret:
+
+- `disableRuntimeExtractor` - when set to `true` under `dataReporting/disableRuntimeExtractor`, disables the deployment and management of all insights-runtime-extractor resources. Default value is `false`.
+
 Content example of the `support` secret:
 
 ```shell script


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Add disableRuntimeExtractor configuration to arch.md and CLAUDE.md. This configmap-only option disables runtime-extractor resources when set to true.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/arch.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `None`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- `None`

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CCXDEV-16450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/updated scheduling guidance for the Runtime Extractor Controller, including the periodic task that manages the runtime extractor DaemonSet lifecycle.
  * Documented the `dataReporting/disableRuntimeExtractor` setting, explaining how setting it to `true` disables runtime extractor deployment and management (default: `false`).
  * Updated the sample `insights-config` configmap to include the new option and default value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->