### PR TITLE
CCXDEV-16671: add GPU node topology gatherer

### DIFF
--- a/docs/gathered-data.md
+++ b/docs/gathered-data.md
@@ -921,6 +921,35 @@ None
 None
 
 
+## GPUNodeTopology
+
+collects GPU-related labels and capacity fields from all nodes.
+Per node it extracts: nvidia.com/gpu.product and amd.com/gpu.product labels,
+and nvidia.com/gpu and amd.com/gpu capacity values.
+Nodes with no GPU data are omitted. If no GPU nodes are found, no record is created.
+
+### API Reference
+- https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/
+
+### Sample data
+- [docs/insights-archive-sample/config/gpu_node_topology.json](./insights-archive-sample/config/gpu_node_topology.json)
+
+### Location in archive
+- `config/gpu_node_topology.json`
+
+### Config ID
+`clusterconfig/gpu_node_topology`
+
+### Released version
+- 5.1
+
+### Backported versions
+None
+
+### Changes
+None
+
+
 ## HelmInfo
 
 Collects statistics about resources deployed via HelmChart, counting only the resources

--- a/docs/insights-archive-sample/config/gpu_node_topology.json
+++ b/docs/insights-archive-sample/config/gpu_node_topology.json
@@ -1,0 +1,17 @@
+[
+  {
+    "nodeName": "gpu-worker-0",
+    "nvidiaGPUProduct": "Tesla-T4",
+    "nvidiaGPUCount": "4"
+  },
+  {
+    "nodeName": "gpu-worker-1",
+    "nvidiaGPUProduct": "A100-SXM4-80GB",
+    "nvidiaGPUCount": "8"
+  },
+  {
+    "nodeName": "gpu-worker-2",
+    "amdGPUProduct": "Instinct-MI250",
+    "amdGPUCount": "2"
+  }
+]

--- a/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
+++ b/pkg/gatherers/clusterconfig/clusterconfig_gatherer.go
@@ -42,6 +42,7 @@ var gatheringFunctions = map[string]gathererFuncPtr{
 	"crds":                             (*Gatherer).GatherCRD,
 	"dvo_metrics":                      (*Gatherer).GatherDVOMetrics,
 	"feature_gates":                    (*Gatherer).GatherClusterFeatureGates,
+	"gpu_node_topology":                (*Gatherer).GatherGPUNodeTopology,
 	"image":                            (*Gatherer).GatherClusterImage,
 	"image_pruners":                    (*Gatherer).GatherClusterImagePruner,
 	"image_registries":                 (*Gatherer).GatherClusterImageRegistry,

--- a/pkg/gatherers/clusterconfig/gather_gpu_node_topology.go
+++ b/pkg/gatherers/clusterconfig/gather_gpu_node_topology.go
@@ -1,0 +1,92 @@
+package clusterconfig
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+type gpuNodeInfo struct {
+	NodeName         string `json:"nodeName"`
+	NvidiaGPUProduct string `json:"nvidiaGPUProduct,omitempty"`
+	AMDGPUProduct    string `json:"amdGPUProduct,omitempty"`
+	NvidiaGPUCount   string `json:"nvidiaGPUCount,omitempty"`
+	AMDGPUCount      string `json:"amdGPUCount,omitempty"`
+}
+
+// GatherGPUNodeTopology collects GPU-related labels and capacity fields from all nodes.
+// Per node it extracts: nvidia.com/gpu.product and amd.com/gpu.product labels,
+// and nvidia.com/gpu and amd.com/gpu capacity values.
+// Nodes with no GPU data are omitted. If no GPU nodes are found, no record is created.
+//
+// ### API Reference
+// - https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/
+//
+// ### Sample data
+// - docs/insights-archive-sample/config/gpu_node_topology.json
+//
+// ### Location in archive
+// - `config/gpu_node_topology.json`
+//
+// ### Config ID
+// `clusterconfig/gpu_node_topology`
+//
+// ### Released version
+// - 5.1
+//
+// ### Backported versions
+// None
+//
+// ### Changes
+// None
+func (g *Gatherer) GatherGPUNodeTopology(ctx context.Context) ([]record.Record, []error) {
+	gatherKubeClient, err := kubernetes.NewForConfig(g.gatherProtoKubeConfig)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return gatherGPUNodeTopology(ctx, gatherKubeClient.CoreV1())
+}
+
+func gatherGPUNodeTopology(ctx context.Context, coreClient corev1client.CoreV1Interface) ([]record.Record, []error) {
+	nodes, err := coreClient.Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	var gpuNodes []gpuNodeInfo
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		info := gpuNodeInfo{
+			NodeName:         node.Name,
+			NvidiaGPUProduct: node.Labels["nvidia.com/gpu.product"],
+			AMDGPUProduct:    node.Labels["amd.com/gpu.product"],
+		}
+		if q, ok := node.Status.Capacity[corev1.ResourceName("nvidia.com/gpu")]; ok {
+			info.NvidiaGPUCount = q.String()
+		}
+		if q, ok := node.Status.Capacity[corev1.ResourceName("amd.com/gpu")]; ok {
+			info.AMDGPUCount = q.String()
+		}
+		if info.NvidiaGPUProduct == "" && info.AMDGPUProduct == "" &&
+			info.NvidiaGPUCount == "" && info.AMDGPUCount == "" {
+			continue
+		}
+		gpuNodes = append(gpuNodes, info)
+	}
+
+	if len(gpuNodes) == 0 {
+		return nil, nil
+	}
+
+	return []record.Record{
+		{
+			Name: "config/gpu_node_topology",
+			Item: record.JSONMarshaller{Object: gpuNodes},
+		},
+	}, nil
+}

