### PR TITLE
OCPBUGS-98690: Fix indentation bug on livenessProbe

### DIFF
--- a/pkg/controller/runtimeextractor/resources/manifests/runtime-extractor-daemonset.yaml
+++ b/pkg/controller/runtimeextractor/resources/manifests/runtime-extractor-daemonset.yaml
@@ -98,8 +98,8 @@ spec:
                 - --timeout
                 - 10s
                 - info
-              periodSeconds: 30
-              timeoutSeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 10
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->
This PR implements a fix on livenessProbe field for runtime extractor's DaemonSet manifest 

## Categories
<!-- Select the categories that your PR better fits on -->

- [X] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

No

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/OCPBUGS-98690
original issue → https://redhat.atlassian.net/browse/OCPBUGS-76962


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime extractor health monitoring by explicitly configuring liveness probe timing.
  * Helps ensure failed health checks are detected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->