### PR TITLE
OCPBUGS-74211: fix: tolerate all node taints for insights-runtime-extractor DaemonSet

### DIFF
--- a/pkg/controller/runtimeextractor/resources/daemonset_test.go
+++ b/pkg/controller/runtimeextractor/resources/daemonset_test.go
@@ -30,6 +30,21 @@ func Test_loadRuntimeExtractorDaemonSet(t *testing.T) {
 	assert.Len(t, ds.Spec.Template.Spec.Containers, 3)
 }
 
+// Test_loadRuntimeExtractorDaemonSet_TolerateAllTaints ensures the DaemonSet tolerates
+// all node taints (including custom ones added by cluster admins), rather than relying
+// on the fixed set of well-known taints the DaemonSet controller tolerates by default.
+func Test_loadRuntimeExtractorDaemonSet_TolerateAllTaints(t *testing.T) {
+	ds, err := loadRuntimeExtractorDaemonSet()
+	assert.NoError(t, err)
+	assert.NotNil(t, ds)
+
+	tolerations := ds.Spec.Template.Spec.Tolerations
+	assert.Len(t, tolerations, 1, "expected a single wildcard toleration")
+	assert.Equal(t, corev1.TolerationOpExists, tolerations[0].Operator)
+	assert.Empty(t, tolerations[0].Key, "key must be empty to match all taints")
+	assert.Empty(t, tolerations[0].Effect, "effect must be empty to match all taint effects")
+}
+
 func Test_applyDaemonSet(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/controller/runtimeextractor/resources/daemonset_test.go
+++ b/pkg/controller/runtimeextractor/resources/daemonset_test.go
@@ -35,14 +35,75 @@ func Test_loadRuntimeExtractorDaemonSet(t *testing.T) {
 // on the fixed set of well-known taints the DaemonSet controller tolerates by default.
 func Test_loadRuntimeExtractorDaemonSet_TolerateAllTaints(t *testing.T) {
 	ds, err := loadRuntimeExtractorDaemonSet()
-	assert.NoError(t, err)
-	assert.NotNil(t, ds)
+	if err != nil || ds == nil {
+		t.Fatalf("failed to load daemonset: %v", err)
+	}
+	if tolerations := ds.Spec.Template.Spec.Tolerations; len(tolerations) != 1 {
+		t.Fatalf("expected a single wildcard toleration, got %d", len(tolerations))
+	}
 
-	tolerations := ds.Spec.Template.Spec.Tolerations
-	assert.Len(t, tolerations, 1, "expected a single wildcard toleration")
-	assert.Equal(t, corev1.TolerationOpExists, tolerations[0].Operator)
-	assert.Empty(t, tolerations[0].Key, "key must be empty to match all taints")
-	assert.Empty(t, tolerations[0].Effect, "effect must be empty to match all taint effects")
+	toleration := ds.Spec.Template.Spec.Tolerations[0]
+	tests := []struct {
+		name string
+		want string
+		got  string
+	}{
+		{"operator is Exists", string(corev1.TolerationOpExists), string(toleration.Operator)},
+		{"key is empty to match all taint keys", "", toleration.Key},
+		{"effect is empty to match all taint effects", "", string(toleration.Effect)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
+}
+
+// Test_loadRuntimeExtractorDaemonSet_NodeAffinityExcludesControlPlaneOnlyNodes ensures
+// that, even though the DaemonSet now tolerates all taints, its nodeAffinity still keeps
+// it off dedicated control-plane nodes, while still allowing it on nodes that are both
+// control-plane and worker (e.g. compact or Single Node OpenShift).
+func Test_loadRuntimeExtractorDaemonSet_NodeAffinityExcludesControlPlaneOnlyNodes(t *testing.T) {
+	ds, err := loadRuntimeExtractorDaemonSet()
+	if err != nil || ds == nil {
+		t.Fatalf("failed to load daemonset: %v", err)
+	}
+
+	affinity := ds.Spec.Template.Spec.Affinity
+	if affinity == nil || affinity.NodeAffinity == nil || affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatal("expected a required node affinity to be set")
+	}
+	required := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if len(required.NodeSelectorTerms) != 2 {
+		t.Fatalf("expected 2 node selector terms, got %d", len(required.NodeSelectorTerms))
+	}
+
+	tests := []struct {
+		name string
+		want corev1.NodeSelectorRequirement
+		term []corev1.NodeSelectorRequirement
+	}{
+		{
+			name: "excludes nodes labeled as master",
+			want: corev1.NodeSelectorRequirement{Key: "node-role.kubernetes.io/master", Operator: corev1.NodeSelectorOpDoesNotExist},
+			term: required.NodeSelectorTerms[0].MatchExpressions,
+		},
+		{
+			name: "excludes nodes labeled as control-plane",
+			want: corev1.NodeSelectorRequirement{Key: "node-role.kubernetes.io/control-plane", Operator: corev1.NodeSelectorOpDoesNotExist},
+			term: required.NodeSelectorTerms[0].MatchExpressions,
+		},
+		{
+			name: "still allows nodes explicitly labeled as worker",
+			want: corev1.NodeSelectorRequirement{Key: "node-role.kubernetes.io/worker", Operator: corev1.NodeSelectorOpExists},
+			term: required.NodeSelectorTerms[1].MatchExpressions,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, tt.term, tt.want)
+		})
+	}
 }
 
 func Test_applyDaemonSet(t *testing.T) {

--- a/pkg/controller/runtimeextractor/resources/manifests/runtime-extractor-daemonset.yaml
+++ b/pkg/controller/runtimeextractor/resources/manifests/runtime-extractor-daemonset.yaml
@@ -35,6 +35,11 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: openshift-user-critical
+      # Tolerate all taints so this DaemonSet schedules on every node, including
+      # nodes with custom taints (e.g. node-role.kubernetes.io/gpu), consistent
+      # with its purpose of running on every node in the cluster.
+      tolerations:
+        - operator: Exists
       containers:
         - name: kube-rbac-proxy
           image: quay.io/openshift/origin-kube-rbac-proxy:latest

--- a/pkg/controller/runtimeextractor/resources/manifests/runtime-extractor-daemonset.yaml
+++ b/pkg/controller/runtimeextractor/resources/manifests/runtime-extractor-daemonset.yaml
@@ -35,11 +35,28 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: openshift-user-critical
-      # Tolerate all taints so this DaemonSet schedules on every node, including
-      # nodes with custom taints (e.g. node-role.kubernetes.io/gpu), consistent
-      # with its purpose of running on every node in the cluster.
+      # Tolerate all taints so this DaemonSet is never blocked from scheduling
+      # by custom taints (e.g. node-role.kubernetes.io/gpu) added by cluster
+      # admins. Which nodes are actually targeted is controlled by the
+      # nodeAffinity below, not by which taints are tolerated.
       tolerations:
         - operator: Exists
+      # Run on worker nodes, and on control-plane nodes only when they also
+      # act as workers (e.g. compact or Single Node OpenShift), matching the
+      # DaemonSet's original scheduling footprint now that all taints are
+      # tolerated.
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
       containers:
         - name: kube-rbac-proxy
           image: quay.io/openshift/origin-kube-rbac-proxy:latest


### PR DESCRIPTION
## Summary
- The insights-runtime-extractor DaemonSet had no explicit tolerations, so it only
  ran on the fixed set of taints the DaemonSet controller tolerates by default
  (not-ready, unreachable, disk-pressure, memory-pressure, pid-pressure, unschedulable).
- Any custom taint added by a cluster admin (e.g. node-role.kubernetes.io/gpu) prevented
  the DaemonSet's pods from scheduling on that node, leaving incomplete cluster coverage.
- Added a wildcard toleration (`operator: Exists`) to the DaemonSet pod spec so it
  schedules on every node regardless of taints, per Kubernetes best practice for
  cluster-wide DaemonSets.
## Changes
- `pkg/controller/runtimeextractor/resources/manifests/runtime-extractor-daemonset.yaml`:
  add wildcard toleration.
- `pkg/controller/runtimeextractor/resources/daemonset_test.go`: add
  `Test_loadRuntimeExtractorDaemonSet_TolerateAllTaints` verifying the toleration.
## References
https://issues.redhat.com/browse/OCPBUGS-74211
## Test plan
- `go test ./pkg/controller/runtimeextractor/...` passes, including new and existing tests.
- `go build ./pkg/controller/runtimeextractor/...` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the runtime extractor DaemonSet to run across all node taints (including custom taints) using a catch-all toleration.
  * Refined scheduling to exclude control-plane-only nodes while still targeting worker-labeled nodes for runtime data collection.
* **Tests**
  * Added unit tests to verify catch-all taints toleration behavior.
  * Added unit tests to confirm node affinity excludes master/control-plane roles while allowing workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->