--- a/pkg/gatherers/clusterconfig/gather_gpu_node_topology_test.go
+++ b/pkg/gatherers/clusterconfig/gather_gpu_node_topology_test.go
@@ -1,0 +1,94 @@
+package clusterconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openshift/insights-operator/pkg/record"
+)
+
+func Test_gatherGPUNodeTopology(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodes         *corev1.NodeList
+		wantRecords   []record.Record
+		wantErrsCount int
+	}{
+		{
+			name: "nodes with nvidia and amd gpu, non-gpu node excluded",
+			nodes: &corev1.NodeList{
+				Items: []corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "gpu-node-nvidia",
+							Labels: map[string]string{"nvidia.com/gpu.product": "Tesla-T4"},
+						},
+						Status: corev1.NodeStatus{
+							Capacity: corev1.ResourceList{
+								corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("4"),
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "gpu-node-amd",
+							Labels: map[string]string{"amd.com/gpu.product": "Instinct-MI250"},
+						},
+						Status: corev1.NodeStatus{
+							Capacity: corev1.ResourceList{
+								corev1.ResourceName("amd.com/gpu"): resource.MustParse("2"),
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cpu-only-node",
+						},
+					},
+				},
+			},
+			wantRecords: []record.Record{
+				{
+					Name: "config/gpu_node_topology",
+					Item: record.JSONMarshaller{Object: []gpuNodeInfo{
+						{NodeName: "gpu-node-amd", AMDGPUProduct: "Instinct-MI250", AMDGPUCount: "2"},
+						{NodeName: "gpu-node-nvidia", NvidiaGPUProduct: "Tesla-T4", NvidiaGPUCount: "4"},
+					}},
+				},
+			},
+			wantErrsCount: 0,
+		},
+		{
+			name:          "no nodes",
+			nodes:         &corev1.NodeList{},
+			wantRecords:   nil,
+			wantErrsCount: 0,
+		},
+		{
+			name: "nodes exist but none have gpu data",
+			nodes: &corev1.NodeList{
+				Items: []corev1.Node{
+					{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "worker-2"}},
+				},
+			},
+			wantRecords:   nil,
+			wantErrsCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coreClient := fake.NewClientset(tt.nodes)
+			records, errs := gatherGPUNodeTopology(context.Background(), coreClient.CoreV1())
+			assert.Equal(t, tt.wantRecords, records)
+			assert.Len(t, errs, tt.wantErrsCount)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Short description of the PR. What does it do? -->

Collect GPU-related labels and capacity fields from all nodes. Per node extracts `nvidia.com/gpu.product` and `amd.com/gpu.product` labels, and `nvidia.com/gpu` and `amd.com/gpu` capacity values. Nodes with no GPU data are omitted.

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `docs/insights-archive-sample/config/gpu_node_topology.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `docs/gathered-data.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `pkg/gatherers/clusterconfig/gather_gpu_node_topology_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

No

## References
<!-- What are related references for this PR? -->

https://redhat.atlassian.net/browse/CCXDEV-16671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU node topology data collection, including GPU product names and capacity values.
  * GPU topology information is available in the cluster configuration when GPU-equipped nodes are present.

* **Documentation**
  * Documented GPU topology collection behavior and configuration output.
  * Added a sample GPU node topology configuration for NVIDIA and AMD GPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->