### PR TITLE
OCPBUGS-112480: Add multicluster gatherer

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -1372,6 +1372,34 @@ None
 - `ALERTS` removed in version 4.17+
 
 
+## MultiClusterEngine
+
+Collects `multiclusterengines.multicluster.openshift.io` resources.
+These resources are created when the Multicluster Engine for Kubernetes operator is installed.
+Usually only one MultiClusterEngine object exists in a cluster.
+
+### API Reference
+- https://github.com/stolostron/backplane-operator/blob/main/api/v1/multiclusterengine_types.go
+
+### Sample data
+- [docs/insights-archive-sample/cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/engine.json](./insights-archive-sample/cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/engine.json)
+
+### Location in archive
+- `cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/{name}.json`
+
+### Config ID
+`clusterconfig/multicluster_engine`
+
+### Released version
+- 5.0
+
+### Backported versions
+None
+
+### Changes
+None
+
+
 ## MutatingWebhookConfigurations
 
 Collects `MutatingWebhookConfiguration` resources.
@@ -1984,10 +2012,10 @@ and can be extended by modifying the const.go file.
 - https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/secret.go
 
 ### Sample data
-- [docs/insights-archive-sample/config/revisioned_objects.json](./insights-archive-sample/config/revisioned_objects.json)
+- [docs/insights-archive-sample/config/versioned_object_revision_counts.json](./insights-archive-sample/config/versioned_object_revision_counts.json)
 
 ### Location in archive
-- `config/revisioned_objects.json`
+- `config/versioned_object_revision_counts.json`
 
 ### Config ID
 `clusterconfig/revisioned_objects`

