### PR TITLE
OCPBUGS-123491: gather InferenceService from the KServe operator

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -981,6 +981,35 @@ None
 None
 
 
+## InferenceServices
+
+Collects InferenceService resources from the KServe operator
+across all namespaces. Only selected non-sensitive fields are collected:
+model format name and version, runtime, and protocol version.
+The storageUri field is explicitly excluded as it may contain S3 bucket names or internal paths.
+
+### API Reference
+- https://kserve.github.io/website/docs/reference/crd-api#inferenceservice
+
+### Sample data
+- [docs/insights-archive-sample/config/serving.kserve.io/inferenceservices.json](./insights-archive-sample/config/serving.kserve.io/inferenceservices.json)
+
+### Location in archive
+- `config/serving.kserve.io/inferenceservices.json`
+
+### Config ID
+`clusterconfig/inference_services`
+
+### Released version
+- 5.1
+
+### Backported versions
+None
+
+### Changes
+None
+
+
 ## InstallPlans
 
 Collects top 100 `InstallPlans` from `openshift-*` namespaces. Because `InstallPlans` have

--- a/docs/insights-archive-sample/config/serving.kserve.io/inferenceservices.json
+++ b/docs/insights-archive-sample/config/serving.kserve.io/inferenceservices.json
@@ -1,0 +1,24 @@
+[
+  {
+    "namespace": "kserve-demo",
+    "name": "sklearn-iris",
+    "modelFormatName": "sklearn",
+    "modelFormatVersion": "1",
+    "runtime": "kserve-sklearnserver",
+    "protocolVersion": "v1"
+  },
+  {
+    "namespace": "kserve-demo",
+    "name": "torchserve-sample",
+    "modelFormatName": "pytorch",
+    "runtime": "kserve-torchserve",
+    "protocolVersion": "v2"
+  },
+  {
+    "namespace": "mlops",
+    "name": "onnx-model",
+    "modelFormatName": "onnx",
+    "modelFormatVersion": "1",
+    "protocolVersion": "v2"
+  }
+]

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -45,6 +45,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"image":                            (*Gatherer).GatherClusterImage,
 	"image_pruners":                    (*Gatherer).GatherClusterImagePruner,
 	"image_registries":                 (*Gatherer).GatherClusterImageRegistry,
+	"inference_services":               (*Gatherer).GatherInferenceServices,
 	"infrastructures":                  (*Gatherer).GatherClusterInfrastructure,
 	"ingress":                          (*Gatherer).GatherClusterIngress,
 	"ingress_certificates":             (*Gatherer).GatherClusterIngressCertificates,

--- a/pkg/gatherers/clusterconfig/const.go
+++ b/pkg/gatherers/clusterconfig/const.go
@@ -114,6 +114,7 @@ var (
 	multiClusterHubGVR = schema.GroupVersionResource{
 		Group: "operator.open-cluster-management.io", Version: "v1", Resource: "multiclusterhubs",
 	}
+	inferenceServiceGVR = schema.GroupVersionResource{Group: "serving.kserve.io", Version: "v1beta1", Resource: "inferenceservices"}
 )
 
 func init() { //nolint: gochecknoinits

--- a/pkg/gatherers/clusterconfig/gather_inference_services.go
+++ b/pkg/gatherers/clusterconfig/gather_inference_services.go
@@ -1,0 +1,95 @@
+package clusterconfig
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/openshift/insights-operator/pkg/record"
+	"github.com/openshift/insights-operator/pkg/utils"
+)
+
+type inferenceService struct {
+	Namespace       string `json:"namespace"`
+	Name            string `json:"name"`
+	ModelFormatName string `json:"modelFormatName,omitempty"`
+	ModelFormatVer  string `json:"modelFormatVersion,omitempty"`
+	Runtime         string `json:"runtime,omitempty"`
+	ProtocolVersion string `json:"protocolVersion,omitempty"`
+}
+
+// GatherInferenceServices Collects InferenceService resources from the KServe operator
+// across all namespaces. Only selected non-sensitive fields are collected:
+// model format name and version, runtime, and protocol version.
+// The storageUri field is explicitly excluded as it may contain S3 bucket names or internal paths.
+//
+// ### API Reference
+// - https://kserve.github.io/website/docs/reference/crd-api#inferenceservice
+//
+// ### Sample data
+// - docs/insights-archive-sample/config/serving.kserve.io/inferenceservices.json
+//
+// ### Location in archive
+// - `config/serving.kserve.io/inferenceservices.json`
+//
+// ### Config ID
+// `clusterconfig/inference_services`
+//
+// ### Released version
+// - 5.1
+//
+// ### Backported versions
+// None
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherInferenceServices(ctx context.Context) ([]record.Record, []error) {
+	dynamicClient, err := dynamic.NewForConfig(g.gatherKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	return gatherInferenceServices(ctx, dynamicClient)
+}
+
+func gatherInferenceServices(ctx context.Context, dynamicClient dynamic.Interface) ([]record.Record, []error) {
+	infereneceServiceList, err := dynamicClient.Resource(inferenceServiceGVR).Namespace("").List(ctx, metav1.ListOptions{})
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []error{err}
+	}
+	if len(infereneceServiceList.Items) == 0 {
+		return nil, nil
+	}
+
+	inferenceServices := make([]inferenceService, 0, len(infereneceServiceList.Items))
+	for i := range infereneceServiceList.Items {
+		item := &infereneceServiceList.Items[i]
+		svc := inferenceService{
+			Namespace: item.GetNamespace(),
+			Name:      item.GetName(),
+		}
+		if v, err := utils.NestedStringWrapper(item.Object, "spec", "predictor", "model", "modelFormat", "name"); err == nil {
+			svc.ModelFormatName = v
+		}
+		if v, err := utils.NestedStringWrapper(item.Object, "spec", "predictor", "model", "modelFormat", "version"); err == nil {
+			svc.ModelFormatVer = v
+		}
+		if v, err := utils.NestedStringWrapper(item.Object, "spec", "predictor", "model", "runtime"); err == nil {
+			svc.Runtime = v
+		}
+		if v, err := utils.NestedStringWrapper(item.Object, "spec", "predictor", "model", "protocolVersion"); err == nil {
+			svc.ProtocolVersion = v
+		}
+		inferenceServices = append(inferenceServices, svc)
+	}
+
+	return []record.Record{{
+		Name: "config/serving.kserve.io/inferenceservices",
+		Item: record.JSONMarshaller{Object: inferenceServices},
+	}}, nil
+}

