### PR TITLE
OCPBUGS-100173: Update installer dependency to use tagged version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/api v0.0.0-20251120220512-cb382c9eaf42
 	github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee
 	github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235
-	github.com/openshift/installer v1.4.21-rc2.0.20260205115605-acb34201ac99
+	github.com/openshift/installer v1.4.21-acb34201ac99
 	github.com/openshift/library-go v0.0.0-20251107090138-0de9712313a5
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.74.0
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.65.2

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee h1:+S
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235 h1:9JBeIXmnHlpXTQPi7LPmu1jdxznBhAE7bb1K+3D8gxY=
 github.com/openshift/client-go v0.0.0-20251015124057-db0dee36e235/go.mod h1:L49W6pfrZkfOE5iC1PqEkuLkXG4W0BX4w8b+L2Bv7fM=
-github.com/openshift/installer v1.4.21-rc2.0.20260205115605-acb34201ac99 h1:BKhIIyj/K4RZZGVYTVYUZZuGV1SG+Dts0xUr3rJ1opw=
-github.com/openshift/installer v1.4.21-rc2.0.20260205115605-acb34201ac99/go.mod h1:3ATaLOa+jMDvA30gkrTskppvkggXmtKHtMWQ1Sog6kA=
+github.com/openshift/installer v1.4.21-acb34201ac99 h1:o6BLIvv+fX1CLe6aVKXUK/Gpq6Zp1QDsXZNvC0WCSsY=
+github.com/openshift/installer v1.4.21-acb34201ac99/go.mod h1:3ATaLOa+jMDvA30gkrTskppvkggXmtKHtMWQ1Sog6kA=
 github.com/openshift/library-go v0.0.0-20251107090138-0de9712313a5 h1:Gq8jCFgSrilZ2ZHjQleFZWlblikc1aaRZ0hqs+yvrP4=
 github.com/openshift/library-go v0.0.0-20251107090138-0de9712313a5/go.mod h1:OlFFws1AO51uzfc48MsStGE4SFMWlMZD0+f5a/zCtKI=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -502,7 +502,7 @@ github.com/openshift/client-go/security/clientset/versioned/fake
 github.com/openshift/client-go/security/clientset/versioned/scheme
 github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
 github.com/openshift/client-go/security/clientset/versioned/typed/security/v1/fake
-# github.com/openshift/installer v1.4.21-rc2.0.20260205115605-acb34201ac99
+# github.com/openshift/installer v1.4.21-acb34201ac99
 ## explicit; go 1.24.0
 github.com/openshift/installer/pkg/ipnet
 github.com/openshift/installer/pkg/types


### PR DESCRIPTION
## Summary
- Switch `github.com/openshift/installer` from pseudo-version `v1.4.21-rc2.0.20260205115605-acb34201ac99` to the tagged version `v1.4.21-acb34201ac99`, which resolves to the same commit.

## Test plan
- [ ] Verify `go mod verify` passes
- [ ] Verify `make build` succeeds
- [ ] Verify `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)