--- a/docs/insights-archive-sample/cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/engine.json
+++ b/docs/insights-archive-sample/cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/engine.json
@@ -1,0 +1,436 @@
+{
+    "apiVersion": "multicluster.openshift.io/v1",
+    "kind": "MultiClusterEngine",
+    "metadata": {
+        "annotations": {
+            "installer.multicluster.openshift.io/resource-adoption-policy": "Strict"
+        },
+        "creationTimestamp": "2023-01-01T00:00:00Z",
+        "finalizers": ["finalizer.multicluster.openshift.io"],
+        "generation": 2,
+        "name": "engine",
+        "resourceVersion": "12345",
+        "uid": "00000000-0000-0000-0000-000000000001"
+    },
+    "spec": {
+        "availabilityConfig": "High",
+        "localClusterName": "local-cluster",
+        "overrides": {
+            "components": [
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "assisted-service"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "cluster-lifecycle"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "cluster-manager"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "cluster-permission"
+                },
+                { "configOverrides": {}, "enabled": true, "name": "discovery" },
+                { "configOverrides": {}, "enabled": true, "name": "hive" },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "server-foundation"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "cluster-proxy-addon"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "local-cluster"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "hypershift-local-hosting"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "hypershift"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "managedserviceaccount"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": false,
+                    "name": "cluster-api"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": false,
+                    "name": "cluster-api-provider-aws"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": false,
+                    "name": "cluster-api-provider-azure-preview"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": false,
+                    "name": "cluster-api-provider-metal3"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": false,
+                    "name": "cluster-api-provider-openshift-assisted"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": false,
+                    "name": "image-based-install-operator"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": false,
+                    "name": "maestro-preview"
+                },
+                {
+                    "configOverrides": {},
+                    "enabled": true,
+                    "name": "console-mce"
+                }
+            ]
+        },
+        "targetNamespace": "multicluster-engine"
+    },
+    "status": {
+        "components": [
+            {
+                "kind": "ClusterManagementAddOn",
+                "message": "Resource is present",
+                "name": "managed-serviceaccount",
+                "reason": "ComponentsDeployed",
+                "status": "True",
+                "type": "Present"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "image-based-install-operator",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:02:45Z",
+                "message": "Deployment is available",
+                "name": "hypershift-addon-manager",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "ClusterManagementAddOn",
+                "message": "Resource is present",
+                "name": "hypershift-addon",
+                "reason": "ComponentsDeployed",
+                "status": "True",
+                "type": "Present"
+            },
+            {
+                "kind": "ManagedClusterAddOn",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "hypershift-addon add-on is available.",
+                "name": "hypershift-addon",
+                "reason": "ManagedClusterAddOnLeaseUpdated",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:03:15Z",
+                "message": "Deployment is available",
+                "name": "console-mce-console",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:01:30Z",
+                "message": "Deployment is available",
+                "name": "discovery-operator",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:02:30Z",
+                "message": "Deployment is available",
+                "name": "hive-operator",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:03:15Z",
+                "message": "Deployment is available",
+                "name": "infrastructure-operator",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:01:30Z",
+                "message": "Deployment is available",
+                "name": "cluster-curator-controller",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:01:30Z",
+                "message": "Deployment is available",
+                "name": "clusterclaims-controller",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:01:30Z",
+                "message": "Deployment is available",
+                "name": "provider-credential-controller",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:01:00Z",
+                "message": "Deployment is available",
+                "name": "cluster-image-set-controller",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:02:30Z",
+                "message": "Deployment is available",
+                "name": "clusterlifecycle-state-metrics-v2",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:01:45Z",
+                "message": "Deployment is available",
+                "name": "cluster-manager",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "ClusterManager",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "Components of cluster manager are applied",
+                "name": "cluster-manager",
+                "reason": "ClusterManagerApplied",
+                "status": "True",
+                "type": "Applied"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:02:30Z",
+                "message": "Deployment is available",
+                "name": "cluster-permission",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:01:00Z",
+                "message": "Deployment is available",
+                "name": "ocm-controller",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:02:45Z",
+                "message": "Deployment is available",
+                "name": "ocm-proxyserver",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:02:45Z",
+                "message": "Deployment is available",
+                "name": "ocm-webhook",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:02:45Z",
+                "message": "Deployment is available",
+                "name": "cluster-proxy-addon-manager",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:03:30Z",
+                "message": "Deployment is available",
+                "name": "cluster-proxy-addon-user",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Deployment",
+                "lastTransitionTime": "2023-01-01T00:03:00Z",
+                "message": "Deployment is available",
+                "name": "cluster-proxy",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "capi-controller-manager",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "capa-controller-manager",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "azureserviceoperator-controller-manager",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "capz-controller-manager",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "mce-capm3-controller-manager",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "capoa-bootstrap-controller-manager",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "capoa-controlplane-controller-manager",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "maestro",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            },
+            {
+                "kind": "local-cluster",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "ManagedCluster is accepted, joined, and available",
+                "name": "local-cluster",
+                "reason": "ManagedClusterImported",
+                "status": "True",
+                "type": "ManagedClusterImportSuccess"
+            },
+            {
+                "kind": "Component",
+                "lastTransitionTime": "2023-01-01T00:05:30Z",
+                "message": "No resources present",
+                "name": "hypershift-removals",
+                "reason": "ComponentDisabled",
+                "status": "True",
+                "type": "NotPresent"
+            }
+        ],
+        "conditions": [
+            {
+                "lastTransitionTime": "2023-01-01T00:00:00Z",
+                "lastUpdateTime": "2023-01-01T00:05:30Z",
+                "message": "All components deployed",
+                "reason": "ComponentsDeployed",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2023-01-01T00:05:00Z",
+                "lastUpdateTime": "2023-01-01T00:05:00Z",
+                "message": "All components available",
+                "reason": "ComponentsAvailable",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "currentVersion": "2.17.1",
+        "desiredVersion": "2.17.1",
+        "phase": "Available"
+    }
+}

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -60,6 +60,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"machines":                         (*Gatherer).GatherMachine,
 	"metrics":                          (*Gatherer).GatherMostRecentMetrics,
 	"monitoring_persistent_volumes":    (*Gatherer).GatherMonitoringPVs,
+	"multicluster_engine":              (*Gatherer).GatherMultiClusterEngine,
 	"mutating_webhook_configurations":  (*Gatherer).GatherMutatingWebhookConfigurations,
 	"networks":                         (*Gatherer).GatherClusterNetwork,
 	"node_logs":                        (*Gatherer).GatherNodeLogs,

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -108,6 +108,9 @@ var (
 
 	nodeNetConfPoliciesV1GVR = schema.GroupVersionResource{Group: "nmstate.io", Version: "v1", Resource: "nodenetworkconfigurationpolicies"}
 	nodeNetStatesV1Beta1GVR  = schema.GroupVersionResource{Group: "nmstate.io", Version: "v1beta1", Resource: "nodenetworkstates"}
+	multiClusterEngineGVR    = schema.GroupVersionResource{
+		Group: "multicluster.openshift.io", Version: "v1", Resource: "multiclusterengines",
+	}
 )
 
 func init() { //nolint: gochecknoinits

--- a/pkg/gatherers/clusterconfig/gather_multicluster_engine.go
+++ b/pkg/gatherers/clusterconfig/gather_multicluster_engine.go
@@ -1,0 +1,70 @@
+package clusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+// GatherMultiClusterEngine Collects `multiclusterengines.multicluster.openshift.io` resources.
+// These resources are created when the Multicluster Engine for Kubernetes operator is installed.
+// Usually only one MultiClusterEngine object exists in a cluster.
+//
+// ### API Reference
+// - https://github.com/stolostron/backplane-operator/blob/main/api/v1/multiclusterengine_types.go
+//
+// ### Sample data
+// - docs/insights-archive-sample/cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/engine.json
+//
+// ### Location in archive
+// - `cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/{name}.json`
+//
+// ### Config ID
+// `clusterconfig/multicluster_engine`
+//
+// ### Released version
+// - 5.0
+//
+// ### Backported versions
+// None
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherMultiClusterEngine(ctx context.Context) ([]record.Record, []error) {
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherMultiClusterEngine(ctx, dynamicClient)
+}
+
+func gatherMultiClusterEngine(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	mceList, err := dynamicClient.Resource(multiClusterEngineGVR).List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		klog.V(2).Infof("Unable to list %s resource due to: %s", multiClusterEngineGVR, err)
+		return nil, []error{err}
+	}
+
+	var records []record.Record
+	for i := range mceList.Items {
+		item := &mceList.Items[i]
+		records = append(records, record.Record{
+			Name: fmt.Sprintf("cluster-scoped-resources/%s/%s/%s",
+				multiClusterEngineGVR.Group,
+				multiClusterEngineGVR.Resource,
+				item.GetName()),
+			Item: record.ResourceMarshaller{Resource: item},
+		})
+	}
+	return records, nil
+}

--- a/pkg/gatherers/clusterconfig/gather_multicluster_engine_test.go
+++ b/pkg/gatherers/clusterconfig/gather_multicluster_engine_test.go
@@ -1,0 +1,118 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func Test_gatherMultiClusterEngine(t *testing.T) {
+	mceYAML := `
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+  resourceVersion: "12345"
+  creationTimestamp: "2024-01-01T00:00:00Z"
+spec:
+  availabilityConfig: High
+  targetNamespace: multicluster-engine
+  overrides:
+    components:
+    - name: hypershift
+      enabled: true
+    - name: managedserviceaccount
+      enabled: true
+status:
+  phase: Available
+  currentVersion: 2.5.0
+  desiredVersion: 2.5.0
+  conditions:
+  - type: Available
+    status: "True"
+    reason: MultiClusterEngineAvailable
+    message: All components are available
+`
+
+	tests := []struct {
+		name          string
+		mceYAMLs      []string
+		expectedCount int
+		expectedName  string
+	}{
+		{
+			name:          "single multiclusterengine resource",
+			mceYAMLs:      []string{mceYAML},
+			expectedCount: 1,
+			expectedName:  "cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/multiclusterengine",
+		},
+		{
+			name:          "no multiclusterengine resources",
+			mceYAMLs:      []string{},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+				runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{
+					multiClusterEngineGVR: "MultiClusterEngineList",
+				},
+			)
+
+			for _, mceYAMLStr := range tt.mceYAMLs {
+				decUnstructured := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+				mce := &unstructured.Unstructured{}
+
+				_, _, err := decUnstructured.Decode([]byte(mceYAMLStr), nil, mce)
+				assert.NoError(t, err, "unable to decode MultiClusterEngine YAML")
+
+				_, err = dynamicClient.Resource(multiClusterEngineGVR).Create(
+					context.Background(),
+					mce,
+					metav1.CreateOptions{},
+				)
+				assert.NoError(t, err, "unable to create fake MultiClusterEngine resource")
+			}
+
+			records, errs := gatherMultiClusterEngine(context.Background(), dynamicClient)
+
+			assert.Empty(t, errs, "unexpected errors when gathering MultiClusterEngine")
+			assert.Len(t, records, tt.expectedCount)
+
+			if tt.expectedName != "" && len(records) > 0 {
+				assert.Equal(t, tt.expectedName, records[0].Name)
+			}
+		})
+	}
+}
+
+func Test_gatherMultiClusterEngine_CRDNotFound(t *testing.T) {
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			multiClusterEngineGVR: "MultiClusterEngineList",
+		},
+	)
+	dynamicClient.PrependReactor("list", "multiclusterengines", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewNotFound(multiClusterEngineGVR.GroupResource(), "")
+	})
+
+	records, errs := gatherMultiClusterEngine(context.Background(), dynamicClient)
+
+	assert.Empty(t, errs, "CRD not found should not produce errors")
+	assert.Empty(t, records, "CRD not found should not produce records")
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Add gatherer function for MultiClusterEngine CRs 
to collect multicluster engine configuration data.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/cluster-scoped-resources/multicluster.openshift.io/multiclusterengines/engine.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_multicluster_engine_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

- `None`

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CCXDEV-16040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collection and archiving of MultiClusterEngine configuration and status information.
  * Included a representative MultiClusterEngine archive sample with deployment, availability, component, and local-cluster details.

* **Documentation**
  * Documented the MultiClusterEngine resource type, archive location, configuration details, release version, and API references.
  * Updated RevisionedObjectCounts sample and archive paths.

* **Bug Fixes**
  * Missing MultiClusterEngine resources are now handled gracefully without errors or records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->