--- a/pkg/gatherers/clusterconfig/gather_inference_services_test.go
+++ b/pkg/gatherers/clusterconfig/gather_inference_services_test.go
@@ -1,0 +1,131 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+func newFakeInferenceServiceClient() *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			inferenceServiceGVR: "InferenceServiceList",
+		},
+	)
+}
+
+func createInferenceService(t *testing.T, client dynamic.Interface, namespace, name string, fields map[string]interface{}) {
+	t.Helper()
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "serving.kserve.io/v1beta1",
+			"kind":       "InferenceService",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"predictor": map[string]interface{}{
+					"model": fields,
+				},
+			},
+		},
+	}
+	_, err := client.Resource(inferenceServiceGVR).Namespace(namespace).Create(
+		context.Background(), obj, metav1.CreateOptions{},
+	)
+	if err != nil {
+		t.Fatalf("failed to create InferenceService: %v", err)
+	}
+}
+
+func Test_gatherInferenceServices(t *testing.T) {
+	t.Run("empty cluster returns no records", func(t *testing.T) {
+		client := newFakeInferenceServiceClient()
+		records, errs := gatherInferenceServices(context.Background(), client)
+		assert.Empty(t, errs)
+		assert.Empty(t, records)
+	})
+
+	t.Run("collects selected fields from all namespaces", func(t *testing.T) {
+		client := newFakeInferenceServiceClient()
+		createInferenceService(t, client, "ns-a", "model-a", map[string]interface{}{
+			"modelFormat": map[string]interface{}{
+				"name":    "onnx",
+				"version": "1",
+			},
+			"runtime":         "kserve-ovms",
+			"protocolVersion": "v2",
+			"storageUri":      "s3://my-bucket/models/model-a",
+		})
+		createInferenceService(t, client, "ns-b", "model-b", map[string]interface{}{
+			"modelFormat": map[string]interface{}{
+				"name": "tensorflow",
+			},
+		})
+
+		records, errs := gatherInferenceServices(context.Background(), client)
+		assert.Empty(t, errs)
+		assert.Len(t, records, 1)
+		assert.Equal(t, "config/serving.kserve.io/inferenceservices", records[0].Name)
+
+		services, ok := records[0].Item.(record.JSONMarshaller).Object.([]inferenceService)
+		assert.True(t, ok)
+		assert.Len(t, services, 2)
+
+		// Verify model-a fields are collected
+		var svcA inferenceService
+		for _, s := range services {
+			if s.Name == "model-a" {
+				svcA = s
+				break
+			}
+		}
+		assert.Equal(t, "ns-a", svcA.Namespace)
+		assert.Equal(t, "onnx", svcA.ModelFormatName)
+		assert.Equal(t, "1", svcA.ModelFormatVer)
+		assert.Equal(t, "kserve-ovms", svcA.Runtime)
+		assert.Equal(t, "v2", svcA.ProtocolVersion)
+
+		// Verify model-b partial fields
+		var svcB inferenceService
+		for _, s := range services {
+			if s.Name == "model-b" {
+				svcB = s
+				break
+			}
+		}
+		assert.Equal(t, "ns-b", svcB.Namespace)
+		assert.Equal(t, "tensorflow", svcB.ModelFormatName)
+		assert.Empty(t, svcB.ModelFormatVer)
+		assert.Empty(t, svcB.Runtime)
+		assert.Empty(t, svcB.ProtocolVersion)
+	})
+
+	t.Run("storageUri is not collected", func(t *testing.T) {
+		client := newFakeInferenceServiceClient()
+		createInferenceService(t, client, "ns-a", "model-a", map[string]interface{}{
+			"modelFormat": map[string]interface{}{"name": "onnx"},
+			"storageUri":  "s3://sensitive-bucket/path/to/model",
+		})
+
+		records, errs := gatherInferenceServices(context.Background(), client)
+		assert.Empty(t, errs)
+		assert.Len(t, records, 1)
+
+		services := records[0].Item.(record.JSONMarshaller).Object.([]inferenceService)
+		assert.Len(t, services, 1)
+		// No storageUri field on the struct — it's simply not present
+		assert.Equal(t, "onnx", services[0].ModelFormatName)
+	})
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

GatherInferenceServices Collects InferenceService resources from the KServe operator across all namespaces. Only selected non-sensitive fields are collected: model format name, version, runtime and protocol version.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/serving.kserve.io/inferenceservices.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_inference_services_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CCXDEV-16666


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added collection of KServe inference service details across all namespaces.
  - Records service names, namespaces, model formats, runtimes, protocols, and applicable format versions.
  - Excludes sensitive storage location data from collected records.
- **Documentation**
  - Documented collected InferenceService resources, archive locations, configuration identifiers, sample data, release versions, and backport status.
- **Tests**
  - Added coverage for empty clusters, multi-namespace collection, partial fields, and sensitive-data exclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->