### PR TITLE
NO-JIRA: Update misleading docs on the QEMU gatherer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Note: This CHANGELOG is only for the changes in insights operator.
-	Please see OpenShift release notes for official changes\n<!--Latest hash: 456de92aaf0a9f62efab834becc1882f864d2518-->
+	Please see OpenShift release notes for official changes\n<!--Latest hash: ad672d905ed6c2df22de2d2ccf6712e04abf10f9-->
+## 4.22
+
+### Data Enhancement
+- [#1247](https://github.com/openshift/insights-operator/pull/1247) kubeletconfig gatherer
+- [#1246](https://github.com/openshift/insights-operator/pull/1246) New Gatherer for OpenTelemetryCollector CRs
+- [#1235](https://github.com/openshift/insights-operator/pull/1235) subscription gathering
+- [#1229](https://github.com/openshift/insights-operator/pull/1229) install config update
+- [#1240](https://github.com/openshift/insights-operator/pull/1240) gather machineconfig size
+
+### Feature
+- [#1257](https://github.com/openshift/insights-operator/pull/1257) fetch TLS profiles from API server
+- [#1248](https://github.com/openshift/insights-operator/pull/1248) add config option to disable runtime extractor 
+
+### Bugfix
+- [#1252](https://github.com/openshift/insights-operator/pull/1252) add permission for opentelemetrycollectors
+- [#1253](https://github.com/openshift/insights-operator/pull/1253) Fix string accessor error
+- [#1223](https://github.com/openshift/insights-operator/pull/1223) obfuscation config precedence
+
+### Others
+- [#1256](https://github.com/openshift/insights-operator/pull/1256) generate gatherer docs
+
+### Misc
+- [#1249](https://github.com/openshift/insights-operator/pull/1249) Updating ose-insights-operator-container image to be consistent with ART for 4.22
+- [#1225](https://github.com/openshift/insights-operator/pull/1225) Migrate Prometheus targets discovering from Endpoints to EndpointSlices
+- [#1245](https://github.com/openshift/insights-operator/pull/1245) Add CodeRabbit inheritance for org-wide rules
+
 ## 4.21
 
 ### Data Enhancement

--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1901,9 +1901,10 @@ None
 
 ## QEMUKubeVirtLauncherLogs
 
-Collects logs from KubeVirt virt-launcher pods containing QEMU process information.
-This gatherer specifically searches for log lines containing "/usr/libexec/qemu-kvm" to capture QEMU-related
-activity within virtual machines managed by KubeVirt.
+Collects QEMU process information from KubeVirt's virt-launcher pods.
+QEMU-related parameters are located in the logs of the virt-launcher pods.
+The data is filtered and parsed into a JSON file to simplify its processing.
+Each pod only contains one iteration of the parameters, so only one data structure is output per pod.
 
 ### API Reference
 None

--- a/pkg/gatherers/clusterconfig/gather_qemu_kubevirt_launcher_logs.go
+++ b/pkg/gatherers/clusterconfig/gather_qemu_kubevirt_launcher_logs.go
@@ -13,9 +13,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// GatherQEMUKubeVirtLauncherLogs Collects logs from KubeVirt virt-launcher pods containing QEMU process information.
-// This gatherer specifically searches for log lines containing "/usr/libexec/qemu-kvm" to capture QEMU-related
-// activity within virtual machines managed by KubeVirt.
+// GatherQEMUKubeVirtLauncherLogs Collects QEMU process information from KubeVirt's virt-launcher pods.
+// QEMU-related parameters are located in the logs of the virt-launcher pods.
+// The data is filtered and parsed into a JSON file to simplify its processing.
+// Each pod only contains one iteration of the parameters, so only one data structure is output per pod.
 //
 // ### API Reference
 // None


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a new update on the documentation for the QEMU gatherer.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (Documentation)

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

Yes

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the 4.22 changelog with categorized release notes and current release metadata.
  * Clarified documentation for collecting and reporting QEMU process information from KubeVirt virt-launcher pods.
  * Documented that QEMU parameters are parsed into JSON, with one output structure produced per pod.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->