### PR TITLE
CCXDEV-16629: Add network policy

### DIFF
--- a/manifests/11-network-policy.yaml
+++ b/manifests/11-network-policy.yaml
@@ -1,0 +1,72 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-insights
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-insights-operator
+  namespace: openshift-insights
+spec:
+  podSelector:
+    matchLabels:
+      app: insights-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  # Allow any traffic to the metrics endpoint
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-gathering-pod-egress
+  namespace: openshift-insights
+spec:
+  podSelector:
+    matchLabels:
+      insights-gathering: ""
+  egress:
+    - {}
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-runtime-extractor
+  namespace: openshift-insights
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: insights-runtime-extractor
+  policyTypes:
+    - Ingress
+    - Egress
+  # kube-rbac-proxy needs to reach the API server
+  egress:
+    - {}
+  # Allow insights-operator and gathering pods to reach the kube-rbac-proxy HTTPS endpoint
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: insights-operator
+        - podSelector:
+            matchLabels:
+              insights-gathering: ""
+      ports:
+        - protocol: TCP
+          port: 8443

--- a/pkg/controller/periodic/job.go
+++ b/pkg/controller/periodic/job.go
@@ -58,6 +58,9 @@ func (j *JobController) CreateGathererJob(
 			BackoffLimit: new(int32),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"insights-gathering": "",
+					},
 					Annotations: map[string]string{
 						"openshift.io/required-scc": "restricted-v2",
 					},


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Introduce default-deny policy and allow-list policies for the insights-operator, gathering pods, and runtime-extractor pods.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [ ] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [X] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `None`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `None`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `None`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- `None`

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CCXDEV-16629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network policies to restrict pod traffic by default and allow only required connections between application components.
  * Added secure access controls for runtime extraction and operator communication on port 8443.
* **Bug Fixes**
  * Ensured gathering job pods receive the appropriate label for network policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->