### PR TITLE
CCXDEV-16524: gather alertmanager configuration

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -99,6 +99,35 @@ Collects instances outside of the `openshift-monitoring` of the following custom
 None
 
 
+## AlertmanagerConfig
+
+Collects the anonymized Alertmanager routing
+configuration from the alertmanager-main secret in the openshift-monitoring
+namespace. Only receivers, route, and inhibit_rules are extracted.
+Sensitive fields (webhook URLs, API keys, passwords, tokens) are anonymized.
+
+### API Reference
+None
+
+### Sample data
+- [docs/insights-archive-sample/config/secrets/openshift-monitoring/alertmanager-main/data.json](./insights-archive-sample/config/secrets/openshift-monitoring/alertmanager-main/data.json)
+
+### Location in archive
+- `config/secrets/openshift-monitoring/alertmanager-main/data.json`
+
+### Config ID
+`clusterconfig/alertmanager_config`
+
+### Released version
+- 5.0.0
+
+### Backported versions
+None
+
+### Changes
+None
+
+
 ## CRD
 
 Collects the specified Custom Resource Definitions.

--- a/docs/insights-archive-sample/config/secrets/openshift-monitoring/alertmanager-main/data.json
+++ b/docs/insights-archive-sample/config/secrets/openshift-monitoring/alertmanager-main/data.json
@@ -1,0 +1,74 @@
+{
+  "inhibit_rules": [
+    {
+      "equal": ["namespace", "alertname"],
+      "source_matchers": ["severity=\"critical\""],
+      "target_matchers": ["severity=\"warning\""]
+    }
+  ],
+  "receivers": [
+    { "name": "null" },
+    {
+      "name": "slack-notifications",
+      "slack_configs": [
+        {
+          "api_url": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+          "channel": "#alerts",
+          "send_resolved": true
+        }
+      ]
+    },
+    {
+      "name": "pagerduty-critical",
+      "pagerduty_configs": [
+        {
+          "routing_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+          "send_resolved": true,
+          "service_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    {
+      "name": "webhook-receiver",
+      "webhook_configs": [
+        {
+          "max_alerts": 10,
+          "url": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+      ]
+    },
+    {
+      "email_configs": [
+        {
+          "auth_password": "xxxxxxxxxxxxxxxxxxx",
+          "auth_secret": "xxxxxxxxxxxxxxxxx",
+          "auth_username": "xxxxxxxxx",
+          "send_resolved": true,
+          "smarthost": "xxxxxxxxxxxxxxxxxxxx",
+          "to": "team@example.com"
+        }
+      ],
+      "name": "email-team"
+    }
+  ],
+  "route": {
+    "group_by": ["namespace", "alertname"],
+    "group_interval": "5m",
+    "group_wait": "30s",
+    "receiver": "null",
+    "repeat_interval": "12h",
+    "routes": [
+      {
+        "continue": true,
+        "matchers": ["severity=\"warning\""],
+        "receiver": "slack-notifications"
+      },
+      {
+        "group_wait": "10s",
+        "matchers": ["severity=\"critical\""],
+        "receiver": "pagerduty-critical"
+      },
+      { "match": { "team": "backend" }, "receiver": "webhook-receiver" }
+    ]
+  }
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -27,6 +27,7 @@ type gathererFuncPtr = func(*Gatherer, context.Context) ([]record.Record, []erro
 
 var gatheringFunctions = map[string]gathererFuncPtr{
 	"active_alerts":                    (*Gatherer).GatherActiveAlerts,
+	"alertmanager_config":              (*Gatherer).GatherAlertmanagerConfig,
 	"aggregated_monitoring_cr_names":   (*Gatherer).GatherAggregatedMonitoringCRNames,
 	"authentication":                   (*Gatherer).GatherClusterAuthentication,
 	"certificate_signing_requests":     (*Gatherer).GatherCertificateSigningRequests,

--- a/pkg/gatherers/clusterconfig/gather_alertmanager_config.go
+++ b/pkg/gatherers/clusterconfig/gather_alertmanager_config.go
@@ -1,0 +1,117 @@
+package clusterconfig
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils/anonymize"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var sensitiveFieldPattern = regexp.MustCompile(`(?i)(token|key|secret|password|auth|url|host)`)
+
+// GatherAlertmanagerConfig Collects the anonymized Alertmanager routing
+// configuration from the alertmanager-main secret in the openshift-monitoring
+// namespace. Only receivers, route, and inhibit_rules are extracted.
+// Sensitive fields (webhook URLs, API keys, passwords, tokens) are anonymized.
+//
+// ### API Reference
+// None
+//
+// ### Sample data
+// - docs/insights-archive-sample/config/secrets/openshift-monitoring/alertmanager-main/data.json
+//
+// ### Location in archive
+// - `config/secrets/openshift-monitoring/alertmanager-main/data.json`
+//
+// ### Config ID
+// `clusterconfig/alertmanager_config`
+//
+// ### Released version
+// - 5.0.0
+//
+// ### Backported versions
+// None
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherAlertmanagerConfig(ctx context.Context) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherAlertmanagerConfig(ctx, gatherKubeClient.CoreV1())
+}
+
+func gatherAlertmanagerConfig(ctx context.Context, cli v1.CoreV1Interface) ([]record.Record, []error) {
+	secret, err := cli.Secrets(monitoringNamespace).Get(ctx, "alertmanager-main", metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	yamlData, found := secret.Data["alertmanager.yaml"]
+	if !found {
+		return nil, nil
+	}
+
+	var fullCfg map[string]interface{}
+	if err := yaml.Unmarshal(yamlData, &fullCfg); err != nil {
+		return nil, []error{err}
+	}
+
+	cfg := make(map[string]interface{})
+	for _, key := range []string{"receivers", "route", "inhibit_rules"} {
+		if val, ok := fullCfg[key]; ok {
+			cfg[key] = val
+		}
+	}
+
+	anonymizeMap(cfg, false)
+
+	return []record.Record{{
+		Name: "config/secrets/openshift-monitoring/alertmanager-main/data",
+		Item: record.JSONMarshaller{Object: cfg},
+	}}, nil
+}
+
+// anonymizeMap redacts string values in m whose key matches sensitiveFieldPattern.
+// Sensitivity propagates to all descendants so that nested fields like
+// authorization.credentials are redacted even when "credentials" alone
+// doesn't match the pattern — the parent "authorization" matches "auth".
+func anonymizeMap(m map[string]interface{}, sensitive bool) {
+	for key, val := range m {
+		isSensitive := sensitive || sensitiveFieldPattern.MatchString(key)
+		switch v := val.(type) {
+		case string:
+			if isSensitive {
+				m[key] = anonymize.String(v)
+			}
+		case map[string]interface{}:
+			anonymizeMap(v, isSensitive)
+		case []interface{}:
+			anonymizeSlice(v, isSensitive)
+		}
+	}
+}
+
+func anonymizeSlice(s []interface{}, sensitive bool) {
+	for i, item := range s {
+		switch v := item.(type) {
+		case map[string]interface{}:
+			anonymizeMap(v, sensitive)
+		case string:
+			if sensitive {
+				s[i] = anonymize.String(v)
+			}
+		}
+	}
+}

--- a/pkg/gatherers/clusterconfig/gather_alertmanager_config_test.go
+++ b/pkg/gatherers/clusterconfig/gather_alertmanager_config_test.go
@@ -1,0 +1,364 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openshift/insights-operator/pkg/utils/anonymize"
+)
+
+func Test_gatherAlertmanagerConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		secret          *corev1.Secret
+		expectedRecords int
+		expectedErrors  int
+	}{
+		{
+			name:            "secret not found returns nil",
+			secret:          nil,
+			expectedRecords: 0,
+			expectedErrors:  0,
+		},
+		{
+			name: "missing alertmanager.yaml key returns nil",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: monitoringNamespace,
+					Name:      "alertmanager-main",
+				},
+				Data: map[string][]byte{
+					"some-other-key": []byte("value"),
+				},
+			},
+			expectedRecords: 0,
+			expectedErrors:  0,
+		},
+		{
+			name: "malformed YAML returns error",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: monitoringNamespace,
+					Name:      "alertmanager-main",
+				},
+				Data: map[string][]byte{
+					"alertmanager.yaml": []byte("{{invalid yaml"),
+				},
+			},
+			expectedRecords: 0,
+			expectedErrors:  1,
+		},
+		{
+			name: "default minimal config",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: monitoringNamespace,
+					Name:      "alertmanager-main",
+				},
+				Data: map[string][]byte{
+					"alertmanager.yaml": []byte(`
+global:
+  resolve_timeout: 5m
+receivers:
+  - name: "null"
+route:
+  group_by:
+    - namespace
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: "null"
+`),
+				},
+			},
+			expectedRecords: 1,
+			expectedErrors:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeClient := kubefake.NewClientset()
+			if tt.secret != nil {
+				_, err := kubeClient.CoreV1().Secrets(monitoringNamespace).Create(
+					context.TODO(), tt.secret, metav1.CreateOptions{},
+				)
+				assert.NoError(t, err)
+			}
+
+			records, errs := gatherAlertmanagerConfig(context.Background(), kubeClient.CoreV1())
+
+			if tt.expectedErrors > 0 {
+				assert.Len(t, errs, tt.expectedErrors)
+			} else {
+				assert.Empty(t, errs)
+			}
+			assert.Len(t, records, tt.expectedRecords)
+		})
+	}
+}
+
+func Test_gatherAlertmanagerConfig_excludesGlobalSection(t *testing.T) {
+	kubeClient := kubefake.NewClientset()
+	_, err := kubeClient.CoreV1().Secrets(monitoringNamespace).Create(
+		context.TODO(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: monitoringNamespace,
+				Name:      "alertmanager-main",
+			},
+			Data: map[string][]byte{
+				"alertmanager.yaml": []byte(`
+global:
+  resolve_timeout: 5m
+  slack_api_url: https://hooks.slack.com/services/GLOBAL/SECRET/TOKEN
+  smtp_smarthost: smtp.secret-server.com:587
+receivers:
+  - name: "null"
+route:
+  receiver: "null"
+`),
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	assert.NoError(t, err)
+
+	records, errs := gatherAlertmanagerConfig(context.Background(), kubeClient.CoreV1())
+	assert.Empty(t, errs)
+	assert.Len(t, records, 1)
+
+	data, err := records[0].Item.Marshal()
+	assert.NoError(t, err)
+
+	assert.NotContains(t, string(data), "global")
+	assert.NotContains(t, string(data), "slack.com")
+	assert.NotContains(t, string(data), "smtp.secret-server.com")
+}
+
+func Test_gatherAlertmanagerConfig_fullConfig(t *testing.T) {
+	kubeClient := kubefake.NewClientset()
+	_, err := kubeClient.CoreV1().Secrets(monitoringNamespace).Create(
+		context.TODO(),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: monitoringNamespace,
+				Name:      "alertmanager-main",
+			},
+			Data: map[string][]byte{
+				"alertmanager.yaml": []byte(`
+receivers:
+  - name: slack-notifications
+    slack_configs:
+      - api_url: https://hooks.slack.com/services/T00/B00/XXXX
+        channel: "#alerts"
+        send_resolved: true
+  - name: pagerduty-critical
+    pagerduty_configs:
+      - service_key: abcdef1234567890
+        routing_key: R0123456789ABCDEF
+  - name: webhook-receiver
+    webhook_configs:
+      - url: https://webhook.example.com/alert?token=secret123
+        max_alerts: 10
+  - name: email-team
+    email_configs:
+      - to: team@example.com
+        smarthost: smtp.example.com:587
+        auth_username: alertuser
+        auth_password: supersecret
+route:
+  receiver: slack-notifications
+  group_by:
+    - namespace
+  routes:
+    - receiver: pagerduty-critical
+      matchers:
+        - severity="critical"
+inhibit_rules:
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity="warning"
+    equal:
+      - namespace
+`),
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	assert.NoError(t, err)
+
+	records, errs := gatherAlertmanagerConfig(context.Background(), kubeClient.CoreV1())
+	assert.Empty(t, errs)
+	assert.Len(t, records, 1)
+	assert.Equal(t, "config/secrets/openshift-monitoring/alertmanager-main/data", records[0].Name)
+
+	data, err := records[0].Item.Marshal()
+	assert.NoError(t, err)
+
+	// Verify non-sensitive fields are preserved
+	assert.Contains(t, string(data), `"slack-notifications"`)
+	assert.Contains(t, string(data), `"pagerduty-critical"`)
+	assert.Contains(t, string(data), `"webhook-receiver"`)
+	assert.Contains(t, string(data), `"email-team"`)
+	assert.Contains(t, string(data), `"#alerts"`)
+	assert.Contains(t, string(data), `"team@example.com"`)
+
+	// Verify sensitive fields are anonymized
+	assert.NotContains(t, string(data), "hooks.slack.com")
+	assert.NotContains(t, string(data), "abcdef1234567890")
+	assert.NotContains(t, string(data), "R0123456789ABCDEF")
+	assert.NotContains(t, string(data), "webhook.example.com")
+	assert.NotContains(t, string(data), "supersecret")
+	assert.NotContains(t, string(data), "alertuser")
+	assert.NotContains(t, string(data), "smtp.example.com")
+
+	// Verify route structure is preserved
+	assert.Contains(t, string(data), `"namespace"`)
+	assert.Contains(t, string(data), `severity=`)
+
+	// Verify inhibit rules are preserved
+	assert.Contains(t, string(data), `"source_matchers"`)
+	assert.Contains(t, string(data), `"target_matchers"`)
+}
+
+func Test_anonymizeMap(t *testing.T) {
+	m := map[string]interface{}{
+		"receivers": []interface{}{
+			map[string]interface{}{
+				"name": "test-receiver",
+				"webhook_configs": []interface{}{
+					map[string]interface{}{
+						"url":        "https://example.com/webhook",
+						"max_alerts": 5,
+					},
+				},
+				"email_configs": []interface{}{
+					map[string]interface{}{
+						"to":            "oncall@example.com",
+						"smarthost":     "smtp.example.com:587",
+						"auth_password": "pass",
+						"send_resolved": true,
+					},
+				},
+				"slack_configs": []interface{}{
+					map[string]interface{}{
+						"api_url": "https://hooks.slack.com/services/T00/B00/XXXX",
+						"channel": "#alerts",
+					},
+				},
+			},
+		},
+		"route": map[string]interface{}{
+			"receiver": "test-receiver",
+			"group_by": []interface{}{"namespace"},
+		},
+		"inhibit_rules": []interface{}{
+			map[string]interface{}{
+				"source_matchers": []interface{}{`severity="critical"`},
+				"target_matchers": []interface{}{`severity="warning"`},
+				"equal":           []interface{}{"namespace"},
+			},
+		},
+	}
+
+	anonymizeMap(m, false)
+
+	receivers := m["receivers"].([]interface{})
+	recv := receivers[0].(map[string]interface{})
+
+	// Sensitive keys anonymized
+	whCfg := recv["webhook_configs"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, anonymize.String("https://example.com/webhook"), whCfg["url"])
+	assert.Equal(t, 5, whCfg["max_alerts"])
+
+	emailCfg := recv["email_configs"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "oncall@example.com", emailCfg["to"])
+	assert.Equal(t, anonymize.String("smtp.example.com:587"), emailCfg["smarthost"])
+	assert.Equal(t, anonymize.String("pass"), emailCfg["auth_password"])
+	assert.Equal(t, true, emailCfg["send_resolved"])
+
+	slackCfg := recv["slack_configs"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, anonymize.String("https://hooks.slack.com/services/T00/B00/XXXX"), slackCfg["api_url"])
+	assert.Equal(t, "#alerts", slackCfg["channel"])
+
+	// Receiver name preserved
+	assert.Equal(t, "test-receiver", recv["name"])
+
+	// Route and inhibit rules unchanged
+	route := m["route"].(map[string]interface{})
+	assert.Equal(t, "test-receiver", route["receiver"])
+	assert.Equal(t, []interface{}{"namespace"}, route["group_by"])
+
+	rules := m["inhibit_rules"].([]interface{})
+	rule := rules[0].(map[string]interface{})
+	assert.Equal(t, []interface{}{`severity="critical"`}, rule["source_matchers"])
+	assert.Equal(t, []interface{}{`severity="warning"`}, rule["target_matchers"])
+}
+
+func Test_anonymizeMap_nestedCredentials(t *testing.T) {
+	m := map[string]interface{}{
+		"receivers": []interface{}{
+			map[string]interface{}{
+				"name": "bearer-receiver",
+				"webhook_configs": []interface{}{
+					map[string]interface{}{
+						"http_config": map[string]interface{}{
+							"authorization": map[string]interface{}{
+								"type":        "Bearer",
+								"credentials": "my-bearer-token",
+							},
+							"basic_auth": map[string]interface{}{
+								"username": "admin",
+								"password": "s3cret",
+							},
+						},
+						"url": "https://webhook.example.com/alert",
+					},
+				},
+			},
+		},
+		"route": map[string]interface{}{
+			"receiver": "bearer-receiver",
+			"routes": []interface{}{
+				map[string]interface{}{
+					"receiver": "bearer-receiver",
+					"matchers": []interface{}{`severity="critical"`},
+				},
+			},
+		},
+	}
+
+	anonymizeMap(m, false)
+
+	receivers := m["receivers"].([]interface{})
+	whCfgs := receivers[0].(map[string]interface{})["webhook_configs"].([]interface{})
+	httpCfg := whCfgs[0].(map[string]interface{})["http_config"].(map[string]interface{})
+
+	// authorization.credentials anonymized via parent "authorization" matching "auth"
+	authz := httpCfg["authorization"].(map[string]interface{})
+	assert.Equal(t, anonymize.String("Bearer"), authz["type"])
+	assert.Equal(t, anonymize.String("my-bearer-token"), authz["credentials"])
+
+	// basic_auth children anonymized via parent "basic_auth" matching "auth"
+	basicAuth := httpCfg["basic_auth"].(map[string]interface{})
+	assert.Equal(t, anonymize.String("admin"), basicAuth["username"])
+	assert.Equal(t, anonymize.String("s3cret"), basicAuth["password"])
+
+	// url is anonymized by its own key matching the pattern
+	assert.Equal(t, anonymize.String("https://webhook.example.com/alert"), whCfgs[0].(map[string]interface{})["url"])
+
+	// route structure is preserved (non-sensitive nested maps)
+	route := m["route"].(map[string]interface{})
+	assert.Equal(t, "bearer-receiver", route["receiver"])
+	routes := route["routes"].([]interface{})
+	subRoute := routes[0].(map[string]interface{})
+	assert.Equal(t, "bearer-receiver", subRoute["receiver"])
+	assert.Equal(t, []interface{}{`severity="critical"`}, subRoute["matchers"])
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Collect anonymized Alertmanager routing configuration (receivers, route, inhibit_rules) from the alertmanager-main secret in openshift-monitoring. Sensitive fields matching token, key, secret, password, auth, url, and host patterns are anonymized before archiving.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/secrets/openshift-monitoring/alertmanager-main/data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_alertmanager_config_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CCXDEV-16524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added collection of Alertmanager routing configuration for cluster diagnostics.
  - Captures receivers, routing rules, and inhibition rules while excluding unrelated global settings.
  - Sensitive credentials and connection details are anonymized before collection.
  - Handles missing configuration gracefully without producing errors.

- **Documentation**
  - Added guidance and sample data describing the collected Alertmanager configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->