### PR TITLE
OCPBUGS-93805: update HyperShift deployment manifest

### DIFF
--- a/manifests/06-deployment-ibm-cloud-managed.yaml
+++ b/manifests/06-deployment-ibm-cloud-managed.yaml
@@ -38,6 +38,12 @@ spec:
               fieldPath: metadata.namespace
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
+        - name: RELATED_IMAGE_INSIGHTS_RUNTIME_EXTRACTOR
+          value: quay.io/openshift/origin-insights-runtime-extractor:latest
+        - name: RELATED_IMAGE_INSIGHTS_RUNTIME_EXPORTER
+          value: quay.io/openshift/origin-insights-runtime-exporter:latest
+        - name: RELATED_IMAGE_KUBE_RBAC_PROXY
+          value: quay.io/openshift/origin-kube-rbac-proxy:latest
         image: quay.io/openshift/origin-insights-operator:latest
         name: insights-operator
         ports:


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Add missing `RELATED_IMAGE` environment variables to the HyperShift deployment manifest to provide correct images for the runtime extractor DaemonSet.

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `None`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

[https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???](https://redhat.atlassian.net/browse/OCPBUGS-93805)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment defaults to include additional container image settings, helping ensure the service starts with the expected components available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->